### PR TITLE
Fix/image upload restrictions

### DIFF
--- a/app/uploaders/cars_uploader.rb
+++ b/app/uploaders/cars_uploader.rb
@@ -10,8 +10,8 @@ class CarsUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  # jpg,jpeg,gif,pngしか受け付けない
+  # jpg, jpeg, pngしか受け付けない
   def extension_white_list
-    %w[jpg jpeg gif png]
+    %w[jpg jpeg png]
   end
 end

--- a/app/uploaders/stamp_images_uploader.rb
+++ b/app/uploaders/stamp_images_uploader.rb
@@ -10,8 +10,8 @@ class StampImagesUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  # jpg,jpeg,gif,pngしか受け付けない
+  # jpg, jpeg ,pngしか受け付けない
   def extension_white_list
-    %w[jpg jpeg gif png]
+    %w[jpg jpeg png]
   end
 end

--- a/app/uploaders/workers_uploader.rb
+++ b/app/uploaders/workers_uploader.rb
@@ -39,7 +39,7 @@ class WorkersUploader < CarrierWave::Uploader::Base
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w[jpg jpeg gif png]
+    %w[jpg jpeg png]
   end
 
   # Override the filename of the uploaded files:

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -42,6 +42,6 @@
 <% end %>
 
 <%= f.label :stamp_images %>
-<%= f.file_field :stamp_images, multiple: true, class: "form-control" %>
+<%= f.file_field :stamp_images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
 
 <%= f.hidden_field :user_id, value: current_user.id %>

--- a/app/views/users/cars/_form.html.erb
+++ b/app/views/users/cars/_form.html.erb
@@ -45,5 +45,5 @@
 <% end %>
 
 <%= f.label :images %>
-<%= f.file_field :images, multiple: true, class: "form-control" %>
+<%= f.file_field :images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
 <br>

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -55,4 +55,4 @@
 <% end %><br>
 
 <%= f.label :images %>
-<%= f.file_field :images, multiple: true, class: "form-control" %><br>
+<%= f.file_field :images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %><br>


### PR DESCRIPTION
### 概要
画像投稿の拡張子からgifをなくす

### タスク
- [ ] なし
- [x] あり _(https://trello.com/c/NiOvZyfl)_

### 実装内容・手法
○画像投稿の拡張子からgifをなくす
　・バックエンド側でGIF画像を受け付けない
　　→ CarrierWaveの image uploaders 3箇所でGIFを削除
　・フロントエンド側でGIF画像を受け付けない
　　→ _form.html.erb 3箇所でGIFを受け付けないように記述
　・2箇所(作業員、事業所)で動作検証済み。

注: 3箇所(作業員、事業所、車両)のうち、車両だけは車両オブジェクトの
作成自体がエラーが出てしまいでできなかったため、動作検証できず。

ご確認をよろしくお願いいたします!

<img width="1440" alt="スクリーンショット 2022-02-14 14 50 50" src="https://user-images.githubusercontent.com/51151357/153807743-a4ccfb35-f973-4afa-a242-8d7dfe42f3f1.png">

