### PR TITLE
Add default email and password values on user and admin login views

### DIFF
--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -3,12 +3,14 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%# 開発用に初期値を入れています(value: "admin@example.com") %>
+    <%= f.email_field :email, value: "admin@example.com", autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
     <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%# 開発用に初期値を入れています(value: "password") %>
+    <%= f.password_field :password, value: "password", autocomplete: "current-password" %>
   </div>
 
   <% if devise_mapping.rememberable? %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -9,7 +9,8 @@
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
         <div class="input-group mb-3">
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", required: true, class:"form-control", placeholder:"メールアドレス" %>
+          <%# 開発用に初期値を入れています(value: "test_user1@gmail.com") %>
+          <%= f.email_field :email, value: "test_user1@gmail.com", autofocus: true, autocomplete: "email", required: true, class:"form-control", placeholder:"メールアドレス" %>
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-envelope"></span>
@@ -17,8 +18,8 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          
-          <%= f.password_field :password, autocomplete: "new-password", required: true, class:"form-control", placeholder:"パスワード" %>
+          <%# 開発用に初期値を入れています(value: "password") %>
+          <%= f.password_field :password, value: "password", autocomplete: "new-password", required: true, class:"form-control", placeholder:"パスワード" %>
           
           <div class="input-group-append">
             <div class="input-group-text">


### PR DESCRIPTION
### 概要
_ログインフォームにデフォルトの値を入れる_

### タスク
- [ ] なし
- [x] あり _https://trello.com/c/DntoC4vG_

### 実装内容・手法
_Viewのemailとpasswordにデフォルト値を代入しました_

### 実装画像などあれば添付する

<img width="566" alt="App 2022-02-14 22-56-14" src="https://user-images.githubusercontent.com/51151357/153878092-2f55d603-6609-4cc9-a90f-c566af191747.png">

