### PR TITLE
Fix/uploader

### DIFF
--- a/app/uploaders/base.rb
+++ b/app/uploaders/base.rb
@@ -22,7 +22,7 @@ class Base < CarrierWave::Uploader::Base
   end
 
   def filename
-    "#{secure_token}.png" if original_filename.present?
+    "#{secure_token}_#{original_filename}" if original_filename.present?
   end
 
   protected

--- a/app/uploaders/base.rb
+++ b/app/uploaders/base.rb
@@ -22,13 +22,23 @@ class Base < CarrierWave::Uploader::Base
   end
 
   def filename
-    "#{secure_token}_#{original_filename}" if original_filename.present?
+    "#{secure_token}.#{file.extension}" if original_filename.present?
   end
 
   protected
 
   def secure_token
-    var = :"@#{mounted_as}_secure_token"
-    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
+    media_original_filenames_var = :"@#{mounted_as}_original_filenames"
+
+    unless model.instance_variable_get(media_original_filenames_var)
+      model.instance_variable_set(media_original_filenames_var, {})
+    end
+
+    unless model.instance_variable_get(media_original_filenames_var).map{|k,v| k }.include? original_filename.to_sym
+      new_value = model.instance_variable_get(media_original_filenames_var).merge({"#{original_filename}": SecureRandom.uuid})
+      model.instance_variable_set(media_original_filenames_var, new_value)
+    end
+
+    model.instance_variable_get(media_original_filenames_var)[original_filename.to_sym]
   end
 end

--- a/app/uploaders/base.rb
+++ b/app/uploaders/base.rb
@@ -34,8 +34,8 @@ class Base < CarrierWave::Uploader::Base
       model.instance_variable_set(media_original_filenames_var, {})
     end
 
-    unless model.instance_variable_get(media_original_filenames_var).map{|k,v| k }.include? original_filename.to_sym
-      new_value = model.instance_variable_get(media_original_filenames_var).merge({"#{original_filename}": SecureRandom.uuid})
+    unless model.instance_variable_get(media_original_filenames_var).map { |k, _v| k }.include? original_filename.to_sym
+      new_value = model.instance_variable_get(media_original_filenames_var).merge({ "#{original_filename}": SecureRandom.uuid })
       model.instance_variable_set(media_original_filenames_var, new_value)
     end
 


### PR DESCRIPTION
### 概要
画像複数投稿機能の不具合修正

### タスク
- [ ] なし
- [x] あり https://trello.com/c/vOd9ycrs

### 実装内容・手法
○色々試しましたが、下記のやり方で一時的に不具合回避しています。
○app/uploaders/base.rbにて、filenameが、モデルごとに一つのsecure_tokenが割り振られる形の名前となっており、複数画像も一つのsecure_tokenのファイル名として保存される形となっていた為、そこにoriginal_filenameをくっ付けて回避しました。

### 実装画像などあれば添付する
○画像複数投稿挙動

https://user-images.githubusercontent.com/63439936/167656772-0afb299d-fe7a-43d1-9fd0-c02e9f51b057.mov

### 確認事項
○更新時のログにて、上述の通り、モデルごとに一つのsecure_tokenが割り振られる形は変わっていない為、「token＋オリジナルファイル名」のtokenの部分は複数画像全て同じtokenが割り振られており（下記添付画像）、もはやsecure_tokenの意味があるのか疑問の実装内容となっております😥その為、secure_tokenを無くして単純にオリジナルファイル名のみの表示の方がシンプルな気がするのですが、それではNGでしょうか？

![スクリーンショット 2022-05-10 22 51 15](https://user-images.githubusercontent.com/63439936/167659075-8d0f813e-35be-4099-bce4-a72c85354d3e.png)

○今回のやり方以外に、secure_tokenをモデルごとに配布ではなく、モデルの画像ファイルごとに配布できればベストな気がしたのですが、色々試した結果そこには辿り着けませんでした💧

以上宜しくお願い致します！