### PR TITLE
ステージング環境での作業員セレクトフォームのstyleのずれ修正(平野)

### DIFF
--- a/app/javascript/packs/users.js
+++ b/app/javascript/packs/users.js
@@ -18,8 +18,8 @@ import 'bootstrap';
 import '../stylesheets/users';
 import "@fortawesome/fontawesome-free/js/all";
 import "@nathanvda/cocoon"
-import 'select2'
-import 'select2/dist/css/select2.css'
+// import 'select2'
+// import 'select2/dist/css/select2.css'
 
 document.addEventListener("turbolinks:load", () => {
   $('[data-toggle="tooltip"]').tooltip()

--- a/app/javascript/packs/users.js
+++ b/app/javascript/packs/users.js
@@ -18,14 +18,13 @@ import 'bootstrap';
 import '../stylesheets/users';
 import "@fortawesome/fontawesome-free/js/all";
 import "@nathanvda/cocoon"
-// import 'select2'
-// import 'select2/dist/css/select2.css'
 
 document.addEventListener("turbolinks:load", () => {
   $('[data-toggle="tooltip"]').tooltip()
   $('.js-select').select2({
-    multiple: "multiple",
-    placeholder: '作業員を選択',
+    width: 'resolve',
+    theme: 'classic',
+    multiple: 'multiple',
     allowClear: true
   })
 });

--- a/app/javascript/packs/users.js
+++ b/app/javascript/packs/users.js
@@ -24,7 +24,7 @@ import 'select2/dist/css/select2.css'
 document.addEventListener("turbolinks:load", () => {
   $('[data-toggle="tooltip"]').tooltip()
   $('.js-select').select2({
-    // multiple: "multiple",
+    multiple: "multiple",
     placeholder: '作業員を選択',
     allowClear: true
   })

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -34,7 +34,7 @@
 <%= f.select :business_type, Business.business_types.keys.map { |k| [I18n.t("enums.business.business_type.#{k}"), k]}, {include_blank: true}, {class: "form-control"} %>
 <br>
 <%= f.label :occupation_ids %><br>
-<%= f.collection_select :occupation_ids, Occupation.all, :id, :name, { selected: f.object.occupations.ids }, { class: "pref form-control", multiple: true } %>
+<%= f.collection_select :occupation_ids, Occupation.all, :id, :name, { selected: f.object.occupations.ids }, { class: "pref js-select", multiple: true, style: "width: 100%" } %>
 <br>
 <br>
 <% if business.stamp_images.present? %>

--- a/app/views/users/documents/doc_5th/_form.html.erb
+++ b/app/views/users/documents/doc_5th/_form.html.erb
@@ -108,7 +108,7 @@
         <%= f.label '作業員選択' %>
         <%= f.select :content, @workers.map { |worker| [worker.name, worker.id] },
                                             { include_hidden: false, selected: @document.content["worker_id"] },
-                                            { name: "document[content][worker][]", class: "js-select", style: "width: 100%" }
+                                            { multiple: 'multiple', name: "document[content][worker][]", class: "js-select", style: "width: 100%" }
         %>
       </div>
     </div><br>

--- a/app/views/users/documents/doc_5th/_form.html.erb
+++ b/app/views/users/documents/doc_5th/_form.html.erb
@@ -105,7 +105,7 @@
     </div>
     <div class="row">
       <div class="col-md-12">
-        <%= f.label '作業員選択' %>
+        <%= f.label '作業員選択1' %>
         <%= f.select :content, @workers.map { |worker| [worker.name, worker.id] },
                                             { include_hidden: false, selected: @document.content["worker_id"] },
                                             { name: "document[content][worker][]", class: "js-select", style: "width: 100%" }

--- a/app/views/users/documents/doc_5th/_form.html.erb
+++ b/app/views/users/documents/doc_5th/_form.html.erb
@@ -108,7 +108,7 @@
         <%= f.label '作業員選択' %>
         <%= f.select :content, @workers.map { |worker| [worker.name, worker.id] },
                                             { include_hidden: false, selected: @document.content["worker_id"] },
-                                            { name: "document[content][worker][]", class: "js-select form-control", multiple: true }
+                                            { name: "document[content][worker][]", class: "js-select", style: "width: 100%" }
         %>
       </div>
     </div><br>

--- a/app/views/users/documents/doc_5th/_form.html.erb
+++ b/app/views/users/documents/doc_5th/_form.html.erb
@@ -105,7 +105,7 @@
     </div>
     <div class="row">
       <div class="col-md-12">
-        <%= f.label '作業員選択1' %>
+        <%= f.label '作業員選択' %>
         <%= f.select :content, @workers.map { |worker| [worker.name, worker.id] },
                                             { include_hidden: false, selected: @document.content["worker_id"] },
                                             { name: "document[content][worker][]", class: "js-select", style: "width: 100%" }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -386,6 +386,7 @@ ActiveRecord::Schema.define(version: 2022_05_17_013339) do
     t.index ["business_id"], name: "index_workers_on_business_id"
   end
 
+  add_foreign_key "articles", "users"
   add_foreign_key "business_occupations", "businesses"
   add_foreign_key "business_occupations", "occupations"
   add_foreign_key "businesses", "users"


### PR DESCRIPTION
### 概要
ステージング環境での作業員セレクトフォームのstyleのずれ修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
●select2のjs設定を修正
　・多分、select2と、bootstrapのスタイルがお互い干渉してずれが生じていた可能性がある。

### 実装画像などあれば添付する

## ■ステージング環境　現在
![ビフォー](https://user-images.githubusercontent.com/52871417/169360267-1e1ae62d-d14e-40b1-8bdd-6a3f7d11a455.png)

↓

## ■自身のheroku環境にて表示確認
![アフター](https://user-images.githubusercontent.com/52871417/169360309-1c5528ac-81ec-4ebe-85af-2a3aaf55faf4.png)


