### PR TITLE
Feature/pdf/th

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,8 +64,13 @@ gem 'closure_tree'
 
 # 動的フォーム
 gem 'cocoon'
+
 # 住所自動入力
 gem 'jp_prefecture'
+
+# pdf変換
+gem 'wicked_pdf'
+gem 'wkhtmltopdf-binary'
 
 group :development, :test do
   # ERD生成

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,8 +397,11 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wicked_pdf (2.1.0)
+      activesupport
     with_advisory_lock (4.6.0)
       activerecord (>= 4.2)
+    wkhtmltopdf-binary (0.12.6.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.3)
@@ -452,6 +455,8 @@ DEPENDENCIES
   web-console (>= 4.1.0)
   webdrivers
   webpacker (~> 5.0)
+  wicked_pdf
+  wkhtmltopdf-binary
 
 RUBY VERSION
    ruby 3.0.3p157

--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -33,7 +33,7 @@ module Users
         format.html
         format.pdf do
           render pdf: '表紙',
-                layout: 'application',
+                layout: 'pdf',
                 encording: 'UTF-8',
                 page_size: 'A4'
         end

--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -28,6 +28,18 @@ module Users
       end
     end
 
+    def cover
+      respond_to do |format|
+        format.html
+        format.pdf do
+          render pdf: '表紙',
+                layout: 'application',
+                encording: 'UTF-8',
+                page_size: 'A4'
+        end
+      end
+    end
+
     private
 
     def set_documents

--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -33,9 +33,9 @@ module Users
         format.html
         format.pdf do
           render pdf: '表紙',
-                layout: 'pdf',
-                encording: 'UTF-8',
-                page_size: 'A4'
+            layout: 'pdf',
+            encording: 'UTF-8',
+            page_size: 'A4'
         end
       end
     end

--- a/app/javascript/stylesheets/users/documents.scss
+++ b/app/javascript/stylesheets/users/documents.scss
@@ -1,22 +1,5 @@
-<body style="font-family: Noto Sans JP, Hiragino Kaku Gothic ProN, Meiryo, sans-serif;">
-  <div>
-    <div id="p1">
-      <div class="text-container">
-        <span id="t1_1" class="t s1 a1">元請確認欄 </span>
-        <span id="t1_1" class="t s1 a3"> </span>
-        <span id="t2_1" class="t s2">施工体制・安全衛生関係提出書類 </span>
-        <span id="t3_1" class="t s3">提出会社名 </span>
-        <span id="t4_1" class="t s4"><%= @cover_document.business_name %></span>
-        <span id="t5_1" class="t s5">1-1 </span>
-        <span id="t6_1" class="t s5 a2">提出日（初回） </span>
-        <span id="t7_1" class="t s4"><%= @cover_document.submitted_on %></span>
-        <span id="t8_1" class="t s5">1-2 </span>
-      </div>
-    </div>
-  </div>
-</body>
+// cover
 
-<style>
 .t {
   transform-origin: bottom left;
   z-index: 2;
@@ -110,31 +93,25 @@
 
 .s1 {
   font-size: 21px;
-  // font-family: A-82l-82r-83S-83V-83b-83N_f;
   color: #000;
 }
 
 .s2 {
   font-size: 34px;
-  // font-family: A-82l-82r-83S-83V-83b-83N_f;
   color: #000;
 }
 
 .s3 {
   font-size: 21px;
-  // font-family: A-82l-82r-83S-83V-83b-83N_f;
   color: #000;
 }
 
 .s4 {
   font-size: 17px;
-  // font-family: A-82l-82r-83S-83V-83b-83N_f;
   color: #15C;
 }
 
 .s5 {
   font-size: 17px;
-  // font-family: A-82l-82r-83S-83V-83b-83N_f;
   color: #000;
 }
-</style>

--- a/app/views/documents/cover_document.html.erb
+++ b/app/views/documents/cover_document.html.erb
@@ -1,0 +1,122 @@
+<div id="p1">  
+  <div id="pg1">
+    <object width="909" height="1286" data="/documents_image/cover.png"></object>
+  </div>
+
+  <div class="text-container"><span id="t1_1" class="t s1">元請確認欄 </span>
+    <span id="t2_1" class="t s2">施工体制・安全衛生関係提出書類 </span>
+    <span id="t3_1" class="t s3">提出会社名 </span>
+    <span id="t4_1" class="t s4">自社の「会社名」 </span>
+    <span id="t5_1" class="t s5">1-1 </span>
+    <span id="t6_1" class="t s5">提出日（初回） </span>
+    <span id="t7_1" class="t s4">「提出日（西暦）」 </span>
+    <span id="t8_1" class="t s5">1-2 </span>
+  </div>
+</div>
+
+<style>
+  .t {
+    transform-origin: bottom left;
+    z-index: 2;
+    position: absolute;
+    white-space: pre;
+    overflow: visible;
+    line-height: 1.5;
+  }
+
+  .text-container {
+    white-space: pre;
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    .text-container {
+      white-space: normal;
+    }
+  }
+
+  #p1 {
+    overflow: hidden;
+    position: relative;
+    background-color: white;
+    width: 909px;
+    height: 1286px;
+  }
+
+  #t1_1 {
+    left: 164px;
+    bottom: 432px;
+    letter-spacing: 0.65px;
+  }
+
+  #t2_1 {
+    left: 198px;
+    bottom: 989px;
+    letter-spacing: -0.07px;
+  }
+
+  #t3_1 {
+    left: 164px;
+    bottom: 592px;
+    letter-spacing: 0.84px;
+  }
+
+  #t4_1 {
+    left: 455px;
+    bottom: 584px;
+    letter-spacing: -0.12px;
+  }
+
+  #t5_1 {
+    left: 590px;
+    bottom: 584px;
+    letter-spacing: -0.07px;
+  }
+
+  #t6_1 {
+    left: 372px;
+    bottom: 518px;
+    letter-spacing: -0.12px;
+  }
+
+  #t7_1 {
+    left: 530px;
+    bottom: 519px;
+    letter-spacing: -0.12px;
+  }
+
+  #t8_1 {
+    left: 681px;
+    bottom: 519px;
+    letter-spacing: -0.07px;
+  }
+
+  .s1 {
+    font-size: 21px;
+    font-family: A-82l-82r-83S-83V-83b-83N_f;
+    color: #000;
+  }
+
+  .s2 {
+    font-size: 34px;
+    font-family: A-82l-82r-83S-83V-83b-83N_f;
+    color: #000;
+  }
+
+  .s3 {
+    font-size: 21px;
+    font-family: A-82l-82r-83S-83V-83b-83N_f;
+    color: #000;
+  }
+
+  .s4 {
+    font-size: 17px;
+    font-family: A-82l-82r-83S-83V-83b-83N_f;
+    color: #15C;
+  }
+
+  .s5 {
+    font-size: 17px;
+    font-family: A-82l-82r-83S-83V-83b-83N_f;
+    color: #000;
+  }
+</style>

--- a/app/views/layouts/pdf.pdf.erb
+++ b/app/views/layouts/pdf.pdf.erb
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP&display=swap&subset=japanese" rel="stylesheet">
+  </head>
+  <body>
+    <div>
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/app/views/users/documents/show.html.erb
+++ b/app/views/users/documents/show.html.erb
@@ -19,5 +19,6 @@
   <div class="card-footer">
     <%= link_to '編集', edit_users_document_path(@document), class: "btn btn-block btn-outline-dark" %>
     <%= link_to '書類一覧に戻る', users_documents_path, class: "btn btn-block btn-outline-secondary" %>
+    <%= link_to "PDF出力", cover_users_document_path(@document), target: :_blank, rel: "noopener noreferrer", class: "btn btn-md btn-block btn-default" %>
   </div>
 </div>

--- a/app/views/users/documents/show.html.erb
+++ b/app/views/users/documents/show.html.erb
@@ -22,3 +22,19 @@
     <%= link_to "PDF出力", cover_users_document_path(@document), target: :_blank, rel: "noopener noreferrer", class: "btn btn-md btn-block btn-default" %>
   </div>
 </div>
+
+<div>
+  <div id="p1">
+    <div class="text-container">
+      <span id="t1_1" class="t s1 a1">元請確認欄 </span>
+      <span id="t1_1" class="t s1 a3"> </span>
+      <span id="t2_1" class="t s2">施工体制・安全衛生関係提出書類 </span>
+      <span id="t3_1" class="t s3">提出会社名 </span>
+      <span id="t4_1" class="t s4"><%= @cover_document.business_name %></span>
+      <span id="t5_1" class="t s5">1-1 </span>
+      <span id="t6_1" class="t s5 a2">提出日（初回） </span>
+      <span id="t7_1" class="t s4"><%= @cover_document.submitted_on %></span>
+      <span id="t8_1" class="t s5">1-2 </span>
+    </div>
+  </div>
+</div>

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,28 @@
+# WickedPDF Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `render :pdf` call.
+#
+# To learn more, check out the README:
+#
+# https://github.com/mileszs/wicked_pdf/blob/master/README.md
+
+WickedPdf.config = {
+  # Path to the wkhtmltopdf executable: This usually isn't needed if using
+  # one of the wkhtmltopdf-binary family of gems.
+  # exe_path: '/usr/local/bin/wkhtmltopdf',
+  #   or
+  # exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
+  exe_path: "#{Gem.loaded_specs['wkhtmltopdf-binary'].full_gem_path}/bin/wkhtmltopdf"
+
+  # Layout file to be used for all PDFs
+  # (but can be overridden in `render :pdf` calls)
+  # layout: 'pdf.html',
+
+  # Using wkhtmltopdf without an X server can be achieved by enabling the
+  # 'use_xvfb' flag. This will wrap all wkhtmltopdf commands around the
+  # 'xvfb-run' command, in order to simulate an X server.
+  #
+  # use_xvfb: true,
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,11 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resources :request_orders, only: %i[index show], param: :uuid do
       resources :sub_request_orders, except: %i[edit destroy show]
     end
-    resources :documents, only: %i[index show edit update], param: :uuid
+    resources :documents, only: %i[index show edit update], param: :uuid do
+      member do
+        get 'cover.pdf', to: 'documents#cover', as: 'cover'
+      end
+    end
   end
   # =================================================================
 


### PR DESCRIPTION
### 概要
書類作成ページ３（試し）

### タスク
- [ ] なし
- [x] あり https://trello.com/c/oJShQNcD

### 実装内容・手法
●書類詳細画面に、資料の「表紙」ををHTML形式で表示させる

●スプレッドシートをhtml出力してコピペする
　・スプレッドシートをhtml変換すると、セルも認識してしまい余計なhtmlコードが大量に混ざってしまい整形に手間がかかってしまうため下記の方法で変換しました。
　・元データは、htmlとcssをapp/views/documents/cover_document.html.erb内に保存しています。
1. スプレッドシートをエクセルとしてダウンロード、エクセルの印刷からPDFとして印刷(変換)する。
2. https://www.idrsolutions.com/ja/online-pdf-to-html-converter のサイトで上記のPDFをhtml変換する。
3. 上記で変換すると、htmlとcssにある程度分けて出力されるので、とりあえずこの方法で整形しました。

スプレッドシート→エクセルでダンロード→PDFとして印刷(保存)→そのPDFを変換サイトでhtmlとcssへ変換　の流れ

●書類詳細画面に、pdf出力ボタンを作成して、ボタン押下で、pdfが出力されること
・PDF出力ボタン押下で、別タブでPDFが開くようにしています。

■課題点
・ PDFへのcssのstyleが反映できない、よって日本語フォントも読み込めない。wicked_pdf_stylesheet_link_tagでstyleを読み込むようだが、これだと通常のapp/assetsから読み込む設定？webpacker経由で読み込む方法をかなり調べましたが、解決できませんでした。
□暫定措置
・日本語フォントは、CDN経由で取得。
・css、フォントの適用は、pdfのviewファイル側にstyleを直接記述。
　で対応しています。

### 実装画像などあれば添付する

書類詳細画面
![0543c68f62240a73e2e2cf577da0e9a9](https://user-images.githubusercontent.com/52871417/159168598-2ef62dae-0591-4787-831e-7d6c0125bab8.png)

https://user-images.githubusercontent.com/52871417/159169057-11cc1c81-e25f-4845-990f-d5cae27e7171.mov

PDF
[表紙.pdf](https://github.com/kensuma-1122/kensuma/files/8311502/default.pdf)

