### PR TITLE
Fix/primary keys

### DIFF
--- a/app/controllers/users/sub_request_orders_controller.rb
+++ b/app/controllers/users/sub_request_orders_controller.rb
@@ -5,8 +5,7 @@ module Users
     def index; end
 
     def new
-      requested_businesses = Business.joins(:request_orders).where(request_orders: { id: @request_order.children })
-      @businesses = Business.where.not(id: requested_businesses).where.not(id: current_business)
+      @businesses = Business.where.not(id: current_business)
     end
 
     def create

--- a/app/models/request_order.rb
+++ b/app/models/request_order.rb
@@ -7,8 +7,6 @@ class RequestOrder < ApplicationRecord
 
   has_closure_tree
 
-  validates :business_id, uniqueness: { scope: :order_id }
-
   before_create -> { self.uuid = SecureRandom.uuid }
 
   def to_param

--- a/db/migrate/20220507064223_remove_i_ndex_composite_primary_keys_to_request_orders.rb
+++ b/db/migrate/20220507064223_remove_i_ndex_composite_primary_keys_to_request_orders.rb
@@ -1,0 +1,5 @@
+class RemoveINdexCompositePrimaryKeysToRequestOrders < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :request_orders, [:business_id, :order_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_20_133157) do
+ActiveRecord::Schema.define(version: 2022_05_07_064223) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "namespace"
@@ -217,7 +217,6 @@ ActiveRecord::Schema.define(version: 2022_04_20_133157) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "parent_id"
     t.string "uuid", null: false
-    t.index ["business_id", "order_id"], name: "index_request_orders_on_business_id_and_order_id", unique: true
     t.index ["business_id"], name: "index_request_orders_on_business_id"
     t.index ["order_id"], name: "index_request_orders_on_order_id"
   end


### PR DESCRIPTION
### 概要
複合ユニークキー削除&事業所表示修正

### タスク
- [x] なし
- [ ] あり 

### 実装内容・手法
○過去追加した「order_id」と「business_id」の複合ユニークキーを削除するマイグレーションを追加
　→下請け発注依頼登録画面にて、何度も同じ事業所への依頼が可能に
○下請け発注依頼登録画面（sub_request_orders/new）の事業所表示一覧も以前の「自分の事業所を除く事業所全て」に戻しました

### 実装画像などあれば添付する

https://user-images.githubusercontent.com/63439936/167294998-b9a9011f-08ab-45cb-b17b-052ea666a370.mov



