### PR TITLE
Fix/staging signup

### DIFF
--- a/app/controllers/users/businesses_controller.rb
+++ b/app/controllers/users/businesses_controller.rb
@@ -5,22 +5,26 @@ module Users
     skip_before_action :business_nil_access, only: %i[new create]
 
     def new
-      @business = Business.new(
-        # テスト用デフォルト値 ==========================
-        uuid:                '1',
-        name:                'test企業',
-        name_kana:           'テストキギョウ',
-        branch_name:         'test支店',
-        representative_name: 'test代表',
-        email:               'test@email.com',
-        address:             'test',
-        post_code:           '0123456',
-        phone_number:        '01234567898',
-        carrier_up_id:       'test',
-        business_type:       0
-        # =============================================
-      )
-      @business.business_occupations.build
+      if Rails.env.development?
+        @business = Business.new(
+          # テスト用デフォルト値 ==========================
+          uuid:                '1',
+          name:                'test企業',
+          name_kana:           'テストキギョウ',
+          branch_name:         'test支店',
+          representative_name: 'test代表',
+          email:               'test@email.com',
+          address:             'test',
+          post_code:           '0123456',
+          phone_number:        '01234567898',
+          carrier_up_id:       'test',
+          business_type:       0
+          # =============================================
+        )
+        @business.business_occupations.build
+      else
+        @business = Business.new
+      end
     end
 
     def create

--- a/app/controllers/users/cars_controller.rb
+++ b/app/controllers/users/cars_controller.rb
@@ -9,30 +9,34 @@ module Users
     def show; end
 
     def new
-      @car = current_business.cars.new(
-        # テスト用デフォルト値 ==========================
-        owner_name:                   current_user.name,
-        safety_manager:               'anzen taro',
-        vehicle_model:                'ZVW30',
-        vehicle_number:               '12-34',
-        vehicle_inspection_start_on:  Date.today,
-        vehicle_inspection_end_on:    Date.today.since(3.years),
-        liability_securities_number:  SecureRandom.hex(5),
-        liability_insurance_start_on: Date.today,
-        liability_insurance_end_on:   Date.today.next_year,
-        car_insurance_company_id:     1
-        # ============================================
-      )
-      @car.car_voluntary_insurances.build(
-        # テスト用デフォルト値 ==========================
-        personal_insurance:           1,
-        objective_insurance:          2,
-        voluntary_securities_number:  SecureRandom.hex(5),
-        voluntary_insurance_start_on: Date.today,
-        voluntary_insurance_end_on:   Date.today.next_year,
-        company_voluntary_id:         3
-        # ============================================
-      )
+      if Rails.env.development?
+        @car = current_business.cars.new(
+          # テスト用デフォルト値 ==========================
+          owner_name:                   current_user.name,
+          safety_manager:               'anzen taro',
+          vehicle_model:                'ZVW30',
+          vehicle_number:               '12-34',
+          vehicle_inspection_start_on:  Date.today,
+          vehicle_inspection_end_on:    Date.today.since(3.years),
+          liability_securities_number:  SecureRandom.hex(5),
+          liability_insurance_start_on: Date.today,
+          liability_insurance_end_on:   Date.today.next_year,
+          car_insurance_company_id:     1
+          # ============================================
+        )
+        @car.car_voluntary_insurances.build(
+          # テスト用デフォルト値 ==========================
+          personal_insurance:           1,
+          objective_insurance:          2,
+          voluntary_securities_number:  SecureRandom.hex(5),
+          voluntary_insurance_start_on: Date.today,
+          voluntary_insurance_end_on:   Date.today.next_year,
+          company_voluntary_id:         3
+          # ============================================
+        )
+      else
+        @car = current_business.cars.new
+      end
     end
 
     def create

--- a/app/controllers/users/cars_controller.rb
+++ b/app/controllers/users/cars_controller.rb
@@ -36,6 +36,7 @@ module Users
         )
       else
         @car = current_business.cars.new
+        @car.car_voluntary_insurances.build
       end
     end
 

--- a/app/controllers/users/general_users_controller.rb
+++ b/app/controllers/users/general_users_controller.rb
@@ -13,7 +13,8 @@ module Users
 
     def create
       @general_user = current_user.general_users.new(general_user_params)
-      @general_user.skip_confirmation! # email認証スキップ
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # @general_user.skip_confirmation! # email認証スキップ
       if @general_user.save
         redirect_to users_general_user_url(@general_user)
       else

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -10,55 +10,59 @@ module Users
     def show; end
 
     def new
-      @order = current_business.orders.new(
-        # テスト用デフォルト値 ==========================
-        site_career_up_id:                          '1234-5678-9000',
-        site_name:                                  Faker::Company.name,
-        site_address:                               current_business.address,
+      if Rails.env.development?
+        @order = current_business.orders.new(
+          # テスト用デフォルト値 ==========================
+          site_career_up_id:                          '1234-5678-9000',
+          site_name:                                  Faker::Company.name,
+          site_address:                               current_business.address,
 
-        order_name:                                 Faker::Company.name,
-        order_post_code:                            current_business.post_code,
-        order_address:                              current_business.address,
-        order_supervisor_name:                      Faker::Name.name,
-        order_supervisor_company:                   Faker::Company.name,
-        order_supervisor_apply:                     %w[基本契約約款の通り 契約書に準拠する 口頭及び文書による].sample,
+          order_name:                                 Faker::Company.name,
+          order_post_code:                            current_business.post_code,
+          order_address:                              current_business.address,
+          order_supervisor_name:                      Faker::Name.name,
+          order_supervisor_company:                   Faker::Company.name,
+          order_supervisor_apply:                     %w[基本契約約款の通り 契約書に準拠する 口頭及び文書による].sample,
 
-        construction_name:                          '工事名',
-        construction_details:                       '工事内容',
-        start_date:                                 Date.today,
-        end_date:                                   Date.today.next_month,
-        contract_date:                              Date.today.prev_month,
-        submission_destination:                     '提出部･提出先名',
-        general_safety_responsible_person_name:     '統括安全衛生責任者名',
-        vice_president_name:                        '副会長名',
-        vice_president_company_name:                '副会長会社',
-        secretary_name:                             '書記名',
-        health_and_safety_manager_name:             '元方安全衛生管理者名',
-        general_safety_agent_name:                  '統括安全衛生責任者代行者',
-        supervisor_name:                            '現場監督員名',
-        supervisor_apply:                           %w[基本契約約款の通り 契約書に準拠する 口頭及び文書による].sample,
-        site_agent_name:                            '現場代理人名',
-        site_agent_apply:                           %w[基本契約約款の通り 契約書に準拠する 口頭及び文書による].sample,
-        supervising_engineer_name:                  '監督技術者･主任技術者名',
-        supervising_engineer_check:                 [0, 1].sample,
-        supervising_engineer_assistant_name:        '監督技術者補佐名',
-        professional_engineer_name:                 '専門技術者名',
-        professional_engineer_construction_details: '専門技術者(担当工事内容)',
-        safety_officer_name:                        '安全衛生担当役名',
-        safety_officer_position_name:               '安全衛生担当役員(役職名)',
-        general_safety_manager_name:                '総括安全衛生管理者名',
-        general_safety_manager_position_name:       '総括安全衛生管理(役職名)',
-        safety_manager_name:                        '安全管理者名',
-        safety_manager_position_name:               '安全管理者(役職名)',
-        health_manager_name:                        '衛生管理者名',
-        health_manager_position_name:               '衛生管理者(役職名)',
-        health_and_safety_promoter_name:            '安全衛生推進者名',
-        health_and_safety_promoter_position_name:   '安全衛生推進者(役職名)',
-        confirm_name:                               '確認欄(氏名)',
-        accept_confirm_date:                        Date.yesterday,
-        subcontractor_name:                         '下請会社'
-        # =============================================
-      )
+          construction_name:                          '工事名',
+          construction_details:                       '工事内容',
+          start_date:                                 Date.today,
+          end_date:                                   Date.today.next_month,
+          contract_date:                              Date.today.prev_month,
+          submission_destination:                     '提出部･提出先名',
+          general_safety_responsible_person_name:     '統括安全衛生責任者名',
+          vice_president_name:                        '副会長名',
+          vice_president_company_name:                '副会長会社',
+          secretary_name:                             '書記名',
+          health_and_safety_manager_name:             '元方安全衛生管理者名',
+          general_safety_agent_name:                  '統括安全衛生責任者代行者',
+          supervisor_name:                            '現場監督員名',
+          supervisor_apply:                           %w[基本契約約款の通り 契約書に準拠する 口頭及び文書による].sample,
+          site_agent_name:                            '現場代理人名',
+          site_agent_apply:                           %w[基本契約約款の通り 契約書に準拠する 口頭及び文書による].sample,
+          supervising_engineer_name:                  '監督技術者･主任技術者名',
+          supervising_engineer_check:                 [0, 1].sample,
+          supervising_engineer_assistant_name:        '監督技術者補佐名',
+          professional_engineer_name:                 '専門技術者名',
+          professional_engineer_construction_details: '専門技術者(担当工事内容)',
+          safety_officer_name:                        '安全衛生担当役名',
+          safety_officer_position_name:               '安全衛生担当役員(役職名)',
+          general_safety_manager_name:                '総括安全衛生管理者名',
+          general_safety_manager_position_name:       '総括安全衛生管理(役職名)',
+          safety_manager_name:                        '安全管理者名',
+          safety_manager_position_name:               '安全管理者(役職名)',
+          health_manager_name:                        '衛生管理者名',
+          health_manager_position_name:               '衛生管理者(役職名)',
+          health_and_safety_promoter_name:            '安全衛生推進者名',
+          health_and_safety_promoter_position_name:   '安全衛生推進者(役職名)',
+          confirm_name:                               '確認欄(氏名)',
+          accept_confirm_date:                        Date.yesterday,
+          subcontractor_name:                         '下請会社'
+          # =============================================
+        )
+      else
+        @order = current_business.orders.new
+      end
     end
 
     def create

--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -14,35 +14,37 @@ module Users
     end
 
     def edit
-      # テスト用デフォルト値 ==========================
-      if @request_order.construction_name.nil?
-        @request_order.tap do |r|
-          r.construction_name =                  'テスト工事名'
-          r.construction_details =               'テスト工事内容'
-          r.start_date =                         '2022-02-01'
-          r.end_date =                           '2022-02-28'
-          r.contract_date =                      '2022-01-01'
-          r.supervisor_name =                    'テスト監督員名'
-          r.supervisor_apply =                   'テスト申出方法'
-          r.professional_engineer_name =         'テスト専門技術者名'
-          r.professional_engineer_details =      'テスト担当工事内容'
-          r.professional_construction =          0
-          r.construction_manager_name =          'テスト工事担当責任者名'
-          r.construction_manager_position_name = 'テスト工事担当責任者役職名'
-          r.site_agent_name =                    'テスト現場代理人名'
-          r.site_agent_apply =                   'テスト現場申出方法'
-          r.lead_engineer_name =                 'テスト主任技術者名'
-          r.lead_engineer_check =                0
-          r.work_chief_name =                    'テスト作業主任者名'
-          r.work_conductor_name =                'テスト作業指揮者名'
-          r.safety_officer_name =                'テスト安全衛生担当責任者名'
-          r.safety_manager_name =                'テスト安全衛生責任者名'
-          r.safety_promoter_name =               'テスト安全推進者名'
-          r.foreman_name =                       'テスト職長名'
-          r.registered_core_engineer_name =      'テスト登録基幹技能者名'
+      if Rails.env.development?
+        # テスト用デフォルト値 ==========================
+        if @request_order.construction_name.nil?
+          @request_order.tap do |r|
+            r.construction_name =                  'テスト工事名'
+            r.construction_details =               'テスト工事内容'
+            r.start_date =                         '2022-02-01'
+            r.end_date =                           '2022-02-28'
+            r.contract_date =                      '2022-01-01'
+            r.supervisor_name =                    'テスト監督員名'
+            r.supervisor_apply =                   'テスト申出方法'
+            r.professional_engineer_name =         'テスト専門技術者名'
+            r.professional_engineer_details =      'テスト担当工事内容'
+            r.professional_construction =          0
+            r.construction_manager_name =          'テスト工事担当責任者名'
+            r.construction_manager_position_name = 'テスト工事担当責任者役職名'
+            r.site_agent_name =                    'テスト現場代理人名'
+            r.site_agent_apply =                   'テスト現場申出方法'
+            r.lead_engineer_name =                 'テスト主任技術者名'
+            r.lead_engineer_check =                0
+            r.work_chief_name =                    'テスト作業主任者名'
+            r.work_conductor_name =                'テスト作業指揮者名'
+            r.safety_officer_name =                'テスト安全衛生担当責任者名'
+            r.safety_manager_name =                'テスト安全衛生責任者名'
+            r.safety_promoter_name =               'テスト安全推進者名'
+            r.foreman_name =                       'テスト職長名'
+            r.registered_core_engineer_name =      'テスト登録基幹技能者名'
+          end
         end
+        # =============================================
       end
-      # =============================================
     end
 
     def update

--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -14,37 +14,35 @@ module Users
     end
 
     def edit
-      if Rails.env.development?
-        # テスト用デフォルト値 ==========================
-        if @request_order.construction_name.nil?
-          @request_order.tap do |r|
-            r.construction_name =                  'テスト工事名'
-            r.construction_details =               'テスト工事内容'
-            r.start_date =                         '2022-02-01'
-            r.end_date =                           '2022-02-28'
-            r.contract_date =                      '2022-01-01'
-            r.supervisor_name =                    'テスト監督員名'
-            r.supervisor_apply =                   'テスト申出方法'
-            r.professional_engineer_name =         'テスト専門技術者名'
-            r.professional_engineer_details =      'テスト担当工事内容'
-            r.professional_construction =          0
-            r.construction_manager_name =          'テスト工事担当責任者名'
-            r.construction_manager_position_name = 'テスト工事担当責任者役職名'
-            r.site_agent_name =                    'テスト現場代理人名'
-            r.site_agent_apply =                   'テスト現場申出方法'
-            r.lead_engineer_name =                 'テスト主任技術者名'
-            r.lead_engineer_check =                0
-            r.work_chief_name =                    'テスト作業主任者名'
-            r.work_conductor_name =                'テスト作業指揮者名'
-            r.safety_officer_name =                'テスト安全衛生担当責任者名'
-            r.safety_manager_name =                'テスト安全衛生責任者名'
-            r.safety_promoter_name =               'テスト安全推進者名'
-            r.foreman_name =                       'テスト職長名'
-            r.registered_core_engineer_name =      'テスト登録基幹技能者名'
-          end
+      # テスト用デフォルト値 ==========================
+      if Rails.env.development? && @request_order.construction_name.nil?
+        @request_order.tap do |r|
+          r.construction_name =                  'テスト工事名'
+          r.construction_details =               'テスト工事内容'
+          r.start_date =                         '2022-02-01'
+          r.end_date =                           '2022-02-28'
+          r.contract_date =                      '2022-01-01'
+          r.supervisor_name =                    'テスト監督員名'
+          r.supervisor_apply =                   'テスト申出方法'
+          r.professional_engineer_name =         'テスト専門技術者名'
+          r.professional_engineer_details =      'テスト担当工事内容'
+          r.professional_construction =          0
+          r.construction_manager_name =          'テスト工事担当責任者名'
+          r.construction_manager_position_name = 'テスト工事担当責任者役職名'
+          r.site_agent_name =                    'テスト現場代理人名'
+          r.site_agent_apply =                   'テスト現場申出方法'
+          r.lead_engineer_name =                 'テスト主任技術者名'
+          r.lead_engineer_check =                0
+          r.work_chief_name =                    'テスト作業主任者名'
+          r.work_conductor_name =                'テスト作業指揮者名'
+          r.safety_officer_name =                'テスト安全衛生担当責任者名'
+          r.safety_manager_name =                'テスト安全衛生責任者名'
+          r.safety_promoter_name =               'テスト安全推進者名'
+          r.foreman_name =                       'テスト職長名'
+          r.registered_core_engineer_name =      'テスト登録基幹技能者名'
         end
-        # =============================================
       end
+      # =============================================
     end
 
     def update

--- a/app/controllers/users/solvents_controller.rb
+++ b/app/controllers/users/solvents_controller.rb
@@ -7,14 +7,18 @@ module Users
     end
 
     def new
-      @solvent = current_business.solvents.new(
-        # テスト用デフォルト値 =====================
-        name:           'テスト塗料液　硬化剤',
-        maker:          'テスト化学工業',
-        classification: 'エポキシ塗料',
-        ingredients:    'アシン類'
-        # =======================================
-      )
+      if Rails.env.development?
+        @solvent = current_business.solvents.new(
+          # テスト用デフォルト値 =====================
+          name:           'テスト塗料液　硬化剤',
+          maker:          'テスト化学工業',
+          classification: 'エポキシ塗料',
+          ingredients:    'アシン類'
+          # =======================================
+        )
+      else
+        @solvent = current_business.solvents.new
+      end
     end
 
     def create

--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -73,6 +73,12 @@ module Users
         )
       else
         @worker = current_business.workers.new
+        @worker.worker_licenses.build
+        @worker.worker_skill_trainings.build
+        @worker.worker_special_educations.build
+        worker_medical = @worker.build_worker_medical
+        worker_medical.worker_exams.build
+        @worker.build_worker_insurance
       end
     end
 

--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -7,69 +7,73 @@ module Users
     end
 
     def new
-      @worker = current_business.workers.new(
-        # テスト用デフォルト値 ==========================
-        name:                          'サンプル作業員',
-        name_kana:                     'サンプルサギョウイン',
-        country:                       '日本',
-        my_address:                    '東京都港区1-1',
-        my_phone_number:               '01234567898',
-        family_address:                '埼玉県三郷市1-1',
-        family_phone_number:           '09876543210',
-        birth_day_on:                  '2000-01-28',
-        abo_blood_type:                0,
-        rh_blood_type:                 0,
-        job_type:                      0,
-        job_title:                     '主任',
-        hiring_on:                     '2022-01-28',
-        experience_term_before_hiring: 10,
-        blank_term:                    3,
-        carrier_up_id:                 '1'
-        # ============================================
-      )
-      @worker.worker_licenses.build(
-        # テスト用デフォルト値 ==========================
-        got_on:     '2022-01-01',
-        license_id: 1
-        # ============================================
-      )
-      @worker.worker_skill_trainings.build(
-        # テスト用デフォルト値 ==========================
-        got_on:            '2022-02-01',
-        skill_training_id: 2
-        # ============================================
-      )
-      @worker.worker_special_educations.build(
-        # テスト用デフォルト値 ==========================
-        got_on:               '2022-03-01',
-        special_education_id: 3
-        # ============================================
-      )
-      worker_medical = @worker.build_worker_medical(
-        # テスト用デフォルト値 ==========================
-        med_exam_on:         '2022-03-01',
-        max_blood_pressure:  120,
-        min_blood_pressure:  70,
-        special_med_exam_on: '2022-03-01'
-        # ============================================
-      )
-      worker_medical.worker_exams.build(
-        # テスト用デフォルト値 ==========================
-        special_med_exam_id: 4,
-        got_on:              '2022-03-01'
-        # ============================================
-      )
-      @worker.build_worker_insurance(
-        # テスト用デフォルト値 ==========================
-        health_insurance_type:         :health_insurance_association,
-        health_insurance_name:         'サンプル健康保険',
-        pension_insurance_type:        :welfare,
-        employment_insurance_type:     :insured,
-        employment_insurance_number:   '0000',
-        severance_pay_mutual_aid_type: :kentaikyo,
-        severance_pay_mutual_aid_name: 'テスト共済制度'
-        # ============================================
-      )
+      if Rails.env.development?
+        @worker = current_business.workers.new(
+          # テスト用デフォルト値 ==========================
+          name:                          'サンプル作業員',
+          name_kana:                     'サンプルサギョウイン',
+          country:                       '日本',
+          my_address:                    '東京都港区1-1',
+          my_phone_number:               '01234567898',
+          family_address:                '埼玉県三郷市1-1',
+          family_phone_number:           '09876543210',
+          birth_day_on:                  '2000-01-28',
+          abo_blood_type:                0,
+          rh_blood_type:                 0,
+          job_type:                      0,
+          job_title:                     '主任',
+          hiring_on:                     '2022-01-28',
+          experience_term_before_hiring: 10,
+          blank_term:                    3,
+          carrier_up_id:                 '1'
+          # ============================================
+        )
+        @worker.worker_licenses.build(
+          # テスト用デフォルト値 ==========================
+          got_on:     '2022-01-01',
+          license_id: 1
+          # ============================================
+        )
+        @worker.worker_skill_trainings.build(
+          # テスト用デフォルト値 ==========================
+          got_on:            '2022-02-01',
+          skill_training_id: 2
+          # ============================================
+        )
+        @worker.worker_special_educations.build(
+          # テスト用デフォルト値 ==========================
+          got_on:               '2022-03-01',
+          special_education_id: 3
+          # ============================================
+        )
+        worker_medical = @worker.build_worker_medical(
+          # テスト用デフォルト値 ==========================
+          med_exam_on:         '2022-03-01',
+          max_blood_pressure:  120,
+          min_blood_pressure:  70,
+          special_med_exam_on: '2022-03-01'
+          # ============================================
+        )
+        worker_medical.worker_exams.build(
+          # テスト用デフォルト値 ==========================
+          special_med_exam_id: 4,
+          got_on:              '2022-03-01'
+          # ============================================
+        )
+        @worker.build_worker_insurance(
+          # テスト用デフォルト値 ==========================
+          health_insurance_type:         :health_insurance_association,
+          health_insurance_name:         'サンプル健康保険',
+          pension_insurance_type:        :welfare,
+          employment_insurance_type:     :insured,
+          employment_insurance_number:   '0000',
+          severance_pay_mutual_aid_type: :kentaikyo,
+          severance_pay_mutual_aid_name: 'テスト共済制度'
+          # ============================================
+        )
+      else
+        @worker = current_business.workers.new
+      end
     end
 
     def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :validatable
-    # :confirmable
+  # :confirmable
 
   has_many :articles, dependent: :destroy
   has_many :news_users, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :validatable,
-    :confirmable
+    :recoverable, :rememberable, :validatable
+    # :confirmable
 
   has_many :articles, dependent: :destroy
   has_many :news_users, dependent: :destroy

--- a/spec/system/businesses_spec.rb
+++ b/spec/system/businesses_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Businesses', type: :system do
 
   describe '事業所関連' do
     before(:each) do
-      user.skip_confirmation!
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # user.skip_confirmation!
       user.save!
       visit new_user_session_path
       fill_in 'user[email]', with: user.email

--- a/spec/system/cars_spec.rb
+++ b/spec/system/cars_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'Cars', type: :system do
 
   describe '車両関連' do
     before(:each) do
-      user.skip_confirmation!
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # user.skip_confirmation!
       user.save!
       business.save!
       visit new_user_session_path

--- a/spec/system/documents_spec.rb
+++ b/spec/system/documents_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'Documnents', type: :system do
 
   describe '書類関連' do
     before(:each) do
-      user.skip_confirmation!
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # user.skip_confirmation!
       user.save!
       business.save!
       visit new_user_session_path

--- a/spec/system/news_spec.rb
+++ b/spec/system/news_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'News', type: :system do
   let!(:news_b) { create(:news, title: 'お知らせ-B', content: 'これはお知らせ-Bの内容です', status: 'published', delivered_at: DateTime.now.yesterday, uuid: SecureRandom.uuid) }
 
   before(:each) do
-    user.skip_confirmation! # ユーザー作成時のメールによる認証をスキップできる
+    # ステージングにて一時的にメール認証スキップ中の為下記コメント
+    # user.skip_confirmation! # ユーザー作成時のメールによる認証をスキップできる
     user.save!
   end
 

--- a/spec/system/orders_spec.rb
+++ b/spec/system/orders_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Orders', type: :system do
 
   describe '発注関連' do
     before(:each) do
-      user.skip_confirmation!
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # user.skip_confirmation!
       user.save!
       business.save!
       visit new_user_session_path

--- a/spec/system/request_orders_spec.rb
+++ b/spec/system/request_orders_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'RequestOrders', type: :system do
 
   describe '発注依頼関連' do
     before(:each) do
-      user.skip_confirmation!
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # user.skip_confirmation!
       user.save!
       business.save!
       visit new_user_session_path

--- a/spec/system/solvents_spec.rb
+++ b/spec/system/solvents_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'Solvents', type: :system do
 
   describe '有機溶剤関連' do
     before(:each) do
-      user.skip_confirmation!
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # user.skip_confirmation!
       user.save!
       business.save!
       visit new_user_session_path

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'Users', type: :system do
       it 'ログイン画面を表示' do
         expect(page).to have_content('ログイン')
         expect(page).to have_content('パスワードを忘れましたか？')
-        expect(page).to have_content('認証メールの再送信')
+        # ステージングにて一時的にメール認証スキップ中の為下記コメント
+        # expect(page).to have_content('認証メールの再送信')
       end
     end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe 'Users', type: :system do
   let(:general_user) { build(:user, role: 'general', admin_user_id: user_a.id) }
 
   before(:each) do
-    user_a.skip_confirmation!
+    # ステージングにて一時的にメール認証スキップ中の為下記コメント
+    # user_a.skip_confirmation!
     user_a.save!
-    user_b.skip_confirmation!
+    # ステージングにて一時的にメール認証スキップ中の為下記コメント
+    # user_b.skip_confirmation!
     user_b.save!
     visit new_user_session_path
   end
@@ -70,7 +72,8 @@ RSpec.describe 'Users', type: :system do
 
       context 'generalユーザーログインの場合' do
         it 'ログイン後ダッシュボードを表示' do
-          general_user.skip_confirmation!
+          # ステージングにて一時的にメール認証スキップ中の為下記コメント
+          # general_user.skip_confirmation!
           general_user.save!
           fill_in 'user[email]', with: general_user.email
           fill_in 'user[password]', with: general_user.password
@@ -84,7 +87,8 @@ RSpec.describe 'Users', type: :system do
 
   describe 'その他ユーザーCRUD' do
     before(:each) do
-      user_a.skip_confirmation!
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # user_a.skip_confirmation!
       user_a.save!
       # 事業所登録
       business_a.save!

--- a/spec/system/workers_spec.rb
+++ b/spec/system/workers_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Workers', type: :system do
   let(:worker_medical) { create(:worker_medical, worker: worker) }
 
   before(:each) do
-    user.skip_confirmation!
+    # ステージングにて一時的にメール認証スキップ中の為下記コメント
+    # user.skip_confirmation!
     user.save!
     business.save!
     sign_in(user)


### PR DESCRIPTION
### 概要
ステージング環境にてsignup後のメール認証を外す

### タスク
- [x] なし
- [ ] あり

### 実装内容・手法
１、User.rbのdeviseの記述から、confirmableのオプションを外す
　→ステージング環境・ローカル環境共にsignup後にメール認証無しにログイン出来るはずです
２、各コントローラのnewアクションにてデフォルト値を設定していた箇所に、railsの環境ごとの条件分岐を行いました
　→ローカル環境…new時にデフォルト値が入る
　→その他環境…new時に手入力
３、上記の変更に伴い、rspecにてメール認証部分のテストをコメントアウト
