### PR TITLE
Fix/sub request order

### DIFF
--- a/app/controllers/users/sub_request_orders_controller.rb
+++ b/app/controllers/users/sub_request_orders_controller.rb
@@ -5,7 +5,7 @@ module Users
     def index; end
 
     def new
-      requested_businesses = Business.joins(:request_orders).where(request_orders: {id: @request_order.children})
+      requested_businesses = Business.joins(:request_orders).where(request_orders: { id: @request_order.children })
       @businesses = Business.where.not(id: requested_businesses).where.not(id: current_business)
     end
 

--- a/app/controllers/users/sub_request_orders_controller.rb
+++ b/app/controllers/users/sub_request_orders_controller.rb
@@ -5,7 +5,8 @@ module Users
     def index; end
 
     def new
-      @businesses = Business.where.not(id: current_business)
+      requested_businesses = Business.joins(:request_orders).where(request_orders: {id: @request_order.children})
+      @businesses = Business.where.not(id: requested_businesses).where.not(id: current_business)
     end
 
     def create

--- a/app/models/request_order.rb
+++ b/app/models/request_order.rb
@@ -7,6 +7,8 @@ class RequestOrder < ApplicationRecord
 
   has_closure_tree
 
+  validates :business_id, uniqueness: { scope: :order_id }
+
   before_create -> { self.uuid = SecureRandom.uuid }
 
   def to_param

--- a/db/fixtures/development/04_car.rb
+++ b/db/fixtures/development/04_car.rb
@@ -1,20 +1,95 @@
-Business.all.each do |business|
-  3.times do |n|
-    Car.seed(:id,
-      {
-        id: n+1,
-        business_id:         business.id,
-        car_insurance_company_id: 1,
-        owner_name:                "車両所有者#{n+1}",
-        safety_manager:           "安全運転管理者#{n+1}",
-        vehicle_model:             "車両型式#{n+1}",
-        vehicle_number:          "12-3#{n+1}",
-        vehicle_inspection_start_on:     '2020-01-01',
-        vehicle_inspection_end_on:      '2025-01-01',
-        liability_securities_number: "12345#{n+1}",
-        liability_insurance_start_on:        '2000-01-01',
-        liability_insurance_end_on:     '2030-01-01'
-      }
-    )
-  end
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+1,
+      business_id:         1,
+      car_insurance_company_id: 1,
+      owner_name:                "車両所有者#{n+1}",
+      safety_manager:           "安全運転管理者#{n+1}",
+      vehicle_model:             "車両型式#{n+1}",
+      vehicle_number:          "12-3#{n+1}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+1}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
 end
+
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+4,
+      business_id:         2,
+      car_insurance_company_id: 4,
+      owner_name:                "車両所有者#{n+4}",
+      safety_manager:           "安全運転管理者#{n+4}",
+      vehicle_model:             "車両型式#{n+4}",
+      vehicle_number:          "12-3#{n+4}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+4}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+7,
+      business_id:         3,
+      car_insurance_company_id: 7,
+      owner_name:                "車両所有者#{n+7}",
+      safety_manager:           "安全運転管理者#{n+7}",
+      vehicle_model:             "車両型式#{n+7}",
+      vehicle_number:          "12-3#{n+7}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+7}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+10,
+      business_id:         4,
+      car_insurance_company_id: 10,
+      owner_name:                "車両所有者#{n+10}",
+      safety_manager:           "安全運転管理者#{n+10}",
+      vehicle_model:             "車両型式#{n+10}",
+      vehicle_number:          "12-3#{n+10}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+10}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+13,
+      business_id:         5,
+      car_insurance_company_id: 13,
+      owner_name:                "車両所有者#{n+13}",
+      safety_manager:           "安全運転管理者#{n+13}",
+      vehicle_model:             "車両型式#{n+13}",
+      vehicle_number:          "12-3#{n+13}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+13}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
+end
+

--- a/db/fixtures/development/06_order.rb
+++ b/db/fixtures/development/06_order.rb
@@ -1,16 +1,74 @@
-Business.all.each do |business|
-  3.times do |n|
-    Order.seed(:id,
-      {
-        id: n+1,
-        business_id:         business.id,
-        status: 0,
-        site_uu_id:                SecureRandom.uuid,
-        site_name:           "現場#{n+1}",
-        order_name:             "発注者#{n+1}",
-        order_post_code:          "123456#{n+1}",
-        order_address:     "埼玉県発注市1-2-#{n+1}"
-      }
-    )
-  end
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+1,
+      business_id:         1,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+1}",
+      order_name:             "発注者#{n+1}",
+      order_post_code:          "123456#{n+1}",
+      order_address:     "埼玉県発注市1-2-#{n+1}"
+    }
+  )
+end
+
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+4,
+      business_id:         2,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+4}",
+      order_name:             "発注者#{n+4}",
+      order_post_code:          "123456#{n+4}",
+      order_address:     "埼玉県発注市1-2-#{n+4}"
+    }
+  )
+end
+
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+7,
+      business_id:         3,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+7}",
+      order_name:             "発注者#{n+7}",
+      order_post_code:          "123456#{n+7}",
+      order_address:     "埼玉県発注市1-2-#{n+7}"
+    }
+  )
+end
+
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+10,
+      business_id:         4,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+10}",
+      order_name:             "発注者#{n+10}",
+      order_post_code:          "123456#{n+10}",
+      order_address:     "埼玉県発注市1-2-#{n+10}"
+    }
+  )
+end
+
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+13,
+      business_id:         5,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+13}",
+      order_name:             "発注者#{n+13}",
+      order_post_code:          "123456#{n+13}",
+      order_address:     "埼玉県発注市1-2-#{n+13}"
+    }
+  )
 end

--- a/db/fixtures/development/10_worker.rb
+++ b/db/fixtures/development/10_worker.rb
@@ -1,23 +1,109 @@
-Business.all.each do |business|
-  3.times do |n|
-    Worker.seed(:id,
-      {
-        id: n+1,
-        business_id:         business.id,
-        name:                "テスト作業員#{n+1}",
-        name_kana:           "テストサギョウイン#{n+1}",
-        country:             "日本",
-        my_address:          "東京都サギョウ区1-2-#{n+1}",
-        my_phone_number:     '01234567898',
-        family_address:      "千葉県サギョウ区1-2-#{n+1}",
-        family_phone_number: '01234567898',
-        birth_day_on:        '2000-01-01',
-        abo_blood_type:      0,
-        rh_blood_type:       0,
-        hiring_on:           '2022-01-01',
-        experience_term_before_hiring: 1,
-        blank_term:          1
-      }
-    )
-  end
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+1,
+      business_id:         1,
+      name:                "テスト作業員#{n+1}",
+      name_kana:           "テストサギョウイン#{n+1}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+1}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+1}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
+end
+
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+4,
+      business_id:         2,
+      name:                "テスト作業員#{n+4}",
+      name_kana:           "テストサギョウイン#{n+4}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+4}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+4}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
+end
+
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+7,
+      business_id:         3,
+      name:                "テスト作業員#{n+7}",
+      name_kana:           "テストサギョウイン#{n+7}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+7}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+7}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
+end
+
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+10,
+      business_id:         4,
+      name:                "テスト作業員#{n+10}",
+      name_kana:           "テストサギョウイン#{n+10}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+10}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+10}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
+end
+
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+13,
+      business_id:         5,
+      name:                "テスト作業員#{n+13}",
+      name_kana:           "テストサギョウイン#{n+13}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+13}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+13}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
 end

--- a/db/fixtures/development/11_worker_license.rb
+++ b/db/fixtures/development/11_worker_license.rb
@@ -1,8 +1,7 @@
 Worker.all.each do |worker|
   3.times do |n|
-    WorkerLicense.seed(:id,
+    WorkerLicense.seed(:worker_id, :license_id,
       {
-        id: n+1,
         worker_id:         worker.id,
         license_id:        n+1,
         got_on:             '2022-02-12'

--- a/db/fixtures/development/12_worker_skill_training.rb
+++ b/db/fixtures/development/12_worker_skill_training.rb
@@ -1,8 +1,7 @@
 Worker.all.each do |worker|
   3.times do |n|
-    WorkerSkillTraining.seed(:id,
+    WorkerSkillTraining.seed(:worker_id, :skill_training_id,
       {
-        id: n+1,
         worker_id:         worker.id,
         skill_training_id:        n+1,
         got_on:             '2022-02-12'

--- a/db/fixtures/development/13_worker_epecial_education.rb
+++ b/db/fixtures/development/13_worker_epecial_education.rb
@@ -1,8 +1,7 @@
 Worker.all.each do |worker|
   3.times do |n|
-    WorkerSpecialEducation.seed(:id,
+    WorkerSpecialEducation.seed(:worker_id, :special_education_id,
       {
-        id: n+1,
         worker_id:         worker.id,
         special_education_id:        n+1,
         got_on:             '2022-02-12'

--- a/db/fixtures/development/16_worker_exam.rb
+++ b/db/fixtures/development/16_worker_exam.rb
@@ -1,8 +1,7 @@
 WorkerMedical.all.each do |worker_medical|
   3.times do |n|
-    WorkerExam.seed(:id,
+    WorkerExam.seed(:worker_medical_id, :special_med_exam_id,
       {
-        id: n+1,
         worker_medical_id:         worker_medical.id,
         special_med_exam_id:        n+1,
         got_on:             '2022-02-12'

--- a/db/fixtures/production/04_car.rb
+++ b/db/fixtures/production/04_car.rb
@@ -1,20 +1,95 @@
-Business.all.each do |business|
-  3.times do |n|
-    Car.seed(:id,
-      {
-        id: n+1,
-        business_id:         business.id,
-        car_insurance_company_id: 1,
-        owner_name:                "車両所有者#{n+1}",
-        safety_manager:           "安全運転管理者#{n+1}",
-        vehicle_model:             "車両型式#{n+1}",
-        vehicle_number:          "12-3#{n+1}",
-        vehicle_inspection_start_on:     '2020-01-01',
-        vehicle_inspection_end_on:      '2025-01-01',
-        liability_securities_number: "12345#{n+1}",
-        liability_insurance_start_on:        '2000-01-01',
-        liability_insurance_end_on:     '2030-01-01'
-      }
-    )
-  end
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+1,
+      business_id:         1,
+      car_insurance_company_id: 1,
+      owner_name:                "車両所有者#{n+1}",
+      safety_manager:           "安全運転管理者#{n+1}",
+      vehicle_model:             "車両型式#{n+1}",
+      vehicle_number:          "12-3#{n+1}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+1}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
 end
+
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+4,
+      business_id:         2,
+      car_insurance_company_id: 4,
+      owner_name:                "車両所有者#{n+4}",
+      safety_manager:           "安全運転管理者#{n+4}",
+      vehicle_model:             "車両型式#{n+4}",
+      vehicle_number:          "12-3#{n+4}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+4}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+7,
+      business_id:         3,
+      car_insurance_company_id: 7,
+      owner_name:                "車両所有者#{n+7}",
+      safety_manager:           "安全運転管理者#{n+7}",
+      vehicle_model:             "車両型式#{n+7}",
+      vehicle_number:          "12-3#{n+7}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+7}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+10,
+      business_id:         4,
+      car_insurance_company_id: 10,
+      owner_name:                "車両所有者#{n+10}",
+      safety_manager:           "安全運転管理者#{n+10}",
+      vehicle_model:             "車両型式#{n+10}",
+      vehicle_number:          "12-3#{n+10}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+10}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  Car.seed(:id,
+    {
+      id: n+13,
+      business_id:         5,
+      car_insurance_company_id: 13,
+      owner_name:                "車両所有者#{n+13}",
+      safety_manager:           "安全運転管理者#{n+13}",
+      vehicle_model:             "車両型式#{n+13}",
+      vehicle_number:          "12-3#{n+13}",
+      vehicle_inspection_start_on:     '2020-01-01',
+      vehicle_inspection_end_on:      '2025-01-01',
+      liability_securities_number: "12345#{n+13}",
+      liability_insurance_start_on:        '2000-01-01',
+      liability_insurance_end_on:     '2030-01-01'
+    }
+  )
+end
+

--- a/db/fixtures/production/06_order.rb
+++ b/db/fixtures/production/06_order.rb
@@ -1,16 +1,74 @@
-Business.all.each do |business|
-  3.times do |n|
-    Order.seed(:id,
-      {
-        id: n+1,
-        business_id:         business.id,
-        status: 0,
-        site_uu_id:                SecureRandom.uuid,
-        site_name:           "現場#{n+1}",
-        order_name:             "発注者#{n+1}",
-        order_post_code:          "123456#{n+1}",
-        order_address:     "埼玉県発注市1-2-#{n+1}"
-      }
-    )
-  end
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+1,
+      business_id:         1,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+1}",
+      order_name:             "発注者#{n+1}",
+      order_post_code:          "123456#{n+1}",
+      order_address:     "埼玉県発注市1-2-#{n+1}"
+    }
+  )
+end
+
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+4,
+      business_id:         2,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+4}",
+      order_name:             "発注者#{n+4}",
+      order_post_code:          "123456#{n+4}",
+      order_address:     "埼玉県発注市1-2-#{n+4}"
+    }
+  )
+end
+
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+7,
+      business_id:         3,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+7}",
+      order_name:             "発注者#{n+7}",
+      order_post_code:          "123456#{n+7}",
+      order_address:     "埼玉県発注市1-2-#{n+7}"
+    }
+  )
+end
+
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+10,
+      business_id:         4,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+10}",
+      order_name:             "発注者#{n+10}",
+      order_post_code:          "123456#{n+10}",
+      order_address:     "埼玉県発注市1-2-#{n+10}"
+    }
+  )
+end
+
+3.times do |n|
+  Order.seed(:id,
+    {
+      id: n+13,
+      business_id:         5,
+      status: 0,
+      site_uu_id:                SecureRandom.uuid,
+      site_name:           "現場#{n+13}",
+      order_name:             "発注者#{n+13}",
+      order_post_code:          "123456#{n+13}",
+      order_address:     "埼玉県発注市1-2-#{n+13}"
+    }
+  )
 end

--- a/db/fixtures/production/10_worker.rb
+++ b/db/fixtures/production/10_worker.rb
@@ -1,23 +1,109 @@
-Business.all.each do |business|
-  3.times do |n|
-    Worker.seed(:id,
-      {
-        id: n+1,
-        business_id:         business.id,
-        name:                "テスト作業員#{n+1}",
-        name_kana:           "テストサギョウイン#{n+1}",
-        country:             "日本",
-        my_address:          "東京都サギョウ区1-2-#{n+1}",
-        my_phone_number:     '01234567898',
-        family_address:      "千葉県サギョウ区1-2-#{n+1}",
-        family_phone_number: '01234567898',
-        birth_day_on:        '2000-01-01',
-        abo_blood_type:      0,
-        rh_blood_type:       0,
-        hiring_on:           '2022-01-01',
-        experience_term_before_hiring: 1,
-        blank_term:          1
-      }
-    )
-  end
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+1,
+      business_id:         1,
+      name:                "テスト作業員#{n+1}",
+      name_kana:           "テストサギョウイン#{n+1}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+1}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+1}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
+end
+
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+4,
+      business_id:         2,
+      name:                "テスト作業員#{n+4}",
+      name_kana:           "テストサギョウイン#{n+4}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+4}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+4}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
+end
+
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+7,
+      business_id:         3,
+      name:                "テスト作業員#{n+7}",
+      name_kana:           "テストサギョウイン#{n+7}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+7}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+7}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
+end
+
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+10,
+      business_id:         4,
+      name:                "テスト作業員#{n+10}",
+      name_kana:           "テストサギョウイン#{n+10}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+10}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+10}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
+end
+
+3.times do |n|
+  Worker.seed(:id,
+    {
+      id: n+13,
+      business_id:         5,
+      name:                "テスト作業員#{n+13}",
+      name_kana:           "テストサギョウイン#{n+13}",
+      country:             "日本",
+      my_address:          "東京都サギョウ区1-2-#{n+13}",
+      my_phone_number:     '01234567898',
+      family_address:      "千葉県サギョウ区1-2-#{n+13}",
+      family_phone_number: '01234567898',
+      birth_day_on:        '2000-01-01',
+      abo_blood_type:      0,
+      rh_blood_type:       0,
+      hiring_on:           '2022-01-01',
+      experience_term_before_hiring: 1,
+      blank_term:          1
+    }
+  )
 end

--- a/db/fixtures/production/11_worker_license.rb
+++ b/db/fixtures/production/11_worker_license.rb
@@ -1,8 +1,7 @@
 Worker.all.each do |worker|
   3.times do |n|
-    WorkerLicense.seed(:id,
+    WorkerLicense.seed(:worker_id, :license_id,
       {
-        id: n+1,
         worker_id:         worker.id,
         license_id:        n+1,
         got_on:             '2022-02-12'

--- a/db/fixtures/production/12_worker_skill_training.rb
+++ b/db/fixtures/production/12_worker_skill_training.rb
@@ -1,8 +1,7 @@
 Worker.all.each do |worker|
   3.times do |n|
-    WorkerSkillTraining.seed(:id,
+    WorkerSkillTraining.seed(:worker_id, :skill_training_id,
       {
-        id: n+1,
         worker_id:         worker.id,
         skill_training_id:        n+1,
         got_on:             '2022-02-12'

--- a/db/fixtures/production/13_worker_epecial_education.rb
+++ b/db/fixtures/production/13_worker_epecial_education.rb
@@ -1,8 +1,7 @@
 Worker.all.each do |worker|
   3.times do |n|
-    WorkerSpecialEducation.seed(:id,
+    WorkerSpecialEducation.seed(:worker_id, :special_education_id,
       {
-        id: n+1,
         worker_id:         worker.id,
         special_education_id:        n+1,
         got_on:             '2022-02-12'

--- a/db/fixtures/production/16_worker_exam.rb
+++ b/db/fixtures/production/16_worker_exam.rb
@@ -1,8 +1,7 @@
 WorkerMedical.all.each do |worker_medical|
   3.times do |n|
-    WorkerExam.seed(:id,
+    WorkerExam.seed(:worker_medical_id, :special_med_exam_id,
       {
-        id: n+1,
         worker_medical_id:         worker_medical.id,
         special_med_exam_id:        n+1,
         got_on:             '2022-02-12'

--- a/db/migrate/20220420133157_add_index_composite_primary_keys_to_request_orders.rb
+++ b/db/migrate/20220420133157_add_index_composite_primary_keys_to_request_orders.rb
@@ -1,0 +1,5 @@
+class AddIndexCompositePrimaryKeysToRequestOrders < ActiveRecord::Migration[6.1]
+  def change
+    add_index :request_orders, [:business_id, :order_id], unique: true 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_28_070543) do
+ActiveRecord::Schema.define(version: 2022_04_20_133157) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "namespace"
@@ -217,6 +217,7 @@ ActiveRecord::Schema.define(version: 2022_03_28_070543) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "parent_id"
     t.string "uuid", null: false
+    t.index ["business_id", "order_id"], name: "index_request_orders_on_business_id_and_order_id", unique: true
     t.index ["business_id"], name: "index_request_orders_on_business_id"
     t.index ["order_id"], name: "index_request_orders_on_order_id"
   end


### PR DESCRIPTION
### 概要
①下請け発注依頼時、同事業所への重複依頼が出来ないようにする
②seedファイルの不具合修正

### タスク
①https://trello.com/c/mnjxGYzd
②タスクリンク無

### 実装内容・手法
①
・`order_id`と`business_id`の複合ユニークキー作成
・joinとwhereで依頼済みの事業所を除く事業所を絞込み表示

②
・各中間テーブルはidではなく、複合ユニークキーでデータ作成
・その他テーブルはeachやtimesを無くしてベタ書きにする事でひとまずの修正としました
※開発環境にて複数回のseedを行い、データが増えないことを確認済

### 実装画像などあれば添付する
①依頼済み事業所を除いた事業所表示

https://user-images.githubusercontent.com/63439936/166086314-c9a72b32-187e-4a66-b6b6-31e31ec0c882.mov




