### PR TITLE
Fix/document creation 5/th

### DIFF
--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -7,7 +7,6 @@ module Users
     before_action :set_document, except: :index # オブジェクトが1つも無い場合、indexで呼び出さないようにする
     before_action :set_cover_documents, only: :index # サイドバー表示 表紙一覧
     before_action :set_cover_document, except: :index # 同上
-    before_action :set_covoer_document_contents, only: %i[show edit cover]
 
     # サイドバーリンク用
     before_action :set_cover_document_uuid, except: :index
@@ -56,17 +55,12 @@ module Users
       @cover_document = current_business.documents.document_type_cover.find_by(uuid: params[:uuid])
     end
 
-    def set_covoer_document_contents
-      @cover_business_name = JSON.parse(@cover_document.content.to_json)[0]['business_name']
-      @cover_submitted_on = JSON.parse(@cover_document.content.to_json)[1]['submitted_on']
-    end
-
     def document_params
       params.require(:document).permit.merge(
-        content: [
-          { id: 1, business_name: params[:document][:content][0] },
-          { id: 2, submitted_on: params[:document][:content][1] }
-        ])
+        content: {
+          business_name: params[:document][:content][0],
+          submitted_on: params[:document][:content][1]
+        })
     end
   end
 end

--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -59,7 +59,7 @@ module Users
       params.require(:document).permit.merge(
         content: {
           business_name: params[:document][:content][0],
-          submitted_on: params[:document][:content][1]
+          submitted_on:  params[:document][:content][1]
         })
     end
   end

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -28,10 +28,10 @@ module Users
           document_type: 0,
           created_on:    Date.current,
           submitted_on:  Date.current,
-          content:       [
-            { 'id': 1, 'business_name': '' }, # 1-1
-            { 'id': 2, 'submitted_on': '' } # 1-2
-          ],
+          content:       {
+            'business_name': 'aaa',      # 1-1
+            'submitted_on': Date.current # 1-2
+          },
           business:      current_business
         )
 
@@ -40,7 +40,7 @@ module Users
           document_type: 1,
           created_on:    Date.current,
           submitted_on:  Date.current,
-          content:       [],
+          content:       {},
           business:      current_business
         )
 
@@ -49,17 +49,17 @@ module Users
           document_type: 2,
           created_on:    Date.current,
           submitted_on:  Date.current,
-          content:       [
-            { 'id': 1, 'submitted_on': '' }, # 3-1
-            { 'id': 2, 'prime_contractor_name': '' }, # 3-2
-            { 'id': 3, 'site_name': '' }, # 3-3
-            { 'id': 4, 'business_name': '' }, # 3-4
-            { 'id': 5, 'orderer_name': '' }, # 3-5
-            { 'id': 6, 'construction_name': '' }, # 3-6
-            { 'id': 7, 'supervisor_name': '' }, # 3-7
-            { 'id': 8, 'apply': '' }, # 3-8
-            { 'id': 9, 'submission_destination': '' } # 3-9
-          ],
+          content:       {
+            'submitted_on':           '', # 3-1
+            'prime_contractor_name':  '', # 3-2
+            'site_name':              '', # 3-3
+            'business_name':          '', # 3-4
+            'orderer_name':           '', # 3-5
+            'construction_name':      '', # 3-6
+            'supervisor_name':        '', # 3-7
+            'apply':                  '', # 3-8
+            'submission_destination': '' # 3-9
+          },
           business:      current_business
         )
 

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -29,8 +29,8 @@ module Users
           created_on:    Date.current,
           submitted_on:  Date.current,
           content:       {
-            'business_name': 'aaa',      # 1-1
-            'submitted_on': Date.current # 1-2
+            'business_name': '', # 1-1
+            'submitted_on':  '' # 1-2
           },
           business:      current_business
         )

--- a/app/controllers/users/second_documents_controller.rb
+++ b/app/controllers/users/second_documents_controller.rb
@@ -5,7 +5,6 @@ module Users
     layout 'documents'
     before_action :set_document
     before_action :set_second_document, only: %i[show edit update]
-    before_action :set_second_document_contents, only: %i[show edit]
 
     # サイドバーリンク用
     before_action :set_cover_document_uuid
@@ -46,31 +45,19 @@ module Users
       @second_document = current_business.documents.document_type_second.find_by(uuid: params[:document_uuid])
     end
 
-    def set_second_document_contents
-      @second_submitted_on = JSON.parse(@second_document.content.to_json)[0]['submitted_on']
-      @second_prime_contractor_name = JSON.parse(@second_document.content.to_json)[1]['prime_contractor_name']
-      @second_site_name = JSON.parse(@second_document.content.to_json)[2]['site_name']
-      @second_business_name = JSON.parse(@second_document.content.to_json)[3]['business_name']
-      @second_orderer_name = JSON.parse(@second_document.content.to_json)[4]['orderer_name']
-      @second_construction_name = JSON.parse(@second_document.content.to_json)[5]['construction_name']
-      @second_supervisor_name = JSON.parse(@second_document.content.to_json)[6]['supervisor_name']
-      @second_apply = JSON.parse(@second_document.content.to_json)[7]['apply']
-      @second_submission_destination = JSON.parse(@second_document.content.to_json)[8]['submission_destination']
-    end
-
     def second_document_params
       params.require(:document).permit.merge(
-        content: [
-          { id: 1, submitted_on: params[:document][:content][0] },
-          { id: 2, prime_contractor_name: params[:document][:content][1] },
-          { id: 3, site_name: params[:document][:content][2] },
-          { id: 4, business_name: params[:document][:content][3] },
-          { id: 5, orderer_name: params[:document][:content][4] },
-          { id: 6, construction_name: params[:document][:content][5] },
-          { id: 7, supervisor_name: params[:document][:content][6] },
-          { id: 8, apply: params[:document][:content][7] },
-          { id: 9, submission_destination: params[:document][:content][8] }
-        ]
+        content: {
+          submitted_on: params[:document][:content][0],
+          prime_contractor_name: params[:document][:content][1],
+          site_name: params[:document][:content][2],
+          business_name: params[:document][:content][3],
+          orderer_name: params[:document][:content][4],
+          construction_name: params[:document][:content][5],
+          supervisor_name: params[:document][:content][6],
+          apply: params[:document][:content][7],
+          submission_destination: params[:document][:content][8]
+        }
       )
     end
   end

--- a/app/controllers/users/second_documents_controller.rb
+++ b/app/controllers/users/second_documents_controller.rb
@@ -48,14 +48,14 @@ module Users
     def second_document_params
       params.require(:document).permit.merge(
         content: {
-          submitted_on: params[:document][:content][0],
-          prime_contractor_name: params[:document][:content][1],
-          site_name: params[:document][:content][2],
-          business_name: params[:document][:content][3],
-          orderer_name: params[:document][:content][4],
-          construction_name: params[:document][:content][5],
-          supervisor_name: params[:document][:content][6],
-          apply: params[:document][:content][7],
+          submitted_on:           params[:document][:content][0],
+          prime_contractor_name:  params[:document][:content][1],
+          site_name:              params[:document][:content][2],
+          business_name:          params[:document][:content][3],
+          orderer_name:           params[:document][:content][4],
+          construction_name:      params[:document][:content][5],
+          supervisor_name:        params[:document][:content][6],
+          apply:                  params[:document][:content][7],
           submission_destination: params[:document][:content][8]
         }
       )

--- a/app/views/users/documents/cover.pdf.erb
+++ b/app/views/users/documents/cover.pdf.erb
@@ -6,11 +6,11 @@
         <span id="t1_1" class="t s1 a3"> </span>
         <span id="t2_1" class="t s2">施工体制・安全衛生関係提出書類 </span>
         <span id="t3_1" class="t s3">提出会社名 </span>
-        <span id="t4_1" class="t s4"><%= @cover_business_name %></span>
+        <span id="t4_1" class="t s4"><%= @document.content["business_name"] %></span>
         <span id="t5_1" class="t s5">1-1 </span>
         <span id="t6_1" class="t s5">提出日（初回） </span>
         <span id="t6_1" class="t s5 a2"></span>
-        <span id="t7_1" class="t s4"><%= @cover_submitted_on %></span>
+        <span id="t7_1" class="t s4"><%= @document.content["submitted_on"] %></span>
         <span id="t8_1" class="t s5">1-2 </span>
       </div>
     </div>

--- a/app/views/users/documents/edit.html.erb
+++ b/app/views/users/documents/edit.html.erb
@@ -4,11 +4,11 @@
     <table class="table">
       <tr>
         <th><%= f.label '事業所名' %></th>
-        <td><%= f.text_field :content, multiple: true, value: @cover_business_name, class: 'form-control' %></td>
+        <td><%= f.text_field :content, multiple: true, value: @document.content["business_name"], class: 'form-control' %></td>
       </tr>
       <tr>
         <th><%= f.label '書類提出日' %></th>
-        <td><%= f.date_field :content, multiple: true, value: @cover_submitted_on, class: 'form-control' %></td>
+        <td><%= f.date_field :content, multiple: true, value: @document.content["submitted_on"], class: 'form-control' %></td>
       </tr>
     </table>
   </div>

--- a/app/views/users/documents/show.html.erb
+++ b/app/views/users/documents/show.html.erb
@@ -9,11 +9,11 @@
       </tr>
       <tr>
         <th>提出会社名</th>
-        <td><%= @cover_business_name %></td>
+        <td><%= @document.content["business_name"] %></td>
       </tr>
       <tr>
         <th>提出日</th>
-        <td><%= @cover_submitted_on %></td>
+        <td><%= @document.content["submitted_on"] %></td>
       </tr>
     </table>
   </div>
@@ -31,11 +31,11 @@
       <span id="t1_1" class="t s1 a3"> </span>
       <span id="t2_1" class="t s2">施工体制・安全衛生関係提出書類 </span>
       <span id="t3_1" class="t s3">提出会社名 </span>
-      <span id="t4_1" class="t s4"><%= @cover_business_name %></span>
+      <span id="t4_1" class="t s4"><%= @document.content["business_name"] %></span>
       <span id="t5_1" class="t s5">1-1 </span>
       <span id="t6_1" class="t s5">提出日（初回） </span>
       <span id="t6_1" class="t s5 a2"></span>
-      <span id="t7_1" class="t s4"><%= @cover_submitted_on %></span>
+      <span id="t7_1" class="t s4"><%= @document.content["submitted_on"] %></span>
       <span id="t8_1" class="t s5">1-2 </span>
     </div>
   </div>

--- a/app/views/users/second_documents/edit.html.erb
+++ b/app/views/users/second_documents/edit.html.erb
@@ -27,20 +27,20 @@
           <span id="sd_t17_1" class="sd_t sd_s2">です。 </span>
           <span id="sd_t18_1" class="sd_t sd_s1">(全建統一様式第２号) </span>
           <span id="sd_t19_1" class="sd_t sd_s2"><%= f.date_field :content, multiple: true,
-                                      value: @second_submitted_on,
+                                      value: @second_document.content["submitted_on"],
                                       placeholder: '提出日（西暦）3-1',
                                       class: 'form-control form-control-sm' %></span>
           <span id="sd_t1a_1" class="sd_t sd_s6">下請負業者の皆さんへ </span>
           <span id="sd_t1b_1" class="sd_t sd_s2">【元請負業者】 </span>
           <span id="sd_t1c_1" class="sd_t sd_s2">
             <%= f.text_field :content, multiple: true,
-                                      value: @second_prime_contractor_name,
+                                      value: @second_document.content["prime_contractor_name"],
                                       placeholder: '「元請会社名」3-2',
                                       class: 'form-control form-control-sm' %></span>
           <span id="sd_t1f_1_1" class="sd_t sd_s2"></span>
           <span id="sd_t13_1" class="sd_t sd_s2">
             <%= f.text_field :content, multiple: true,
-                                      value: @second_site_name,
+                                      value: @second_document.content["site_name"],
                                       placeholder: '「現場名」3-3',
                                       class: 'form-control form-control-sm' %></span>
           <span id="sd_t13_1_1" class="sd_t sd_s2"></span>
@@ -56,7 +56,7 @@
                   <td class="sd_td_1">元 請 名</td>
                   <td class="sd_td_1" colspan="3">
                     <%= f.text_field :content, multiple: true,
-                                              value: @second_business_name,
+                                              value: @second_document.content["business_name"],
                                               placeholder: '「会社名」3-4',
                                               class: 'form-control form-control-sm' %>
                   </td>
@@ -65,7 +65,7 @@
                   <td class="sd_td_1">発 注 者 名</td>
                   <td class="sd_td_1" colspan="3">
                     <%= f.text_field :content, multiple: true,
-                                              value: @second_orderer_name,
+                                              value: @second_document.content["orderer_name"],
                                               placeholder: '「発注者名」3-5',
                                               class: 'form-control form-control-sm' %>
                   </td>
@@ -74,7 +74,7 @@
                   <td class="sd_td_1">工 事 名</td>
                   <td class="sd_td_1" colspan="3">
                     <%= f.text_field :content, multiple: true,
-                                              value: @second_construction_name,
+                                              value: @second_document.content["construction_name"],
                                               placeholder: '元請会社の「各会社の工事名」3-6',
                                               class: 'form-control form-control-sm' %>
                 </td>
@@ -82,14 +82,14 @@
                   <td class="sd_td_1" style="width: 15%">監 督 員 名</td>
                   <td class="sd_td_1" style="width: 20%">
                     <%= f.text_field :content, multiple: true,
-                                              value: @second_supervisor_name,
+                                              value: @second_document.content["supervisor_name"],
                                               placeholder: '元請会社の「各会社の監督員名」3-7',
                                               class: 'form-control form-control-sm' %>
                   </td>
                   <td class="sd_td_1" style="width: 15%">権限及び意見<br>申出方法</td>
                   <td class="sd_td_1" style="vertical-align: middle !important">
                     <%= f.text_field :content, multiple: true,
-                                              value: @second_apply,
+                                              value: @second_document.content["apply"],
                                               placeholder: '「各会社の監督員名・権限及び意見の申出方法」3-8',
                                               class: 'form-control form-control-sm' %>
                   </td>
@@ -105,7 +105,7 @@
                   <td class="sd_td_1" style="width: 15%">提出先及び<br>担 当 者</td>
                   <td class="sd_td_1" style="vertical-align: middle !important">
                     <%= f.text_field :content, multiple: true,
-                                        value: @second_submission_destination,
+                                        value: @second_document.content["submission_destination"],
                                         placeholder: '「提出先及び担当者（元請会社のみ）」3-9',
                                         class: 'form-control form-control-sm' %>
                   </td>

--- a/app/views/users/second_documents/show.html.erb
+++ b/app/views/users/second_documents/show.html.erb
@@ -33,12 +33,12 @@
       <span id="sd_t16_1" class="sd_t sd_s2">当工事は、建設業法（昭和24年法律第100号）第24条の7に基づく施工体制台帳の作成を要する建設工事 </span>
       <span id="sd_t17_1" class="sd_t sd_s2">です。 </span>
       <span id="sd_t18_1" class="sd_t sd_s1">(全建統一様式第２号) </span>
-      <span id="sd_t19_1" class="sd_t sd_s2"><%= @second_submitted_on %> 3-1 </span>
+      <span id="sd_t19_1" class="sd_t sd_s2"><%= @second_document.content["submitted_on"] %> 3-1 </span>
       <span id="sd_t1a_1" class="sd_t sd_s6">下請負業者の皆さんへ </span>
       <span id="sd_t1b_1" class="sd_t sd_s2">【元請負業者】 </span>
-      <span id="sd_t1c_1" class="sd_t sd_s2"><%= @second_prime_contractor_name %> 3-2 </span>
+      <span id="sd_t1c_1" class="sd_t sd_s2"><%= @second_document.content["prime_contractor_name"] %> 3-2 </span>
       <span id="sd_t1f_1_1" class="sd_t sd_s2"></span>
-      <span id="sd_t13_1" class="sd_t sd_s2"><%= @second_site_name %> 3-3 </span>
+      <span id="sd_t13_1" class="sd_t sd_s2"><%= @second_document.content["site_name"] %> 3-3 </span>
       <span id="sd_t13_1_1" class="sd_t sd_s2"></span>
       <span id="sd_t14_1" class="sd_t sd_s2">事業所の名称 </span>
       <span id="sd_t1d_1" class="sd_t sd_s2">会 </span>
@@ -50,20 +50,20 @@
           <tbody>
             <tr>
               <td class="sd_td_1">元 請 名</td>
-              <td class="sd_td_1" colspan="3"><%= @second_business_name %> 3-4</td>
+              <td class="sd_td_1" colspan="3"><%= @second_document.content["business_name"] %> 3-4</td>
             </tr>
             <tr>
               <td class="sd_td_1">発 注 者 名</td>
-              <td class="sd_td_1" colspan="3"><%= @second_orderer_name %> 3-5</td>
+              <td class="sd_td_1" colspan="3"><%= @second_document.content["orderer_name"] %> 3-5</td>
             </tr>
             <tr>
               <td class="sd_td_1">工 事 名</td>
-              <td class="sd_td_1" colspan="3"><%= @second_construction_name %> 3-6</td>
+              <td class="sd_td_1" colspan="3"><%= @second_document.content["construction_name"] %> 3-6</td>
             <tr>
               <td class="sd_td_1" style="width: 15%">監 督 員 名</td>
-              <td class="sd_td_1" style="width: 20%"><%= @second_supervisor_name %> 3-7</td>
+              <td class="sd_td_1" style="width: 20%"><%= @second_document.content["supervisor_name"] %> 3-7</td>
               <td class="sd_td_1" style="width: 15%">権限及び意見<br>申出方法</td>
-              <td class="sd_td_1" style="vertical-align: middle !important"><%= @second_apply %> 3-8</td>
+              <td class="sd_td_1" style="vertical-align: middle !important"><%= @second_document.content["apply"] %> 3-8</td>
             </tr>
           </tbody>
         </table>
@@ -74,7 +74,7 @@
           <tbody>
             <tr>
               <td class="sd_td_1" style="width: 15%">提出先及び<br>担 当 者</td>
-              <td class="sd_td_1" style="vertical-align: middle !important"><%= @second_submission_destination %> 3-9</td>
+              <td class="sd_td_1" style="vertical-align: middle !important"><%= @second_document.content["submission_destination"] %> 3-9</td>
             </tr>
           </tbody>
         </table>

--- a/app/views/users/second_documents/show.pdf.erb
+++ b/app/views/users/second_documents/show.pdf.erb
@@ -25,12 +25,12 @@
       <span id="sd_t16_1" class="sd_t sd_s2">当工事は、建設業法（昭和24年法律第100号）第24条の7に基づく施工体制台帳の作成を要する建設工事 </span>
       <span id="sd_t17_1" class="sd_t sd_s2">です。 </span>
       <span id="sd_t18_1" class="sd_t sd_s1">(全建統一様式第２号) </span>
-      <span id="sd_t19_1" class="sd_t sd_s2"><%= @second_submitted_on %> 3-1 </span>
+      <span id="sd_t19_1" class="sd_t sd_s2"><%= @second_document.content["submitted_on"] %> 3-1 </span>
       <span id="sd_t1a_1" class="sd_t sd_s6">下請負業者の皆さんへ </span>
       <span id="sd_t1b_1" class="sd_t sd_s2">【元請負業者】 </span>
-      <span id="sd_t1c_1" class="sd_t sd_s2"><%= @second_prime_contractor_name %> 3-2 </span>
+      <span id="sd_t1c_1" class="sd_t sd_s2"><%= @second_document.content["prime_contractor_name"] %> 3-2 </span>
       <span id="sd_t1f_1_1" class="sd_t sd_s2"></span>
-      <span id="sd_t13_1" class="sd_t sd_s2"><%= @second_site_name %> 3-3 </span>
+      <span id="sd_t13_1" class="sd_t sd_s2"><%= @second_document.content["site_name"] %> 3-3 </span>
       <span id="sd_t13_1_1" class="sd_t sd_s2"></span>
       <span id="sd_t14_1" class="sd_t sd_s2">事業所の名称 </span>
       <span id="sd_t1d_1" class="sd_t sd_s2">会 </span>
@@ -42,20 +42,20 @@
           <tbody>
             <tr>
               <td class="sd_td_1">元 請 名</td>
-              <td class="sd_td_1" colspan="3"><%= @second_business_name %> 3-4</td>
+              <td class="sd_td_1" colspan="3"><%= @second_document.content["business_name"] %> 3-4</td>
             </tr>
             <tr>
               <td class="sd_td_1">発 注 者 名</td>
-              <td class="sd_td_1" colspan="3"><%= @second_orderer_name %> 3-5</td>
+              <td class="sd_td_1" colspan="3"><%= @second_document.content["orderer_name"] %> 3-5</td>
             </tr>
             <tr>
               <td class="sd_td_1">工 事 名</td>
-              <td class="sd_td_1" colspan="3"><%= @second_construction_name %> 3-6</td>
+              <td class="sd_td_1" colspan="3"><%= @second_document.content["construction_name"] %> 3-6</td>
             <tr>
               <td class="sd_td_1" style="width: 15%">監 督 員 名</td>
-              <td class="sd_td_1" style="width: 20%"><%= @second_supervisor_name %> 3-7</td>
+              <td class="sd_td_1" style="width: 20%"><%= @second_document.content["supervisor_name"] %> 3-7</td>
               <td class="sd_td_1" style="width: 15%">権限及び意見<br>申出方法</td>
-              <td class="sd_td_1" style="vertical-align: middle !important"><%= @second_apply %> 3-8</td>
+              <td class="sd_td_1" style="vertical-align: middle !important"><%= @second_document.content["apply"] %> 3-8</td>
             </tr>
           </tbody>
         </table>
@@ -66,7 +66,7 @@
           <tbody>
             <tr>
               <td class="sd_td_1" style="width: 15%">提出先及び<br>担 当 者</td>
-              <td class="sd_td_1" style="vertical-align: middle !important"><%= @second_submission_destination %> 3-9</td>
+              <td class="sd_td_1" style="vertical-align: middle !important"><%= @second_document.content["submission_destination"] %> 3-9</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
### 概要
書類作成5

### タスク
- [ ] なし
- [x] ありhttps://trello.com/c/zGR6g3HD

### 実装内容・手法
●documentのcontent登録形式をハッシュ へ修正
　・こちらのコメントの修正です。https://github.com/kensuma-1122/kensuma/pull/110#issuecomment-1086800310

```
# View側での値の取得
例:
@document.content["business_name"]   => "テスト事業所名"
```

```
# 表紙のcontentデータ

{
  "submitted_on": "2022-04-03",
  "business_name": "テスト事業所名"
}
```

```
# 施工のcontentデータ

{
  "apply": "テスト申出",
  "site_name": "テスト事業所名称",
  "orderer_name": "テスト発注者名",
  "submitted_on": "2022-04-03",
  "business_name": "テスト元請名",
  "supervisor_name": "テスト監督",
  "construction_name": "テスト工事名",
  "prime_contractor_name": "テスト会社名",
  "submission_destination": "テスト担当者"
}
```

### 実装画像などあれば添付する

![スクリーンショット 2022-04-03 20 55 12](https://user-images.githubusercontent.com/52871417/161427227-7987d39e-52e9-4c03-8831-9a88009905ca.png)