### PR TITLE
S3で投稿した画像が見れなかったの現象を解消

### DIFF
--- a/app/uploaders/base.rb
+++ b/app/uploaders/base.rb
@@ -1,0 +1,34 @@
+class Base < CarrierWave::Uploader::Base
+  include CarrierWave::RMagick
+
+  # 画像の上限を100pxにする
+  process resize_to_limit: [100, 100]
+
+  if Rails.env.development?
+    storage :file
+  elsif Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # jpg, jpeg, pngしか受け付けない
+  def extension_white_list
+    %w[jpg jpeg png]
+  end
+
+  def filename
+    "#{secure_token}.png" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
+  end
+end

--- a/app/uploaders/cars_uploader.rb
+++ b/app/uploaders/cars_uploader.rb
@@ -1,23 +1,2 @@
-class CarsUploader < CarrierWave::Uploader::Base
-  include CarrierWave::RMagick
-
-  # 画像の上限を100pxにする
-  process resize_to_limit: [100, 100]
-
-  if Rails.env.development?
-    storage :file
-  elsif Rails.env.test?
-    storage :file
-  else
-    storage :fog
-  end
-
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  # jpg, jpeg, pngしか受け付けない
-  def extension_white_list
-    %w[jpg jpeg png]
-  end
+class CarsUploader < Base
 end

--- a/app/uploaders/stamp_images_uploader.rb
+++ b/app/uploaders/stamp_images_uploader.rb
@@ -1,23 +1,2 @@
-class StampImagesUploader < CarrierWave::Uploader::Base
-  include CarrierWave::RMagick
-
-  # 画像の上限を100pxにする
-  process resize_to_limit: [100, 100]
-
-  if Rails.env.development?
-    storage :file
-  elsif Rails.env.test?
-    storage :file
-  else
-    storage :fog
-  end
-
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  # jpg, jpeg ,pngしか受け付けない
-  def extension_white_list
-    %w[jpg jpeg png]
-  end
+class StampImagesUploader < Base
 end

--- a/app/uploaders/worker_licenses_uploader.rb
+++ b/app/uploaders/worker_licenses_uploader.rb
@@ -1,17 +1,2 @@
-class WorkerLicensesUploader < CarrierWave::Uploader::Base
-  include CarrierWave::RMagick
-
-  # 画像の上限を100pxにする
-  process resize_to_limit: [100, 100]
-
-  storage :file
-
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  # jpg, jpeg, pngしか受け付けない
-  def extension_white_list
-    %w[jpg jpeg png]
-  end
+class WorkerLicensesUploader < Base
 end

--- a/app/uploaders/worker_skill_trainings_uploader.rb
+++ b/app/uploaders/worker_skill_trainings_uploader.rb
@@ -1,17 +1,2 @@
-class WorkerSkillTrainingsUploader < CarrierWave::Uploader::Base
-  include CarrierWave::RMagick
-
-  # 画像の上限を100pxにする
-  process resize_to_limit: [100, 100]
-
-  storage :file
-
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  # jpg, jpeg, pngしか受け付けない
-  def extension_white_list
-    %w[jpg jpeg png]
-  end
+class WorkerSkillTrainingsUploader < Base
 end

--- a/app/uploaders/worker_special_educations_uploader.rb
+++ b/app/uploaders/worker_special_educations_uploader.rb
@@ -1,17 +1,2 @@
-class WorkerSpecialEducationsUploader < CarrierWave::Uploader::Base
-  include CarrierWave::RMagick
-
-  # 画像の上限を100pxにする
-  process resize_to_limit: [100, 100]
-
-  storage :file
-
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  # jpg, jpeg, pngしか受け付けない
-  def extension_white_list
-    %w[jpg jpeg png]
-  end
+class WorkerSpecialEducationsUploader < Base
 end

--- a/app/uploaders/workers_uploader.rb
+++ b/app/uploaders/workers_uploader.rb
@@ -1,25 +1,2 @@
-class WorkersUploader < CarrierWave::Uploader::Base
-  # Include RMagick or MiniMagick support:
-  include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
-
-  # 画像の上限を100pxにする
-  process resize_to_limit: [100, 100]
-
-  # Choose what kind of storage to use for this uploader:
-  if Rails.env.development?
-    storage :file
-  elsif Rails.env.test?
-    storage :file
-  else
-    storage :fog
-  end
-
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  def extension_allowlist
-    %w[jpg jpeg png]
-  end
+class WorkersUploader < Base
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,20 +3,21 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  if Rails.env.production? # 本番環境の場合はS3へアップロード
-    config.storage :fog
-    config.fog_provider = 'fog/aws'
-    config.fog_directory = ENV['S3_BUCKET_NAME'] # バケット名
-    config.fog_public = false
-    config.fog_credentials = {
-      provider:              'AWS',
-      aws_access_key_id:     ENV['S3_ACCESS_KEY_ID'],
-      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'],
-      region:                'ap-northeast-1',
-      path_style:            true
-    }
-  else # 本番環境以外の場合はアプリケーション内にアップロード
-    config.storage :file
-    config.enable_processing = false if Rails.env.test?
-  end
+  # if Rails.env.production? # 本番環境の場合はS3へアップロード
+  config.storage :fog
+  config.fog_provider = 'fog/aws'
+  config.fog_directory = ENV['S3_BUCKET_NAME'] # バケット名
+  config.asset_host = ENV['S3_ASSET_HOST']
+  config.fog_public = false
+  config.fog_credentials = {
+    provider:              'AWS',
+    aws_access_key_id:     ENV['S3_ACCESS_KEY_ID'],
+    aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'],
+    region:                'ap-northeast-1',
+    path_style:            true
+  }
+  # else # 本番環境以外の場合はアプリケーション内にアップロード
+  #   config.storage :file
+  #   config.enable_processing = false if Rails.env.test?
+  # end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,21 +3,21 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  # if Rails.env.production? # 本番環境の場合はS3へアップロード
-  config.storage :fog
-  config.fog_provider = 'fog/aws'
-  config.fog_directory = ENV['S3_BUCKET_NAME'] # バケット名
-  config.asset_host = ENV['S3_ASSET_HOST']
-  config.fog_public = false
-  config.fog_credentials = {
-    provider:              'AWS',
-    aws_access_key_id:     ENV['S3_ACCESS_KEY_ID'],
-    aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'],
-    region:                'ap-northeast-1',
-    path_style:            true
-  }
-  # else # 本番環境以外の場合はアプリケーション内にアップロード
-  #   config.storage :file
-  #   config.enable_processing = false if Rails.env.test?
-  # end
+  if Rails.env.production? # 本番環境の場合はS3へアップロード
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory = ENV['S3_BUCKET_NAME'] # バケット名
+    config.asset_host = ENV['S3_ASSET_HOST']
+    config.fog_public = false
+    config.fog_credentials = {
+      provider:              'AWS',
+      aws_access_key_id:     ENV['S3_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'],
+      region:                'ap-northeast-1',
+      path_style:            true
+    }
+  else # 本番環境以外の場合はアプリケーション内にアップロード
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end
 end


### PR DESCRIPTION
### 概要
- 直接的な原因はherokuで使用しているmysqlがバージョン5.7を利用していたためだった。jawsdb mysqlに変更して8.0系にバージョンアップさせて、json型に対応できるようにした。

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
_実装内容や、問題の解決手法を記述する_

### 実装画像などあれば添付する


