### PR TITLE
発注、発注依頼の現場情報入力フォームバリデーション追加(平野)

### DIFF
--- a/app/controllers/users/special_vehicles_controller.rb
+++ b/app/controllers/users/special_vehicles_controller.rb
@@ -1,0 +1,74 @@
+module Users
+  class SpecialVehiclesController < Users::Base
+    before_action :set_special_vehicle, except: %i[index new create]
+
+    def index
+      @special_vehicles = current_business.special_vehicles
+    end
+
+    def show; end
+
+    def new
+      @special_vehicle = current_business.special_vehicles.new(
+        # テスト用デフォルト値 ==========================
+        name:                    'コンテナ用セミトレーラ1',
+        maker:                   '三菱',
+        standards_performance:   '幅2.5M',
+        year_manufactured:       Date.today.ago(3.years),
+        control_number:          SecureRandom.hex(5),
+        check_exp_date_year:     Date.today.since(2.years),
+        check_exp_date_month:    Date.today.since(2.years).since(3.month),
+        check_exp_date_specific: Date.today.since(2.years).since(6.month),
+        check_exp_date_machine:  Date.today.since(3.years),
+        check_exp_date_car:      Date.today.since(5.years),
+        personal_insurance:      1,
+        objective_insurance:     2,
+        passenger_insurance:     3,
+        other_insurance:         4,
+        exp_date_insurance:      Date.today.since(5.years)
+        # ============================================
+      )
+    end
+
+    def create
+      @special_vehicle = current_business.special_vehicles.build(special_vehicle_params)
+      if @special_vehicle.save
+        redirect_to users_special_vehicle_url(@special_vehicle)
+      else
+        render :new
+      end
+    end
+
+    def edit; end
+
+    def update
+      if @special_vehicle.update(special_vehicle_params)
+        flash[:success] = '更新しました'
+        redirect_to users_special_vehicle_url
+      else
+        render 'edit'
+      end
+    end
+
+    def destroy
+      @special_vehicle.destroy!
+      flash[:danger] = "#{@special_vehicle.name}を削除しました"
+      redirect_to users_special_vehicles_url
+    end
+
+    private
+
+    def set_special_vehicle
+      @special_vehicle = current_business.special_vehicles.find_by(uuid: params[:uuid])
+    end
+
+    def special_vehicle_params
+      params.require(:special_vehicle).permit(:name, :maker, :standards_performance,
+        :year_manufactured, :control_number, :check_exp_date_year, :check_exp_date_month,
+        :check_exp_date_specific, :check_exp_date_machine, :check_exp_date_car,
+        :personal_insurance, :objective_insurance, :passenger_insurance, :other_insurance,
+        :exp_date_insurance
+      )
+    end
+  end
+end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -1,6 +1,7 @@
 class Business < ApplicationRecord
   belongs_to :user
   has_many :cars, dependent: :destroy
+  has_many :special_vehicles, dependent: :destroy
   has_many :documents, dependent: :destroy
   has_many :orders, dependent: :destroy
   has_many :request_orders, dependent: :destroy

--- a/app/models/special_vehicle.rb
+++ b/app/models/special_vehicle.rb
@@ -1,0 +1,52 @@
+class SpecialVehicle < ApplicationRecord
+  belongs_to :business
+
+  before_create -> { self.uuid = SecureRandom.uuid }
+
+  validates :name, presence: true
+  validates :maker, presence: true
+  validates :standards_performance, presence: true
+  validates :year_manufactured, presence: true
+  validates :control_number, presence: true
+  validates :check_exp_date_year, presence: true
+  validates :check_exp_date_month, presence: true
+  validates :check_exp_date_specific, presence: true
+  validates :check_exp_date_machine, presence: true
+  validates :check_exp_date_car, presence: true
+
+  enum personal_insurance: {
+    無制限: 0,
+    "1,000": 1, "2,000": 2, "3,000": 3, "4,000": 4, "5,000": 5,
+    "6,000": 6, "7,000": 7, "8,000": 8, "9,000": 9, "10,000": 10,
+    "11,000": 11, "12,000": 12, "13,000": 13, "14,000": 14, "15,000": 15,
+    "16,000": 16, "17,000": 17, "18,000": 18, "19,000": 19, "20,000": 20
+  }, _prefix: true
+
+  enum objective_insurance: {
+    無制限: 0,
+    "1,000": 1, "2,000": 2, "3,000": 3, "4,000": 4, "5,000": 5,
+    "6,000": 6, "7,000": 7, "8,000": 8, "9,000": 9, "10,000": 10,
+    "11,000": 11, "12,000": 12, "13,000": 13, "14,000": 14, "15,000": 15,
+    "16,000": 16, "17,000": 17, "18,000": 18, "19,000": 19, "20,000": 20
+  }, _prefix: true
+
+  enum passenger_insurance: {
+    無制限: 0,
+    "1,000": 1, "2,000": 2, "3,000": 3, "4,000": 4, "5,000": 5,
+    "6,000": 6, "7,000": 7, "8,000": 8, "9,000": 9, "10,000": 10,
+    "11,000": 11, "12,000": 12, "13,000": 13, "14,000": 14, "15,000": 15,
+    "16,000": 16, "17,000": 17, "18,000": 18, "19,000": 19, "20,000": 20
+  }, _prefix: true
+
+  enum other_insurance: {
+    無制限: 0,
+    "1,000": 1, "2,000": 2, "3,000": 3, "4,000": 4, "5,000": 5,
+    "6,000": 6, "7,000": 7, "8,000": 8, "9,000": 9, "10,000": 10,
+    "11,000": 11, "12,000": 12, "13,000": 13, "14,000": 14, "15,000": 15,
+    "16,000": 16, "17,000": 17, "18,000": 18, "19,000": 19, "20,000": 20
+  }, _prefix: true
+
+  def to_param
+    uuid
+  end
+end

--- a/app/views/users/dash_boards/index.html.erb
+++ b/app/views/users/dash_boards/index.html.erb
@@ -44,6 +44,11 @@
           <%= link_to "有機溶剤", users_solvents_path, class: "btn btn-lg byn-block mt-5 mb-5", style: 'font-size:40px;' %>
         </div>
       </div>
+      <div class="col-lg-6">
+        <div class="card pt-5 pb-5">
+          <%= link_to "特殊車両", users_special_vehicles_path, class: "btn btn-lg byn-block mt-5 mb-5", style: 'font-size:40px;' %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/users/orders/_form.html.erb
+++ b/app/views/users/orders/_form.html.erb
@@ -1,7 +1,8 @@
 <%= render 'shared/error_massages', object: f.object %>
+
 <% if controller.action_name == 'edit' %>
   <%= f.label :status %>
-  <span class="text-danger">※必須</span>
+  <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
   <%= f.select :status, Order.statuses_i18n.invert, {}, { class: "form-control" } %>
 <% end %>
 <br>
@@ -13,11 +14,11 @@
     <%= f.text_field :site_career_up_id, class: "form-control", placeholder: Order.human_attribute_name(:site_career_up_id) %>
     <br>
     <%= f.label :site_name %> <!-- 事業所名(現場名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :site_name, class: "form-control", placeholder: Order.human_attribute_name(:site_name) %>
     <br>
     <%= f.label :site_address %> <!-- 施工場所(住所) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :site_address, class: "form-control", placeholder: Order.human_attribute_name(:site_address) %>
     <br>
   </div>
@@ -27,28 +28,28 @@
 <div class="list-group">
   <div class="list-group-item">
     <%= f.label :order_name %>
-    <span class="text-danger">※必須</span> <!-- 発注者(会社名or氏名) -->
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span> <!-- 発注者(会社名or氏名) -->
     <%= f.text_field :order_name, class: "form-control", placeholder: Order.human_attribute_name(:order_name) %>
     <br>
     <%= f.label :order_post_code %> <!-- 郵便番号 -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :order_post_code, class: "form-control", placeholder: Order.human_attribute_name(:hyphen_is_unnecessary) %>
     <br>
     <%= f.label :order_address %> <!-- 住所 -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :order_address, class: "form-control", placeholder: Order.human_attribute_name(:order_address) %>
     <br>
   </div>
   <div class="list-group-item">
     <%= f.label :order_supervisor_name %> <!-- 監督員(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :order_supervisor_name, class: "form-control", placeholder: Order.human_attribute_name(:order_supervisor_name) %>
     <br>
     <%= f.label :order_supervisor_company %> <!-- 監督員(所属会社) -->
     <%= f.text_field :order_supervisor_company, class: "form-control", placeholder: Order.human_attribute_name(:order_supervisor_company) %>
     <br>
     <%= f.label :order_supervisor_apply %> <!-- 監督員(権限及び意見の申出方法) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :order_supervisor_apply,
                   (@current_business.orders.map { |order|order.order_supervisor_apply }).uniq,
                   { include_blank: true },
@@ -61,34 +62,34 @@
 <div class="list-group">
   <div class="list-group-item">
     <%= f.label :construction_name %> <!-- 工事名 -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :construction_name, class: "form-control", placeholder: Order.human_attribute_name(:construction_name) %>
     <br>
     <%= f.label :construction_details %> <!-- 工事内容 -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :construction_details, class: "form-control", placeholder: Order.human_attribute_name(:construction_details) %>
     <br>
     <div class="row">
       <div class="col-md-3">
         <%= f.label :start_date %> <!-- 工期(自) -->
-        <span class="text-danger">※必須</span>
+        <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
         <%= f.date_field :start_date, class: "form-control" %>
       </div>
       <div class="col-md-3">
         <%= f.label :end_date %> <!-- 工期(至) -->
-        <span class="text-danger">※必須</span>
+        <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
         <%= f.date_field :end_date, class: "form-control" %>
       </div>
     </div><br>
     <div class="row">
       <div class="col-md-3">
         <%= f.label :contract_date %> <!-- 契約日 -->
-        <span class="text-danger">※必須</span>
+        <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
         <%= f.date_field :contract_date, class: "form-control" %>
       </div>
     </div><br>
     <%= f.label :submission_destination %> <!-- 提出先及び担当者(部署･氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :submission_destination,
                   (@business_workers_name + [@order.submission_destination]).uniq,
                   {},
@@ -98,7 +99,7 @@
   </div>
   <div class="list-group-item">
     <%= f.label :general_safety_responsible_person_name %> <!-- 統括安全衛生責任者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :general_safety_responsible_person_name,
                   (@business_workers_name + [@order.general_safety_responsible_person_name]).uniq,
                   { include_blank: true },
@@ -108,7 +109,7 @@
   </div>
   <div class="list-group-item">
     <%= f.label :vice_president_name %> <!-- 副会長(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :vice_president_name,
                   (@business_workers_name + [@order.vice_president_name]).uniq,
                   { include_blank: true },
@@ -116,13 +117,13 @@
     %>
     <br><br>
     <%= f.label :vice_president_company_name %> <!-- 副会長(会社名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :vice_president_company_name, class: "form-control", placeholder: Order.human_attribute_name(:vice_president_company_name) %>
     <br>
   </div>
   <div class="list-group-item">
     <%= f.label :secretary_name %> <!-- 書記(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :secretary_name,
                   (@business_workers_name + [@order.secretary_name]).uniq,
                   { include_blank: true },
@@ -130,7 +131,7 @@
     %>
     <br><br>
     <%= f.label :health_and_safety_manager_name %> <!-- 元方安全衛生管理者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :health_and_safety_manager_name,
                   (@business_workers_name + [@order.health_and_safety_manager_name]).uniq,
                   { include_blank: true },
@@ -138,7 +139,7 @@
     %>
     <br><br>
     <%= f.label :general_safety_agent_name %> <!-- 統括安全衛生責任者代行者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :general_safety_agent_name,
                   (@business_workers_name + [@order.general_safety_agent_name]).uniq,
                   { include_blank: true },
@@ -147,33 +148,33 @@
   </div>
   <div class="list-group-item">
     <%= f.label :supervisor_name %> <!-- 監督員(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :supervisor_name,
                   (@business_workers_name + [@order.supervisor_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :supervisor_apply %> <!-- 監督員(権限及び意見の申出方法) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :supervisor_apply, class: "form-control", placeholder: Order.human_attribute_name(:supervisor_apply) %>
     <br>
   </div>
   <div class="list-group-item">
     <%= f.label :site_agent_name %> <!-- 現場代理人(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :site_agent_name,
                   (@business_workers_name + [@order.site_agent_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :site_agent_apply %> <!-- 現場代理人(権限及び意見の申出方法) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :site_agent_apply, class: "form-control", placeholder: Order.human_attribute_name(:site_agent_apply) %>
     <br>
   </div>
   <div class="list-group-item">
     <%= f.label :supervising_engineer_name %> <!-- 監督技術者･主任技術者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :supervising_engineer_name,
                   (@business_workers_name + [@order.supervising_engineer_name]).uniq,
                   { include_blank: true },
@@ -202,14 +203,14 @@
   </div>
   <div class="list-group-item">
     <%= f.label :safety_officer_name %> <!-- 安全衛生担当役員(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :safety_officer_name,
                   (@business_workers_name + [@order.safety_officer_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :safety_officer_position_name %> <!-- 安全衛生担当役員(役職名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :safety_officer_position_name, class: "form-control", placeholder: Order.human_attribute_name(:safety_officer_position_name) %>
     <br>
   </div>
@@ -259,7 +260,7 @@
   </div>
   <div class="list-group-item">
     <%= f.label :confirm_name %> <!-- 確認欄(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :confirm_name,
                   (@business_workers_name + [@order.confirm_name]).uniq,
                   { include_blank: true },
@@ -272,7 +273,7 @@
       </div>
     </div><br>
     <%= f.label :subcontractor_name %> <!-- 下請会社名 -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :subcontractor_name,
                   (@current_business.orders.map { |order|order.subcontractor_name }).uniq,
                   { include_blank: true },
@@ -282,6 +283,7 @@
 </div><br>
 
 <script>
+  // 入力フォームのバリデーション
   $(function(){
     let methods = {
       postcode: function(value, element){
@@ -293,10 +295,10 @@
     });
     $(".order-form-validation").validate({
       rules: {
-        "order[status]": {
+        "order[site_name]": {
           required: true
         },
-        "order[site_name]": {
+        "order[site_address]": {
           required: true
         },
         "order[order_name]": {
@@ -309,13 +311,79 @@
         "order[order_address]": {
           required: true
         },
+        "order[order_supervisor_name]": {
+          required: true
+        },
+        "order[order_supervisor_apply]": {
+          required: true
+        },
+        "order[construction_name]": {
+          required: true
+        },
+        "order[construction_details]": {
+          required: true
+        },
+        "order[start_date]": {
+          required: true
+        },
+        "order[end_date]": {
+          required: true
+        },
+        "order[contract_date]": {
+          required: true
+        },
+        "order[submission_destination]": {
+          required: true
+        },
+        "order[general_safety_responsible_person_name]": {
+          required: true
+        },
+        "order[vice_president_name]": {
+          required: true
+        },
+        "order[vice_president_company_name]": {
+          required: true
+        },
+        "order[secretary_name]": {
+          required: true
+        },
+        "order[health_and_safety_manager_name]": {
+          required: true
+        },
+        "order[supervisor_name]": {
+          required: true
+        },
+        "order[supervisor_apply]": {
+          required: true
+        },
+        "order[site_agent_name]": {
+          required: true
+        },
+        "order[site_agent_apply]": {
+          required: true
+        },
+        "order[supervising_engineer_name]": {
+          required: true
+        },
+        "order[safety_officer_name]": {
+          required: true
+        },
+        "order[safety_officer_position_name]": {
+          required: true
+        },
+        "order[confirm_name]": {
+          required: true
+        },
+        "order[subcontractor_name]": {
+          required: true
+        },
       },
       messages: {
-        "order[status]": {
-          required: "どれか一つを選択してください。"
-        },
         "order[site_name]": {
           required: "現場名を入力してください。"
+        },
+        "order[site_address]": {
+          required: "施工場所の住所を入力してください。"
         },
         "order[order_name]": {
           required: "発注者名を入力してください。"
@@ -327,7 +395,78 @@
         "order[order_address]": {
           required: "発注者住所を入力してください。"
         },
+        "order[order_supervisor_name]": {
+          required: "監督員名を入力してください。"
+        },
+        "order[order_supervisor_apply]": {
+          required: "権限及び意見の申出方法を入力してください。"
+        },
+        "order[construction_name]": {
+          required: "工事名を入力してください。"
+        },
+        "order[construction_details]": {
+          required: "工事内容を入力してください。"
+        },
+        "order[start_date]": {
+          required: "工期(自)を入力してください。"
+        },
+        "order[end_date]": {
+          required: "工期(至)を入力してください。"
+        },
+        "order[contract_date]": {
+          required: "契約日を入力してください。"
+        },
+        "order[submission_destination]": {
+          required: "提出先及び担当者を入力してください。"
+        },
+        "order[general_safety_responsible_person_name]": {
+          required: "統括安全衛生責任者名を入力してください。"
+        },
+        "order[vice_president_name]": {
+          required: "副会長名を入力してください。"
+        },
+        "order[vice_president_company_name]": {
+          required: "会社名を入力してください。"
+        },
+        "order[secretary_name]": {
+          required: "書記名を入力してください。"
+        },
+        "order[health_and_safety_manager_name]": {
+          required: "元方安全衛生管理者名を入力してください。"
+        },
+        "order[supervisor_name]": {
+          required: "監督員名を入力してください。"
+        },
+        "order[supervisor_apply]": {
+          required: "権限及び意見の申出方法を入力してください。"
+        },
+        "order[site_agent_name]": {
+          required: "現場代理人名を入力してください。"
+        },
+        "order[site_agent_apply]": {
+          required: "権限及び意見の申出方法を入力してください。"
+        },
+        "order[supervising_engineer_name]": {
+          required: "監督技術者･主任技術者名を入力してください。"
+        },
+        "order[safety_officer_name]": {
+          required: "安全衛生担当役員名を入力してください。"
+        },
+        "order[safety_officer_position_name]": {
+          required: "役職名を入力してください。"
+        },
+        "order[confirm_name]": {
+          required: "確認欄を入力してください。"
+        },
+        "order[subcontractor_name]": {
+          required: "下請会社名を入力してください。"
+        },
       },
+      errorClass: "input_form_error"
+    });
+    // 入力欄を変更したときにバリデーションを実行
+    $(".order-form-validation").change(function () {
+      $(this).valid();
     });
   });
 </script>

--- a/app/views/users/request_orders/_form.html.erb
+++ b/app/views/users/request_orders/_form.html.erb
@@ -4,41 +4,41 @@
 <div class="list-group">
   <div class="list-group-item">
     <%= f.label :construction_name %> <!-- 工事名 -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :construction_name, class: "form-control", placeholder: RequestOrder.human_attribute_name(:construction_name) %>
     <br>
     <%= f.label :construction_details %> <!-- 工事内容 -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :construction_details, class: "form-control", placeholder: RequestOrder.human_attribute_name(:construction_details) %>
     <br>
     <div class="row">
       <div class="col-md-3">
         <%= f.label :start_date %> <!-- 工期(自) -->
-        <span class="text-danger">※必須</span>
+        <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
         <%= f.date_field :start_date, class: "form-control" %>
       </div>
       <div class="col-md-3">
         <%= f.label :end_date %> <!-- 工期(至) -->
-        <span class="text-danger">※必須</span>
+        <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
         <%= f.date_field :end_date, class: "form-control" %>
       </div>
     </div><br>
     <div class="row">
       <div class="col-md-3">
         <%= f.label :contract_date %> <!-- 契約日 -->
-        <span class="text-danger">※必須</span>
+        <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
         <%= f.date_field :contract_date, class: "form-control" %>
       </div>
     </div><br>
     <%= f.label :supervisor_name %> <!-- 監督員(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :supervisor_name,
                   (@business_workers_name + [@request_order.supervisor_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :supervisor_apply %> <!-- 監督員(権限及び意見の申出方法) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :supervisor_apply, class: "form-control", placeholder: Order.human_attribute_name(:supervisor_apply) %>
     <%#= f.select :supervisor_apply,
                   (@current_business.request_orders.map { |request_order|request_order.supervisor_apply }).uniq,
@@ -52,7 +52,7 @@
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :professional_engineer_details %> <!-- 専門技術者(担当工事内容) -->
-    <%= f.text_field :professional_engineer_details, class: "form-control", placeholder: Order.human_attribute_name(:professional_engineer_details) %>
+    <%= f.text_field :professional_engineer_details, class: "form-control", placeholder: RequestOrder.human_attribute_name(:professional_engineer_details) %>
     <%#= f.select :professional_engineer_details,
                   (@current_business.request_orders.map { |request_order|request_order.professional_engineer_details }).uniq,
                   { include_blank: true },
@@ -62,25 +62,25 @@
     <%= f.select :professional_construction, RequestOrder.professional_constructions_i18n.invert, { prompt: true }, { class: "form-control" } %>
     <br>
     <%= f.label :construction_manager_name %> <!-- 工事担任責任者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :construction_manager_name,
                       (@business_workers_name + [@request_order.construction_manager_name]).uniq,
                       { include_blank: true },
                       { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :construction_manager_position_name %> <!-- 工事担任責任者(役職名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :construction_manager_position_name, class: "form-control", placeholder: RequestOrder.human_attribute_name(:construction_manager_position_name) %>
     <br>
     <%= f.label :site_agent_name %> <!-- 現場代理人(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :site_agent_name,
                   (@business_workers_name + [@request_order.site_agent_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :site_agent_apply %> <!-- 現場代理人(権限及び意見の申出方法) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :site_agent_apply, class: "form-control", placeholder: Order.human_attribute_name(:site_agent_apply) %>
     <%#= f.select :site_agent_apply,
                   (@current_business.request_orders.map { |request_order|request_order.site_agent_apply }).uniq,
@@ -88,25 +88,25 @@
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :lead_engineer_name %> <!-- 主任技術者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :lead_engineer_name,
                   (@business_workers_name + [@request_order.lead_engineer_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :lead_engineer_check %> <!-- 主任技術者(専任or非専任) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :lead_engineer_check, RequestOrder.lead_engineer_checks_i18n.invert, { prompt: true }, { class: "form-control" } %>
     <br>
     <%= f.label :work_chief_name %> <!-- 作業主任者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :work_chief_name,
                   (@business_workers_name + [@request_order.work_chief_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
-    <%= f.label :work_conductor_name %> <!-- 作業指揮者名(氏名) -->
-    <span class="text-danger">※必須</span>
+    <%= f.label :work_conductor_name %> <!-- 作業指揮者(氏名) -->
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :work_conductor_name,
                   (@business_workers_name + [@request_order.work_conductor_name]).uniq,
                   { include_blank: true },
@@ -114,28 +114,28 @@
     %>
     <br><br>
     <%= f.label :safety_officer_name %> <!-- 安全衛生担当責任者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :safety_officer_name,
                   (@business_workers_name + [@request_order.safety_officer_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :safety_manager_name %> <!-- 安全衛生責任者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :safety_manager_name,
                   (@business_workers_name + [@request_order.safety_manager_name]).uniq,
                   { include_blank: true },
                   { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :safety_promoter_name %> <!-- 安全推進者(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :safety_promoter_name,
                       (@business_workers_name + [@request_order.safety_promoter_name]).uniq,
                       { include_blank: true },
                       { class: "single-select", style: "width: 100%" }
     %><br><br>
     <%= f.label :foreman_name %> <!-- 職長(氏名) -->
-    <span class="text-danger">※必須</span>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :foreman_name,
                       (@business_workers_name + [@request_order.foreman_name]).uniq,
                       { include_blank: true },
@@ -149,3 +149,137 @@
     %><br><br>
   </div>
 </div><br>
+
+<script>
+  // 入力フォームのバリデーション
+  $(function(){
+    $.each(function(key){
+      $.validator.addMethod(key, this);
+    });
+    $(".order-form-validation").validate({
+      rules: {
+        "request_order[construction_name]": {
+          required: true
+        },
+        "request_order[construction_details]": {
+          required: true
+        },
+        "request_order[start_date]": {
+          required: true
+        },
+        "request_order[end_date]": {
+          required: true
+        },
+        "request_order[contract_date]": {
+          required: true
+        },
+        "request_order[supervisor_name]": {
+          required: true
+        },
+        "request_order[supervisor_apply]": {
+          required: true
+        },
+        "request_order[construction_manager_name]": {
+          required: true
+        },
+        "request_order[construction_manager_position_name]": {
+          required: true
+        },
+        "request_order[site_agent_name]": {
+          required: true
+        },
+        "request_order[site_agent_apply]": {
+          required: true
+        },
+        "request_order[lead_engineer_name]": {
+          required: true
+        },
+        "request_order[lead_engineer_check]": {
+          required: true
+        },
+        "request_order[work_chief_name]": {
+          required: true
+        },
+        "request_order[work_conductor_name]": {
+          required: true
+        },
+        "request_order[safety_officer_name]": {
+          required: true
+        },
+        "request_order[safety_manager_name]": {
+          required: true
+        },
+        "request_order[safety_promoter_name]": {
+          required: true
+        },
+        "request_order[foreman_name]": {
+          required: true
+        },
+      },
+      messages: {
+        "request_order[construction_name]": {
+          required: "工事名を入力してください。"
+        },
+        "request_order[construction_details]": {
+          required: "工事内容を入力してください。"
+        },
+        "request_order[start_date]": {
+          required: "工期(自)を入力してください。"
+        },
+        "request_order[end_date]": {
+          required: "工期(至)を入力してください。"
+        },
+        "request_order[contract_date]": {
+          required: "契約日を入力してください。"
+        },
+        "request_order[supervisor_name]": {
+          required: "監督員名を入力してください。"
+        },
+        "request_order[supervisor_apply]": {
+          required: "権限及び意見の申出方法を入力してください。"
+        },
+        "request_order[construction_manager_name]": {
+          required: "工事担任責任者名を入力してください。"
+        },
+        "request_order[construction_manager_position_name]": {
+          required: "工事担任責任者の役職名を入力してください。"
+        },
+        "request_order[site_agent_name]": {
+          required: "現場代理人名を入力してください。"
+        },
+        "request_order[site_agent_apply]": {
+          required: "権限及び意見の申出方法を入力してください。"
+        },
+        "request_order[lead_engineer_name]": {
+          required: "主任技術者名を入力してください。"
+        },
+        "request_order[lead_engineer_check]": {
+          required: "専任or非専任を選択してください。"
+        },
+        "request_order[work_chief_name]": {
+          required: "作業主任者名を入力してください。"
+        },
+        "request_order[work_conductor_name]": {
+          required: "作業指揮者名を入力してください。"
+        },
+        "request_order[safety_officer_name]": {
+          required: "安全衛生担当責任者名を入力してください。"
+        },
+        "request_order[safety_manager_name]": {
+          required: "安全衛生責任者名を入力してください。"
+        },
+        "request_order[safety_promoter_name]": {
+          required: "安全推進者名を入力してください。"
+        },
+        "request_order[foreman_name]": {
+          required: "職長名を入力してください。"
+        },
+      },
+      errorClass: "input_form_error"
+    });
+    // 入力欄を変更したときにバリデーションを実行
+    $(".order-form-validation").change(function () {
+      $(this).valid();
+    });
+  });
+</script>

--- a/app/views/users/special_vehicles/_form.html.erb
+++ b/app/views/users/special_vehicles/_form.html.erb
@@ -1,0 +1,137 @@
+<%= render 'shared/error_massages', object: f.object %>
+
+<%= f.label :name %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.text_field :name, class: "form-control", placeholder: SpecialVehicle.human_attribute_name(:name) %>
+<br>
+<%= f.label :maker %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.text_field :maker, class: "form-control", placeholder: SpecialVehicle.human_attribute_name(:maker) %>
+<br>
+<%= f.label :standards_performance %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.text_field :standards_performance, class: "form-control", placeholder: SpecialVehicle.human_attribute_name(:standards_performance) %>
+<br>
+<%= f.label :year_manufactured %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.date_field :year_manufactured, class: "form-control", placeholder: SpecialVehicle.human_attribute_name(:year_manufactured) %>
+<br>
+<%= f.label :control_number %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.text_field :control_number, class: "form-control", placeholder: SpecialVehicle.human_attribute_name(:control_number) %>
+<br>
+<%= f.label :check_exp_date_year %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.date_field :check_exp_date_year, class: "form-control" %>
+<br>
+<%= f.label :check_exp_date_month %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.date_field :check_exp_date_month, class: "form-control" %>
+<br>
+<%= f.label :check_exp_date_specific %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.date_field :check_exp_date_specific, class: "form-control" %>
+<br>
+<%= f.label :check_exp_date_machine %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.date_field :check_exp_date_machine, class: "form-control" %>
+<br>
+<%= f.label :check_exp_date_car %>
+<span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.date_field :check_exp_date_car, class: "form-control" %>
+<br>
+<%= f.label :personal_insurance %>
+<%= f.select :personal_insurance, SpecialVehicle.personal_insurances.keys.to_a, { prompt: true }, { class: "form-control" } %>
+<br>
+<%= f.label :objective_insurance %>
+<%= f.select :objective_insurance, SpecialVehicle.objective_insurances.keys.to_a, { prompt: true }, { class: "form-control" } %>
+<br>
+<%= f.label :passenger_insurance %>
+<%= f.select :passenger_insurance, SpecialVehicle.passenger_insurances.keys.to_a, { prompt: true }, { class: "form-control" } %>
+<br>
+<%= f.label :other_insurance %>
+<%= f.select :other_insurance, SpecialVehicle.other_insurances.keys.to_a, { prompt: true }, { class: "form-control" } %>
+<br>
+<%= f.label :exp_date_insurance %>
+<%= f.date_field :exp_date_insurance, class: "form-control" %>
+<br>
+
+<script>
+  $(function(){
+    $.each(function(key){
+      $.validator.addMethod(key, this);
+    });
+    $(".special-vehicle-form-validation").validate({
+      rules:{
+        "special_vehicle[name]": {
+          required: true
+        },
+        "special_vehicle[maker]": {
+          required: true
+        },
+        "special_vehicle[standards_performance]": {
+          required: true
+        },
+        "special_vehicle[year_manufactured]": {
+          required: true
+        },
+        "special_vehicle[control_number]": {
+          required: true
+        },
+        "special_vehicle[check_exp_date_year]": {
+          required: true
+        },
+        "special_vehicle[check_exp_date_month]": {
+          required: true
+        },
+        "special_vehicle[check_exp_date_specific]": {
+          required: true
+        },
+        "special_vehicle[check_exp_date_machine]": {
+          required: true
+        },
+        "special_vehicle[check_exp_date_car]": {
+          required: true
+        },
+        
+      },
+      messages:{
+        "special_vehicle[name]": {
+          required: "名称を入力してください。"
+        },
+        "special_vehicle[maker]": {
+          required: "メーカーを入力してください。"
+        },
+        "special_vehicle[standards_performance]": {
+          required: "規格・性能を入力してください。"
+        },
+        "special_vehicle[year_manufactured]": {
+          required: "製造年を入力または選択してください。"
+        },
+        "special_vehicle[control_number]": {
+          required: "管理番号（整理番号）を入力してください。"
+        },
+        "special_vehicle[check_exp_date_year]": {
+          required: "年月日を入力または選択してください。"
+        },
+        "special_vehicle[check_exp_date_month]": {
+          required: "年月日を入力または選択してください。"
+        },
+        "special_vehicle[check_exp_date_specific]": {
+          required: "年月日を入力または選択してください。"
+        },
+        "special_vehicle[check_exp_date_machine]": {
+          required: "年月日を入力または選択してください。"
+        },
+        "special_vehicle[check_exp_date_car]": {
+          required: "年月日を入力または選択してください。"
+        },
+      },
+      errorClass: "input_form_error"
+    });
+    // 入力欄を変更したときにバリデーションを実行
+    $(".special-vehicle-form-validation").change(function () {
+      $(this).valid();
+    });
+  });
+</script>

--- a/app/views/users/special_vehicles/edit.html.erb
+++ b/app/views/users/special_vehicles/edit.html.erb
@@ -1,0 +1,15 @@
+<% provide(:title, "特殊車両情報編集") %>
+<% provide(:btn_text, "更新") %>
+
+<div class="card">
+  <%= form_with model: @special_vehicle, url: users_special_vehicle_path, method: :patch, local: true, class: "special-vehicle-form-validation" do |f| %>
+    <div class="card-body">
+      <%= render partial: "form", locals: { f: f } %>
+    </div>
+    <div class="card-footer">
+      <%= f.submit yield(:btn_text), class: "btn btn-md btn-block btn-success" %>
+      <%= link_to "詳細画面へ", users_special_vehicle_path(@special_vehicle), class: "btn btn-md btn-block btn-default" %>
+      <%= link_to "一覧画面へ", users_special_vehicles_path, class: "btn btn-md btn-block btn-default" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/special_vehicles/index.html.erb
+++ b/app/views/users/special_vehicles/index.html.erb
@@ -1,0 +1,30 @@
+<% provide(:title,  "特殊車両情報一覧") %>
+
+<%= link_to "特殊車両情報新規作成画面へ", new_users_special_vehicle_path, class: "btn btn-lg btn-block btn-outline-primary" %>
+<br>
+<% if @special_vehicles.present? %>
+  <div class="card">
+    <div class="card-body table-responsive p-0">
+      <table class="table table-hover text-nowrap">
+        <thead>
+          <tr align="center">
+            <th><%= SpecialVehicle.human_attribute_name(:name) %></th>
+            <th><%= SpecialVehicle.human_attribute_name(:maker) %></th>
+            <th></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @special_vehicles.each do |special_vehicle| %>
+          <tr align="center">
+            <td><%= link_to special_vehicle.name, users_special_vehicle_path(special_vehicle) %></td>
+            <td><%= special_vehicle.maker %></td>
+            <td><%= link_to "編集", edit_users_special_vehicle_path(special_vehicle), class: "btn btn-md btn-success" %></td>
+            <td><%= link_to "削除", users_special_vehicle_path(special_vehicle), method: :delete, data: { confirm: "#{special_vehicle.name}の車両情報を削除します。本当によろしいですか？" }, class: "btn btn-md btn-danger" %></td>
+          </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/special_vehicles/new.html.erb
+++ b/app/views/users/special_vehicles/new.html.erb
@@ -1,0 +1,13 @@
+<% provide(:title, "特殊車両情報登録") %>
+<% provide(:btn_text, "登録") %>
+
+<div class="card">
+  <div class="card-body">
+    <%= form_with model: @special_vehicle, url: users_special_vehicles_path, method: :post, local: true, class: "special-vehicle-form-validation" do |f| %>
+      <%= render partial: "form", locals: { f: f } %>
+      
+      <%= f.submit yield(:btn_text), class: "btn btn-md btn-block btn-primary" %>
+      <%= link_to "一覧画面へ", users_special_vehicles_path, class: "btn btn-md btn-block btn-default" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/special_vehicles/show.html.erb
+++ b/app/views/users/special_vehicles/show.html.erb
@@ -1,0 +1,75 @@
+<% provide(:title, "特殊車両情報詳細") %>
+
+<div class="card">
+  <div class="card-body table-responsive p-0">
+    <table class="table table-hover text-nowrap">
+      <tbody>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:name) %></th>
+          <td><%= @special_vehicle.name %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:maker) %></th>
+          <td><%= @special_vehicle.maker %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:standards_performance) %></th>
+          <td><%= @special_vehicle.standards_performance %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:year_manufactured) %></th>
+          <td><%= @special_vehicle.year_manufactured %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:control_number) %></th>
+          <td><%= @special_vehicle.control_number %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:check_exp_date_year) %></th>
+          <td><%= @special_vehicle.check_exp_date_year %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:check_exp_date_month) %></th>
+          <td><%= @special_vehicle.check_exp_date_month %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:check_exp_date_specific) %></th>
+          <td><%= @special_vehicle.check_exp_date_specific %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:check_exp_date_machine) %></th>
+          <td><%= @special_vehicle.check_exp_date_machine %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:check_exp_date_car) %></th>
+          <td><%= @special_vehicle.check_exp_date_car %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:personal_insurance) %></th>
+          <td><%= @special_vehicle.personal_insurance %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:objective_insurance) %></th>
+          <td><%= @special_vehicle.objective_insurance %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:passenger_insurance) %></th>
+          <td><%= @special_vehicle.passenger_insurance %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:other_insurance) %></th>
+          <td><%= @special_vehicle.other_insurance %></td>
+        </tr>
+        <tr>
+          <th><%= SpecialVehicle.human_attribute_name(:exp_date_insurance) %></th>
+          <td><%= @special_vehicle.exp_date_insurance %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="card-footer">
+    <%= link_to "編集", edit_users_special_vehicle_path(@special_vehicle), class: "btn btn-md btn-block btn-success" %>
+    <%= link_to "削除", users_special_vehicle_path(@special_vehicle), method: :delete, data: { confirm: "#{@special_vehicle.name}の車両情報を削除します。本当によろしいですか？" }, class: "btn btn-md btn-danger btn-block" %>
+    <%= link_to "一覧画面へ", users_special_vehicles_path, class: "btn btn-md btn-block btn-default" %>
+  </div>
+</div>

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -287,7 +287,7 @@
         "worker[job_type]": {
           required: true
         },
-         "worker[job_title]": {
+        "worker[job_title]": {
           required: true
         },
         "worker[hiring_on]": {
@@ -302,7 +302,7 @@
         "worker[worker_insurance_attributes][health_insurance_type]": {
           required: true
         },
-         "worker[worker_insurance_attributes][health_insurance_name]": {
+        "worker[worker_insurance_attributes][health_insurance_name]": {
           required: true
         },
         "worker[worker_insurance_attributes][pension_insurance_type]": {
@@ -311,7 +311,7 @@
         "worker[worker_insurance_attributes][employment_insurance_type]": {
           required: true
         },
-         "worker[worker_insurance_attributes][employment_insurance_number]": {
+        "worker[worker_insurance_attributes][employment_insurance_number]": {
           required: true
         },
         "worker[worker_insurance_attributes][severance_pay_mutual_aid_type]": {
@@ -367,8 +367,8 @@
         "worker[worker_insurance_attributes][health_insurance_type]": {
           required: "健康保険のタイプを選択してください。"
         },
-         "worker[worker_insurance_attributes][health_insurance_name]": {
-           required: "健康保険の名前を入力してください。"
+        "worker[worker_insurance_attributes][health_insurance_name]": {
+          required: "健康保険の名前を入力してください。"
         },
         "worker[worker_insurance_attributes][pension_insurance_type]": {
           required: "年金保険のタイプを選択してください。"
@@ -376,13 +376,13 @@
         "worker[worker_insurance_attributes][employment_insurance_type]": {
           required: "雇用保険のタイプを選択してください。"
         },
-         "worker[worker_insurance_attributes][employment_insurance_number]": {
+        "worker[worker_insurance_attributes][employment_insurance_number]": {
           required: "被保険者番号の下4桁を入力してください。"
         },
         "worker[worker_insurance_attributes][severance_pay_mutual_aid_type]": {
           required: "建設業退職金共済制度を選択してください。"
         },
-         "worker[worker_insurance_attributes][severance_pay_mutual_aid_name]": {
+        "worker[worker_insurance_attributes][severance_pay_mutual_aid_name]": {
           required: "建設業退職金共済制度名前を入力してください。"
         },
       },

--- a/config/locales/model_ja.yml
+++ b/config/locales/model_ja.yml
@@ -5,6 +5,8 @@ ja:
       car: 車両情報
       car_insurance_company: ⾃動⾞保険会社
       car_voluntary_insurance: 任意保険
+      car: 車両情報
+      special_vehicle: 特殊車両情報
       field_worker: 現場作業員情報
       order: 発注
       request_order: 発注依頼
@@ -64,6 +66,22 @@ ja:
         voluntary_securities_number: 任意保険証券番号
         voluntary_insurance_start_on: 任意保険初め
         voluntary_insurance_end_on: 任意保険終わり
+      special_vehicle:
+        name: 名称
+        maker: メーカー
+        standards_performance: 規格・性能
+        year_manufactured: 製造年
+        control_number: 管理番号(整理番号)
+        check_exp_date_year: 自主検査有効期限(正規・年次)
+        check_exp_date_month: 自主検査有効期限(正規・月次)
+        check_exp_date_specific: 自主検査有効期限(特定)
+        check_exp_date_machine: 移動式クレーン等の性能検査有効期限
+        check_exp_date_car: 自動車検査証有効期限
+        personal_insurance: 任意保険加入額(対人)
+        objective_insurance: 任意保険加入額(対物)
+        passenger_insurance: 任意保険加入額(搭乗者)
+        other_insurance: 任意保険加入額(その他)
+        exp_date_insurance: 任意保険加入有効期限
       field_car:
         car_name: 車両名
         driver_name: 運転者名

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   namespace :users do
     resources :cars, param: :uuid
+    resources :special_vehicles, param: :uuid
     resources :cars, except: %i[index create new show edit update destroy] do
       patch 'update_images'
     end

--- a/db/fixtures/development/20_special_vehicle.rb
+++ b/db/fixtures/development/20_special_vehicle.rb
@@ -1,0 +1,124 @@
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                       n+1,
+      business_id:              1,
+      name:                     "クレーン",
+      maker:                    "トヨタ",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                        n+4,
+      business_id:               2,
+      name:                      "コンテナ用セミトレーラ",
+      maker:                     "ヤマハ",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                        n+7,
+      business_id:               3,
+      name:                      "タンク型セミトレーラ",
+      maker:                     "日産",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                        n+10,
+      business_id:               4,
+      name:                      "フルトレーラ",
+      maker:                     "三菱",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                        n+13,
+      business_id:               5,
+      name:                      "ポールトレーラ",
+      maker:                     "いすゞ",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end

--- a/db/fixtures/production/20_special_vehicle.rb
+++ b/db/fixtures/production/20_special_vehicle.rb
@@ -1,0 +1,124 @@
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                       n+1,
+      business_id:              1,
+      name:                     "クレーン",
+      maker:                    "トヨタ",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                        n+4,
+      business_id:               2,
+      name:                      "コンテナ用セミトレーラ",
+      maker:                     "ヤマハ",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                        n+7,
+      business_id:               3,
+      name:                      "タンク型セミトレーラ",
+      maker:                     "日産",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                        n+10,
+      business_id:               4,
+      name:                      "フルトレーラ",
+      maker:                     "三菱",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end
+
+3.times do |n|
+  SpecialVehicle.seed(:id,
+    {
+      id:                        n+13,
+      business_id:               5,
+      name:                      "ポールトレーラ",
+      maker:                     "いすゞ",
+      standards_performance:    '幅2.5M',
+      year_manufactured:        Date.today.ago(3.years),
+      control_number:           SecureRandom.hex(5),
+      uuid:                     SecureRandom.uuid,
+      check_exp_date_year:      '2020-01-01',
+      check_exp_date_month:     '2020-02-01',
+      check_exp_date_specific:  '2020-03-01',
+      check_exp_date_machine:   '2020-04-01',
+      check_exp_date_car:       '2020-05-01',
+      personal_insurance:        1,
+      objective_insurance:       2,
+      passenger_insurance:       3,
+      other_insurance:           4,
+      exp_date_insurance:        '2023-01-01'
+    }
+  )
+end

--- a/db/migrate/20220718140049_create_special_vehicles.rb
+++ b/db/migrate/20220718140049_create_special_vehicles.rb
@@ -1,0 +1,25 @@
+class CreateSpecialVehicles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :special_vehicles do |t|
+      t.string :uuid, null: false
+      t.string :name
+      t.string :maker
+      t.string :standards_performance
+      t.date :year_manufactured
+      t.string :control_number
+      t.date :check_exp_date_year, null: false
+      t.date :check_exp_date_month, null: false
+      t.date :check_exp_date_specific, null: false
+      t.date :check_exp_date_machine, null: false
+      t.date :check_exp_date_car, null: false
+      t.integer :personal_insurance
+      t.integer :objective_insurance
+      t.integer :passenger_insurance
+      t.integer :other_insurance
+      t.integer :exp_date_insurance
+      t.references :business, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220813185310_change_column_special_vehicles.rb
+++ b/db/migrate/20220813185310_change_column_special_vehicles.rb
@@ -1,0 +1,10 @@
+class ChangeColumnSpecialVehicles < ActiveRecord::Migration[6.1]
+  def change
+    change_column :special_vehicles, :name, :string, null: false
+    change_column :special_vehicles, :maker, :string, null: false
+    change_column :special_vehicles, :standards_performance, :string, null: false
+    change_column :special_vehicles, :year_manufactured, :date, null: false
+    change_column :special_vehicles, :control_number, :string, null: false
+    change_column :special_vehicles, :exp_date_insurance, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_10_052834) do
+ActiveRecord::Schema.define(version: 2022_08_13_185310) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "namespace"
@@ -391,6 +391,29 @@ ActiveRecord::Schema.define(version: 2022_08_10_052834) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "special_vehicles", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.string "name", null: false
+    t.string "maker", null: false
+    t.string "standards_performance", null: false
+    t.date "year_manufactured", null: false
+    t.string "control_number", null: false
+    t.date "check_exp_date_year", null: false
+    t.date "check_exp_date_month", null: false
+    t.date "check_exp_date_specific", null: false
+    t.date "check_exp_date_machine", null: false
+    t.date "check_exp_date_car", null: false
+    t.integer "personal_insurance"
+    t.integer "objective_insurance"
+    t.integer "passenger_insurance"
+    t.integer "other_insurance"
+    t.date "exp_date_insurance"
+    t.bigint "business_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["business_id"], name: "index_special_vehicles_on_business_id"
+  end
+
   create_table "tags", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
@@ -546,6 +569,7 @@ ActiveRecord::Schema.define(version: 2022_08_10_052834) do
   add_foreign_key "request_orders", "businesses"
   add_foreign_key "request_orders", "orders"
   add_foreign_key "solvents", "businesses"
+  add_foreign_key "special_vehicles", "businesses"
   add_foreign_key "worker_exams", "special_med_exams"
   add_foreign_key "worker_exams", "worker_medicals"
   add_foreign_key "worker_insurances", "workers"

--- a/spec/factories/special_vehicles.rb
+++ b/spec/factories/special_vehicles.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :special_vehicle do
+    uuid { SecureRandom.uuid }
+    sequence(:name) { |n| "name#{n}" }
+    sequence(:maker) { |n| "maker#{n}" }
+    sequence(:standards_performance) { |n| "standards_performance#{n}" }
+    year_manufactured { '2021-01-30' }
+    sequence(:control_number) { |n| "12345#{n}" }
+    check_exp_date_year { '2022-01-30' }
+    check_exp_date_month { '2022-02-28' }
+    check_exp_date_specific { '2022-03-30' }
+    check_exp_date_machine { '2022-04-30' }
+    check_exp_date_car { '2022-05-30' }
+    business
+  end
+end

--- a/spec/models/special_vehicle_spec.rb
+++ b/spec/models/special_vehicle_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe SpecialVehicle, type: :model do
+  let :special_vehicle do
+    build(:special_vehicle)
+  end
+
+  describe 'バリデーションについて' do
+    subject do
+      special_vehicle
+    end
+
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
+
+    describe '#name' do
+      context '存在しない場合' do
+        before :each do
+          subject.name = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('名称を入力してください')
+        end
+      end
+    end
+
+    describe '#maker' do
+      context '存在しない場合' do
+        before :each do
+          subject.maker = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('メーカーを入力してください')
+        end
+      end
+    end
+
+    describe '#year_manufactured' do
+      context '存在しない場合' do
+        before :each do
+          subject.year_manufactured = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('製造年を入力してください')
+        end
+      end
+    end
+
+    describe '#control_number' do
+      context '存在しない場合' do
+        before :each do
+          subject.control_number = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('管理番号(整理番号)を入力してください')
+        end
+      end
+    end
+
+    describe '#check_exp_date_year' do
+      context '存在しない場合' do
+        before :each do
+          subject.check_exp_date_year = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('自主検査有効期限(正規・年次)を入力してください')
+        end
+      end
+    end
+
+    describe '#check_exp_date_month' do
+      context '存在しない場合' do
+        before :each do
+          subject.check_exp_date_month = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('自主検査有効期限(正規・月次)を入力してください')
+        end
+      end
+    end
+
+    describe '#check_exp_date_specific' do
+      context '存在しない場合' do
+        before :each do
+          subject.check_exp_date_specific = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('自主検査有効期限(特定)を入力してください')
+        end
+      end
+    end
+
+    describe '#check_exp_date_machine' do
+      context '存在しない場合' do
+        before :each do
+          subject.check_exp_date_machine = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('移動式クレーン等の性能検査有効期限を入力してください')
+        end
+      end
+    end
+
+    describe '#check_exp_date_car' do
+      context '存在しない場合' do
+        before :each do
+          subject.check_exp_date_car = nil
+        end
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('自動車検査証有効期限を入力してください')
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/special_vehicles_spec.rb
+++ b/spec/requests/special_vehicles_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'Users::SpecialVehicles', type: :request do
+  describe 'GET /index' do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/system/special_vehicle_spec.rb
+++ b/spec/system/special_vehicle_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe 'Special_Vehicles', type: :system do
+  let(:user) { create(:user) }
+  let(:business) { create(:business, user: user) }
+  let(:special_vehicle) { create(:special_vehicle, business: business) }
+
+  describe '特殊車両関連' do
+    before(:each) do
+      # ステージングにて一時的にメール認証スキップ中の為下記コメント
+      # user.skip_confirmation!
+      user.save!
+      business.save!
+      visit new_user_session_path
+      fill_in 'user[email]', with: user.email
+      fill_in 'user[password]', with: user.password
+      click_button 'ログイン'
+    end
+
+    it 'ログイン後に特殊車両情報一覧画面へ遷移できること' do
+      visit users_special_vehicles_path
+      expect(page).to have_content '特殊車両情報一覧'
+    end
+
+    context '特殊車両情報登録' do
+      it '新規登録したあと詳細画面へ遷移すること' do
+        visit new_users_special_vehicle_path
+
+        # 名称
+        fill_in 'special_vehicle[name]', with: special_vehicle.name
+        # メーカー
+        fill_in 'special_vehicle[maker]', with: special_vehicle.maker
+        # 規格・性能
+        fill_in 'special_vehicle[standards_performance]', with: special_vehicle.standards_performance
+        # 製造年
+        fill_in 'special_vehicle[year_manufactured]', with: special_vehicle.year_manufactured
+        # 管理番号(整理番号)
+        fill_in 'special_vehicle[control_number]', with: special_vehicle.control_number
+        # 自主検査有効期限(正規・年次)
+        fill_in 'special_vehicle[check_exp_date_year]', with: special_vehicle.check_exp_date_year
+        # 自主検査有効期限(正規・月次)
+        fill_in 'special_vehicle[check_exp_date_month]', with: special_vehicle.check_exp_date_month
+        # 自主検査有効期限(特定)
+        fill_in 'special_vehicle[check_exp_date_specific]', with: special_vehicle.check_exp_date_specific
+        # 移動式クレーン等の性能検査有効期限
+        fill_in 'special_vehicle[check_exp_date_machine]', with: special_vehicle.check_exp_date_machine
+        # 自動車検査証有効期限
+        fill_in 'special_vehicle[check_exp_date_car]', with: special_vehicle.check_exp_date_car
+
+        # ========== 任意保険ここから ==========
+        # 任意保険加入額(対人)
+        select '1,000', from: 'special_vehicle[personal_insurance]'
+        # 任意保険加入額(対物)
+        select '2,000', from: 'special_vehicle[objective_insurance]'
+        # 任意保険加入額(搭乗者)
+        select '3,000', from: 'special_vehicle[passenger_insurance]'
+        # 任意保険加入額(その他)
+        select '4,000', from: 'special_vehicle[other_insurance]'
+        # 任意保険加入有効期限
+        fill_in 'special_vehicle[exp_date_insurance]', with: '2022-01-28'
+        # ========== 任意保険ここまで ==========
+
+        click_button '登録'
+
+        visit users_special_vehicle_path(special_vehicle)
+        expect(page).to have_content '特殊車両情報詳細'
+        expect(page).to have_content special_vehicle.name
+      end
+    end
+
+    context '特殊車両情報編集' do
+      it '更新したあと詳細画面へ遷移すること' do
+        visit edit_users_special_vehicle_path(special_vehicle)
+
+        fill_in 'special_vehicle[name]', with: '編集後名称'
+        click_button '更新'
+
+        visit users_special_vehicle_path(special_vehicle)
+        expect(page).to have_content '特殊車両情報詳細'
+        expect(page).to have_content '編集後名称'
+      end
+    end
+
+    context '特殊車両情報削除' do
+      it '削除したあと一覧画面に遷移すること', js: true do
+        visit users_special_vehicle_path(special_vehicle)
+        click_on '削除'
+
+        expect {
+          expect(page.accept_confirm).to eq "#{special_vehicle.name}の車両情報を削除します。本当によろしいですか？"
+          expect(page).to have_content "#{special_vehicle.name}を削除しました"
+        }.to change(SpecialVehicle, :count).by(-1)
+
+        visit users_special_vehicles_path
+        expect(page).to have_content '特殊車両情報一覧'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要
発注、発注依頼の現場情報入力フォームバリデーション追加

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- 発注、発注依頼の現場情報入力フォームの、未設定部分のフォームバリデーションを追加。

### 未改修部分
- select2の機能を使用しているフォームのバリデーション表示が下ではなく横に表示される。
- select2関連の機能(タグ周り)が邪魔していると思われる。(引き続き調査、原因解明次第修正する。)

### 実装画像などあれば添付する

![発注](https://user-images.githubusercontent.com/52871417/185531590-966c72ef-8215-465f-9461-b6b5ad67009b.png)

![発注依頼](https://user-images.githubusercontent.com/52871417/185531603-b4ffe4c7-8205-4776-92f8-f866324dcff9.png)

