### PR TITLE
お知らせの表示編集

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ gem 'wkhtmltopdf-binary'
 # aws_for_rails
 gem 'aws-sdk-rails'
 
+# ページネーション
+gem 'kaminari'
+
 group :development, :test do
   # ERD生成
   gem 'rails-erd'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,6 +464,7 @@ DEPENDENCIES
   fog-aws
   jbuilder (~> 2.7)
   jp_prefecture
+  kaminari
   letter_opener_web (~> 1.0)
   listen (~> 3.3)
   mysql2 (~> 0.5)

--- a/app/controllers/users/news_controller.rb
+++ b/app/controllers/users/news_controller.rb
@@ -3,7 +3,7 @@ module Users
     after_action :unread_news_count
 
     def index
-      @news_all = News.published.order(delivered_at: 'DESC')
+      @news_all = News.published.page(params[:page]).per(10).order(id: 'ASC')
     end
 
     def show

--- a/app/controllers/users/news_controller.rb
+++ b/app/controllers/users/news_controller.rb
@@ -3,7 +3,7 @@ module Users
     after_action :unread_news_count
 
     def index
-      @news_all = News.published.page(params[:page]).per(10).order(id: 'ASC')
+      @news_all = News.published.page(params[:page]).per(10).order(delivered_at: 'ASC')
     end
 
     def show

--- a/app/controllers/users/news_controller.rb
+++ b/app/controllers/users/news_controller.rb
@@ -3,7 +3,7 @@ module Users
     after_action :unread_news_count
 
     def index
-      @news_all = News.published.page(params[:page]).per(10).order(delivered_at: 'ASC')
+      @news_all = News.published.page(params[:page]).per(10).order(delivered_at: 'DESC')
     end
 
     def show

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/users/news/index.html.erb
+++ b/app/views/users/news/index.html.erb
@@ -5,13 +5,12 @@
       <% @news_all.each do |news| %>
         <table class='table card card-body'>
           <tbody>
-            <tr><td class='table-secondary'><%= link_to news.title, users_news_path(news) %></td></tr>
-            <tr><td><%= news.content %></td></tr>
-            <tr><td>配信日: <%= l(news.delivered_at, format: :long) %></td></tr>
-            <tr><td>公開状態: <%= news.status_i18n %></td></tr>
+            <tr class="card bg-light"><td><%= link_to news.title, users_news_path(news) %></td></tr>
+            <tr class="card"><td>配信日: <%= l(news.delivered_at, format: :long) %></td></tr>
           </tbody>
         </table>
       <% end %>
+      <%= paginate @news_all %>
     </div><!-- /.row -->
   </div><!-- /.container-fluid -->
 </div>

--- a/app/views/users/news/show.html.erb
+++ b/app/views/users/news/show.html.erb
@@ -2,12 +2,12 @@
 <div class="content">
   <div class="container-fluid">
     <div class="row">
-      <table class='table card card-body'>
+      <table class="table card card-body">
         <tbody>
-          <tr><td class='table-secondary'><%= @news.title %></td></tr>
-          <tr><td><%= @news.content %></td></tr>
-          <tr><td>配信日: <%= l(@news.delivered_at, format: :long) %></td></tr>
-          <tr><td>公開状態: <%= @news.status_i18n %></td></tr>
+          <tr class="card bg-light"><td><%= @news.title %></td></tr>
+          <tr class="card"><td><%= simple_format(@news.content) %></td></tr>
+          <tr class="card"><td>配信日: <%= l(@news.delivered_at, format: :long) %></td></tr>
+          <tr class="card"><td>公開状態: <%= @news.status_i18n %></td></tr>
         </tbody>
       </table>
       <%= link_to 'お知らせ一覧に戻る', users_news_index_path %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  config.left = 2
+  config.right = 1
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -15,4 +15,3 @@ ja:
           other: "<strong>1-%{count}</strong>/%{count}件中"
       more_pages:
         display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"
-            

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,18 @@
+ja:
+  views:
+    pagination:
+      first: "最初"
+      last: "最後"
+      previous: "« 前"
+      next: "次 »"
+      truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: ""
+          one: "<strong>1-1</strong>/1件中"
+          other: "<strong>1-%{count}</strong>/%{count}件中"
+      more_pages:
+        display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"
+            

--- a/db/fixtures/development/17_news.rb
+++ b/db/fixtures/development/17_news.rb
@@ -1,37 +1,11 @@
-News.seed(
-  {
-    id: 1,
-    title: "お知らせ-1",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  },
-  {
-    id: 2,
-    title: "お知らせ-2",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  },
-  {
-    id: 3,
-    title: "お知らせ-3",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  },
-  {
-    id: 4,
-    title: "お知らせ-4",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  },
-  {
-    id: 5,
-    title: "お知らせ-5",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  }
-)
+20.times do |n|
+  News.seed(
+    {
+      id: n+1,
+      title: "お知らせ-#{n+1}",
+      content: "改行テスト-#{n+1}\r\n改行\r再度改行\n最終行".gsub(/\R/, "\n"),
+      delivered_at: DateTime.now.yesterday,
+      status: 'published'
+    }
+  )
+end

--- a/db/fixtures/development/17_news.rb
+++ b/db/fixtures/development/17_news.rb
@@ -4,7 +4,7 @@
       id: n+1,
       title: "お知らせ-#{n+1}",
       content: "改行テスト-#{n+1}\r\n改行\r再度改行\n最終行".gsub(/\R/, "\n"),
-      delivered_at: DateTime.now.yesterday,
+      delivered_at: DateTime.now - (n+1),
       status: 'published'
     }
   )

--- a/db/fixtures/production/17_news.rb
+++ b/db/fixtures/production/17_news.rb
@@ -1,37 +1,11 @@
-News.seed(
-  {
-    id: 1,
-    title: "お知らせ-1",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  },
-  {
-    id: 2,
-    title: "お知らせ-2",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  },
-  {
-    id: 3,
-    title: "お知らせ-3",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  },
-  {
-    id: 4,
-    title: "お知らせ-4",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  },
-  {
-    id: 5,
-    title: "お知らせ-5",
-    content: Faker::Lorem.sentence(word_count: 20),
-    delivered_at: DateTime.now.yesterday,
-    status: 'published'
-  }
-)
+20.times do |n|
+  News.seed(
+    {
+      id: n+1,
+      title: "お知らせ-#{n+1}",
+      content: "改行テスト-#{n+1}\r\n改行\r再度改行\n最終行".gsub(/\R/, "\n"),
+      delivered_at: DateTime.now.yesterday,
+      status: 'published'
+    }
+  )
+end

--- a/db/fixtures/production/17_news.rb
+++ b/db/fixtures/production/17_news.rb
@@ -4,7 +4,7 @@
       id: n+1,
       title: "お知らせ-#{n+1}",
       content: "改行テスト-#{n+1}\r\n改行\r再度改行\n最終行".gsub(/\R/, "\n"),
-      delivered_at: DateTime.now.yesterday,
+      delivered_at: DateTime.now - (n+1),
       status: 'published'
     }
   )


### PR DESCRIPTION
### 概要
- ユーザーログイン後のお知らせ一覧画面(users/news)において
    - 添付画像の①のお知らせの内容と公開状態は非表示にする
    - ①のレイアウトがお知らせそれぞれで長さが違うので画面横いっぱいに広がるように表示すること
    - お知らせの表示は最大10件まで、それ以上はページネーションにすること    
    - 本番環境で確認できるようにテスト用のデータ20件をseed_fuで作ること        
- お知らせ詳細画面
    - システム管理者側でお知らせを作成できるが、改行された文章を作成したときに、ユーザー側でも改行されてお知らせの内容が表示されること
        

### タスク
- [https://trello.com/c/jRa38KVT](url)

### 実装内容・手法
_実装内容や、問題の解決手法を記述する_
・改行文字の表示に関しては、simple_formatにて対応。
・kaminariのgemをbundleしてページネーション機能を実装
　　kaminariの設定ファイル、見た目を編集するためのviewファイルを設定
　　設定↓
　　`config/initializers/kaminari_config.rb`　設定ファイル
　　`rails g kaminari:views bootstrap4`コマンドを実行、デザインをbootstrap4に変更

### 実装画像などあれば添付する

添付画像１
![App_2022-03-11_05-59-51](https://user-images.githubusercontent.com/69907902/167280344-146b54d6-1e49-4a00-b59e-cfb5eb4859f2.png)

ページネーション画像1
![全画面_01](https://user-images.githubusercontent.com/69907902/167293098-d13af829-5176-4729-8779-08211802c272.jpg)

ページネーション画像2
![全画面_02](https://user-images.githubusercontent.com/69907902/167293116-ee7a04db-673e-4487-b694-7e0e113e6575.jpg)

ページネーション順番確認画像
![全画面_03](https://user-images.githubusercontent.com/69907902/167298206-2a92bcb3-dbde-45c6-bed6-c5cb1eda1b1c.jpg)

