### PR TITLE
特殊車両関係書類用の現場特殊車両モデル作成(平野)

### DIFF
--- a/app/controllers/users/base.rb
+++ b/app/controllers/users/base.rb
@@ -90,7 +90,7 @@ module Users
     def special_vehicle_info(special_vehicle)
       JSON.parse(
         special_vehicle.to_json(
-          except:  %i[uuid created_at updated_at], # 特殊車両情報
+          except: %i[uuid created_at updated_at] # 特殊車両情報
         )
       )
     end

--- a/app/controllers/users/base.rb
+++ b/app/controllers/users/base.rb
@@ -85,5 +85,14 @@ module Users
 
       json.merge(insurance_company, voluntary_insurance_company)
     end
+
+    # 書類に反映させる特殊車両情報
+    def special_vehicle_info(special_vehicle)
+      JSON.parse(
+        special_vehicle.to_json(
+          except:  %i[uuid created_at updated_at], # 特殊車両情報
+        )
+      )
+    end
   end
 end

--- a/app/controllers/users/orders/field_cars_controller.rb
+++ b/app/controllers/users/orders/field_cars_controller.rb
@@ -7,7 +7,7 @@ module Users::Orders
 
     def index
       field_car_ids = @field_cars.map { |field_car| field_car.content['id'] }
-      @car = current_business.cars
+      @car = current_business.cars.where.not(id: field_car_ids)
     end
 
     def create

--- a/app/controllers/users/orders/field_cars_controller.rb
+++ b/app/controllers/users/orders/field_cars_controller.rb
@@ -7,7 +7,7 @@ module Users::Orders
 
     def index
       field_car_ids = @field_cars.map { |field_car| field_car.content['id'] }
-      @car = current_business.cars.where.not(id: current_user).where.not(id: field_car_ids)
+      @car = current_business.cars
     end
 
     def create

--- a/app/controllers/users/orders/field_special_vehicles_controller.rb
+++ b/app/controllers/users/orders/field_special_vehicles_controller.rb
@@ -1,0 +1,56 @@
+module Users::Orders
+  class FieldSpecialVehiclesController < Users::Base
+    before_action :set_order
+    before_action :set_field_special_vehicle, only: :destroy
+    before_action :set_field_special_vehicles, only: %i[index edit_special_vehicles update_special_vehicles]
+
+    def index
+      field_special_vehicle_ids = @field_special_vehicles.map { |field_special_vehicle| field_special_vehicle.content['id'] }
+      @special_vehicle = current_business.special_vehicles
+    end
+
+    def create
+      ActiveRecord::Base.transaction do
+        params[:special_vehicle_ids].each do |special_vehicle_id|
+          @order.field_special_vehicles.create!(
+            # special_vehicle_name: FieldSpecialVehicle.find(special_vehicle_id).name,
+            content:  special_vehicle_info(SpecialVehicle.find(special_vehicle_id))
+          )
+        end
+        flash[:success] = "#{params[:special_vehicle_ids].count}件追加しました。"
+        redirect_to users_order_field_special_vehicles_url
+      end
+    rescue ActiveRecord::RecordInvalid
+      flash[:danger] = '登録に失敗しました。再度登録してください。'
+      redirect_to users_order_field_special_vehicles_url
+    end
+
+    def destroy; end
+
+    def edit_special_vehicles; end
+
+    def update_special_vehicles; end
+
+    private
+
+    def set_order
+      @order = current_business.orders.find_by(site_uu_id: params[:order_site_uu_id])
+    end
+
+    def set_field_special_vehicle
+      @field_special_vehicle = @order.field_special_vehicles.find_by(uuid: params[:uuid])
+    end
+
+    def set_field_special_vehicles
+      @field_special_vehicles = @order.field_special_vehicles
+    end
+
+    def field_special_vehicles_params
+      params.require(:order).permit(
+        field_special_vehicles: %i[
+          
+        ]
+      )[:field_special_vehicles]
+    end
+  end
+end

--- a/app/controllers/users/orders/field_special_vehicles_controller.rb
+++ b/app/controllers/users/orders/field_special_vehicles_controller.rb
@@ -6,14 +6,14 @@ module Users::Orders
 
     def index
       field_special_vehicle_ids = @field_special_vehicles.map { |field_special_vehicle| field_special_vehicle.content['id'] }
-      @special_vehicle = current_business.special_vehicles
+      @special_vehicle = current_business.special_vehicles.where.not(id: field_special_vehicle_ids)
     end
 
     def create
       ActiveRecord::Base.transaction do
         params[:special_vehicle_ids].each do |special_vehicle_id|
           @order.field_special_vehicles.create!(
-            # special_vehicle_name: FieldSpecialVehicle.find(special_vehicle_id).name,
+            vehicle_name: SpecialVehicle.find(special_vehicle_id).name,
             content:  special_vehicle_info(SpecialVehicle.find(special_vehicle_id))
           )
         end
@@ -25,11 +25,24 @@ module Users::Orders
       redirect_to users_order_field_special_vehicles_url
     end
 
-    def destroy; end
+    def destroy
+      @field_special_vehicle.destroy!
+      flash[:danger] = "#{@field_special_vehicle.vehicle_name}を削除しました"
+      redirect_to users_order_field_special_vehicles_url
+    end
 
     def edit_special_vehicles; end
 
-    def update_special_vehicles; end
+    def update_special_vehicles
+      field_special_vehicles_params.each do |id, item|
+        item[:driver_name] = Worker.find(item[:driver_worker_id]).name
+        item[:driver_license] = Worker.find(item[:driver_worker_id]).worker_licenses.map {|worker_license|License.find(worker_license.license_id).name}.to_s.gsub(/,|"|\[|\]/) { '' }
+        field_special_vehicle = FieldSpecialVehicle.find(id)
+        field_special_vehicle.update(item)
+      end
+      flash[:success] = '特殊車両情報を更新しました'
+      redirect_to users_order_field_special_vehicles_url
+    end
 
     private
 
@@ -48,7 +61,8 @@ module Users::Orders
     def field_special_vehicles_params
       params.require(:order).permit(
         field_special_vehicles: %i[
-          
+          driver_worker_id driver_name driver_licence vehicle_name vehicle_type carry_on_company_name owning_company_name
+          use_company_name carry_on_date carry_out_date use_place lease_type contact_prevention precautions
         ]
       )[:field_special_vehicles]
     end

--- a/app/controllers/users/orders/field_special_vehicles_controller.rb
+++ b/app/controllers/users/orders/field_special_vehicles_controller.rb
@@ -14,7 +14,7 @@ module Users::Orders
         params[:special_vehicle_ids].each do |special_vehicle_id|
           @order.field_special_vehicles.create!(
             vehicle_name: SpecialVehicle.find(special_vehicle_id).name,
-            content:  special_vehicle_info(SpecialVehicle.find(special_vehicle_id))
+            content:      special_vehicle_info(SpecialVehicle.find(special_vehicle_id))
           )
         end
         flash[:success] = "#{params[:special_vehicle_ids].count}件追加しました。"
@@ -35,10 +35,15 @@ module Users::Orders
 
     def update_special_vehicles
       field_special_vehicles_params.each do |id, item|
-        item[:driver_name] = Worker.find(item[:driver_worker_id]).name
-        item[:driver_license] = Worker.find(item[:driver_worker_id]).worker_licenses.map {|worker_license|License.find(worker_license.license_id).name}.to_s.gsub(/,|"|\[|\]/) { '' }
-        field_special_vehicle = FieldSpecialVehicle.find(id)
-        field_special_vehicle.update(item)
+        unless item[:driver_worker_id].blank?
+          item[:driver_name] = Worker.find(item[:driver_worker_id]).name
+          item[:driver_license] = Worker.find(item[:driver_worker_id]).worker_licenses.map { |worker_license| License.find(worker_license.license_id).name }.to_s.gsub(/,|"|\[|\]/) { '' }
+          field_special_vehicle = FieldSpecialVehicle.find(id)
+          field_special_vehicle.update(item)
+        else
+          field_special_vehicle = FieldSpecialVehicle.find(id)
+          field_special_vehicle.update(item)
+        end
       end
       flash[:success] = '特殊車両情報を更新しました'
       redirect_to users_order_field_special_vehicles_url

--- a/app/controllers/users/orders/field_special_vehicles_controller.rb
+++ b/app/controllers/users/orders/field_special_vehicles_controller.rb
@@ -31,19 +31,20 @@ module Users::Orders
       redirect_to users_order_field_special_vehicles_url
     end
 
-    def edit_special_vehicles; end
+    def edit_special_vehicles
+      @carry_on_companies = @field_special_vehicles.distinct.pluck(:carry_on_company_name)
+      @owning_companies = @field_special_vehicles.distinct.pluck(:owning_company_name)
+      @use_companies = @field_special_vehicles.distinct.pluck(:use_company_name)
+    end
 
     def update_special_vehicles
       field_special_vehicles_params.each do |id, item|
         unless item[:driver_worker_id].blank?
           item[:driver_name] = Worker.find(item[:driver_worker_id]).name
           item[:driver_license] = Worker.find(item[:driver_worker_id]).worker_licenses.map { |worker_license| License.find(worker_license.license_id).name }.to_s.gsub(/,|"|\[|\]/) { '' }
-          field_special_vehicle = FieldSpecialVehicle.find(id)
-          field_special_vehicle.update(item)
-        else
-          field_special_vehicle = FieldSpecialVehicle.find(id)
-          field_special_vehicle.update(item)
         end
+        field_special_vehicle = FieldSpecialVehicle.find(id)
+        field_special_vehicle.update(item)
       end
       flash[:success] = '特殊車両情報を更新しました'
       redirect_to users_order_field_special_vehicles_url

--- a/app/controllers/users/orders/field_workers_controller.rb
+++ b/app/controllers/users/orders/field_workers_controller.rb
@@ -6,7 +6,7 @@ module Users::Orders
 
     def index
       field_worker_ids = @field_workers.map { |field_worker| field_worker.content['id'] }
-      @worker = current_business.workers.where.not(id: current_user).where.not(id: field_worker_ids)
+      @worker = current_business.workers
     end
 
     def create

--- a/app/controllers/users/orders/field_workers_controller.rb
+++ b/app/controllers/users/orders/field_workers_controller.rb
@@ -6,7 +6,7 @@ module Users::Orders
 
     def index
       field_worker_ids = @field_workers.map { |field_worker| field_worker.content['id'] }
-      @worker = current_business.workers
+      @worker = current_business.workers.where.not(id: field_worker_ids)
     end
 
     def create

--- a/app/controllers/users/request_orders/field_cars_controller.rb
+++ b/app/controllers/users/request_orders/field_cars_controller.rb
@@ -7,7 +7,7 @@ module Users::RequestOrders
 
     def index
       field_car_ids = @field_cars.map { |field_car| field_car.content['id'] }
-      @car = current_business.cars
+      @car = current_business.cars.where.not(id: field_car_ids)
     end
 
     def create

--- a/app/controllers/users/request_orders/field_cars_controller.rb
+++ b/app/controllers/users/request_orders/field_cars_controller.rb
@@ -7,7 +7,7 @@ module Users::RequestOrders
 
     def index
       field_car_ids = @field_cars.map { |field_car| field_car.content['id'] }
-      @car = current_business.cars.where.not(id: current_user).where.not(id: field_car_ids)
+      @car = current_business.cars
     end
 
     def create

--- a/app/controllers/users/request_orders/field_special_vehicles_controller.rb
+++ b/app/controllers/users/request_orders/field_special_vehicles_controller.rb
@@ -1,0 +1,4 @@
+module Users::RequestOrders
+  class FieldSpecialVehiclesController < Users::Base
+  end
+end

--- a/app/controllers/users/request_orders/field_special_vehicles_controller.rb
+++ b/app/controllers/users/request_orders/field_special_vehicles_controller.rb
@@ -1,4 +1,75 @@
 module Users::RequestOrders
   class FieldSpecialVehiclesController < Users::Base
+    before_action :set_request_order
+    before_action :set_field_special_vehicle, only: :destroy
+    before_action :set_field_special_vehicles, only: %i[index edit_special_vehicles update_special_vehicles]
+
+    def index
+      field_special_vehicle_ids = @field_special_vehicles.map { |field_special_vehicle| field_special_vehicle.content['id'] }
+      @special_vehicle = current_business.special_vehicles.where.not(id: field_special_vehicle_ids)
+    end
+
+    def create
+      ActiveRecord::Base.transaction do
+        params[:special_vehicle_ids].each do |special_vehicle_id|
+          @request_order.field_special_vehicles.create!(
+            vehicle_name: SpecialVehicle.find(special_vehicle_id).name,
+            content:      special_vehicle_info(SpecialVehicle.find(special_vehicle_id))
+          )
+        end
+        flash[:success] = "#{params[:special_vehicle_ids].count}件追加しました。"
+        redirect_to users_request_order_field_special_vehicles_url
+      end
+    rescue ActiveRecord::RecordInvalid
+      flash[:danger] = '登録に失敗しました。再度登録してください。'
+      redirect_to users_request_order_field_special_vehicles_url
+    end
+
+    def destroy
+      @field_special_vehicle.destroy!
+      flash[:danger] = "#{@field_special_vehicle.vehicle_name}を削除しました"
+      redirect_to users_request_order_field_special_vehicles_url
+    end
+
+    def edit_special_vehicles; end
+
+    def update_special_vehicles
+      field_special_vehicles_params.each do |id, item|
+        unless item[:driver_worker_id].blank?
+          item[:driver_name] = Worker.find(item[:driver_worker_id]).name
+          item[:driver_license] = Worker.find(item[:driver_worker_id]).worker_licenses.map { |worker_license| License.find(worker_license.license_id).name }.to_s.gsub(/,|"|\[|\]/) { '' }
+          field_special_vehicle = FieldSpecialVehicle.find(id)
+          field_special_vehicle.update(item)
+        else
+          field_special_vehicle = FieldSpecialVehicle.find(id)
+          field_special_vehicle.update(item)
+        end
+      end
+      flash[:success] = '特殊車両情報を更新しました'
+      redirect_to users_request_order_field_special_vehicles_url
+    end
+
+    private
+
+    def set_request_order
+      @request_order = current_business.request_orders.find_by(site_uu_id: params[:order_site_uu_id])
+    end
+
+    def set_field_special_vehicle
+      @field_special_vehicle = @request_order.field_special_vehicles.find_by(uuid: params[:uuid])
+    end
+
+    def set_field_special_vehicles
+      @field_special_vehicles = @request_order.field_special_vehicles
+    end
+
+    def field_special_vehicles_params
+      params.require(:request_order).permit(
+        field_special_vehicles: %i[
+          driver_worker_id driver_name driver_licence vehicle_name vehicle_type carry_on_company_name owning_company_name
+          use_company_name carry_on_date carry_out_date use_place lease_type contact_prevention precautions
+        ]
+      )[:field_special_vehicles]
+    end
   end
 end

--- a/app/controllers/users/request_orders/field_special_vehicles_controller.rb
+++ b/app/controllers/users/request_orders/field_special_vehicles_controller.rb
@@ -31,19 +31,20 @@ module Users::RequestOrders
       redirect_to users_request_order_field_special_vehicles_url
     end
 
-    def edit_special_vehicles; end
+    def edit_special_vehicles
+      @carry_on_companies = @field_special_vehicles.distinct.pluck(:carry_on_company_name)
+      @owning_companies = @field_special_vehicles.distinct.pluck(:owning_company_name)
+      @use_companies = @field_special_vehicles.distinct.pluck(:use_company_name)
+    end
 
     def update_special_vehicles
       field_special_vehicles_params.each do |id, item|
         unless item[:driver_worker_id].blank?
           item[:driver_name] = Worker.find(item[:driver_worker_id]).name
           item[:driver_license] = Worker.find(item[:driver_worker_id]).worker_licenses.map { |worker_license| License.find(worker_license.license_id).name }.to_s.gsub(/,|"|\[|\]/) { '' }
-          field_special_vehicle = FieldSpecialVehicle.find(id)
-          field_special_vehicle.update(item)
-        else
-          field_special_vehicle = FieldSpecialVehicle.find(id)
-          field_special_vehicle.update(item)
         end
+        field_special_vehicle = FieldSpecialVehicle.find(id)
+        field_special_vehicle.update(item)
       end
       flash[:success] = '特殊車両情報を更新しました'
       redirect_to users_request_order_field_special_vehicles_url
@@ -52,7 +53,7 @@ module Users::RequestOrders
     private
 
     def set_request_order
-      @request_order = current_business.request_orders.find_by(site_uu_id: params[:order_site_uu_id])
+      @request_order = current_business.request_orders.find_by(uuid: params[:request_order_uuid])
     end
 
     def set_field_special_vehicle

--- a/app/controllers/users/request_orders/field_workers_controller.rb
+++ b/app/controllers/users/request_orders/field_workers_controller.rb
@@ -6,7 +6,7 @@ module Users::RequestOrders
 
     def index
       field_worker_ids = @field_workers.map { |field_worker| field_worker.content['id'] }
-      @worker = current_business.workers.where.not(id: current_user).where.not(id: field_worker_ids)
+      @worker = current_business.workers
     end
 
     def create

--- a/app/controllers/users/request_orders/field_workers_controller.rb
+++ b/app/controllers/users/request_orders/field_workers_controller.rb
@@ -6,7 +6,7 @@ module Users::RequestOrders
 
     def index
       field_worker_ids = @field_workers.map { |field_worker| field_worker.content['id'] }
-      @worker = current_business.workers
+      @worker = current_business.workers.where.not(id: field_worker_ids)
     end
 
     def create

--- a/app/models/field_special_vehicle.rb
+++ b/app/models/field_special_vehicle.rb
@@ -5,7 +5,10 @@ class FieldSpecialVehicle < ApplicationRecord
 
   enum vehicle_type: { crane: 0, construction: 1 }
   enum lease_type: { own: 0, lease: 1 }
-
+  
+  validates :driver_worker_id, presence: true, on: :update
+  validates :vehicle_name, presence: true
+  validates :content, presence: true
   # validates :vehicle_type, presence: true
   # validates :carry_on_company_name, presence: true
   # validates :owning_company_name, presence: true

--- a/app/models/field_special_vehicle.rb
+++ b/app/models/field_special_vehicle.rb
@@ -3,6 +3,9 @@ class FieldSpecialVehicle < ApplicationRecord
 
   before_create -> { self.uuid = SecureRandom.uuid }
 
+  enum vehicle_type: { crane: 0, construction: 1 }
+  enum lease_type: { own: 0, lease: 1 }
+
   validates :vehicle_type, presence: true
   validates :carry_on_company_name, presence: true
   validates :owning_company_name, presence: true

--- a/app/models/field_special_vehicle.rb
+++ b/app/models/field_special_vehicle.rb
@@ -8,6 +8,9 @@ class FieldSpecialVehicle < ApplicationRecord
 
   validates :vehicle_name, presence: true
   validates :content, presence: true
+  validates :use_place, length: { maximum: 100 }
+  validates :contact_prevention, length: { maximum: 40 }
+  validates :precautions, length: { maximum: 500 }
 
   def to_param
     uuid

--- a/app/models/field_special_vehicle.rb
+++ b/app/models/field_special_vehicle.rb
@@ -5,18 +5,9 @@ class FieldSpecialVehicle < ApplicationRecord
 
   enum vehicle_type: { crane: 0, construction: 1 }
   enum lease_type: { own: 0, lease: 1 }
-  
-  validates :driver_worker_id, presence: true, on: :update
+
   validates :vehicle_name, presence: true
   validates :content, presence: true
-  # validates :vehicle_type, presence: true
-  # validates :carry_on_company_name, presence: true
-  # validates :owning_company_name, presence: true
-  # validates :use_company_name, presence: true
-  # validates :carry_on_date, presence: true
-  # validates :carry_out_date, presence: true
-  # validates :use_place, presence: true
-  # validates :lease_type, presence: true
 
   def to_param
     uuid

--- a/app/models/field_special_vehicle.rb
+++ b/app/models/field_special_vehicle.rb
@@ -1,0 +1,18 @@
+class FieldSpecialVehicle < ApplicationRecord
+  belongs_to :field_special_vehicleable, polymorphic: true
+
+  before_create -> { self.uuid = SecureRandom.uuid }
+
+  validates :vehicle_type, presence: true
+  validates :carry_on_company_name, presence: true
+  validates :owning_company_name, presence: true
+  validates :use_company_name, presence: true
+  validates :carry_on_date, presence: true
+  validates :carry_out_date, presence: true
+  validates :use_place, presence: true
+  validates :lease_type, presence: true
+
+  def to_param
+    uuid
+  end
+end

--- a/app/models/field_special_vehicle.rb
+++ b/app/models/field_special_vehicle.rb
@@ -6,14 +6,14 @@ class FieldSpecialVehicle < ApplicationRecord
   enum vehicle_type: { crane: 0, construction: 1 }
   enum lease_type: { own: 0, lease: 1 }
 
-  validates :vehicle_type, presence: true
-  validates :carry_on_company_name, presence: true
-  validates :owning_company_name, presence: true
-  validates :use_company_name, presence: true
-  validates :carry_on_date, presence: true
-  validates :carry_out_date, presence: true
-  validates :use_place, presence: true
-  validates :lease_type, presence: true
+  # validates :vehicle_type, presence: true
+  # validates :carry_on_company_name, presence: true
+  # validates :owning_company_name, presence: true
+  # validates :use_company_name, presence: true
+  # validates :carry_on_date, presence: true
+  # validates :carry_out_date, presence: true
+  # validates :use_place, presence: true
+  # validates :lease_type, presence: true
 
   def to_param
     uuid

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@ class Order < ApplicationRecord
   has_many :request_orders, dependent: :destroy
   has_many :field_workers, as: :field_workerable, dependent: :destroy
   has_many :field_cars, as: :field_carable, dependent: :destroy
+  has_many :field_special_vehicles, as: :field_special_vehicleable, dependent: :destroy
 
   enum status: { created: 0, completed: 1 }
   enum supervising_engineer_check: { full_time: 0, non_dedicated: 1 }

--- a/app/models/request_order.rb
+++ b/app/models/request_order.rb
@@ -4,6 +4,7 @@ class RequestOrder < ApplicationRecord
   has_many :documents, dependent: :destroy
   has_many :field_workers, as: :field_workerable, dependent: :destroy
   has_many :field_cars, as: :field_carable, dependent: :destroy
+  has_many :field_special_vehicles, as: :field_special_vehicleable, dependent: :destroy
 
   enum status: { requested: 0, submitted: 1, fix_requested: 2, approved: 3 }
   enum professional_construction: { y: 0, n: 1 }

--- a/app/views/users/orders/field_cars/edit_cars.html.erb
+++ b/app/views/users/orders/field_cars/edit_cars.html.erb
@@ -11,7 +11,7 @@
         <td>
           <%= link_to "入場作業員", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
           <%= link_to "車両", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
-          <%= link_to "特殊車両", "#", class: "btn btn-md btn-success" %>
+          <%= link_to "特殊車両", users_order_field_special_vehicles_path(@order), class: "btn btn-md btn-success" %>
           <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
           <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
         </td>

--- a/app/views/users/orders/field_cars/index.html.erb
+++ b/app/views/users/orders/field_cars/index.html.erb
@@ -11,7 +11,7 @@
         <td>
           <%= link_to "入場作業員", users_order_field_workers_path(@order), class: "btn btn-md btn-success" %>
           <%= link_to "車両", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
-          <%= link_to "特殊車両", "#", class: "btn btn-md btn-success" %>
+          <%= link_to "特殊車両", users_order_field_special_vehicles_path(@order), class: "btn btn-md btn-success" %>
           <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
           <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
         </td>
@@ -25,7 +25,7 @@
     <div class="card">
       <div class="card-body">
         <%= form_with url: users_order_field_cars_path, method: :post, local: true do |f| %>
-          <%= f.label "追加する作業員を選択してください。" %>
+          <%= f.label "追加する車両を選択してください。" %>
           <div class="pb-1">
             <%= f.collection_select :car_ids, @car, :id, :vehicle_name, { include_hidden: false }, { required: true, multiple: true, class: "multiple-select", style: "width: 100%" } %>
           </div>

--- a/app/views/users/orders/field_special_vehicles/edit_special_vehicles.html.erb
+++ b/app/views/users/orders/field_special_vehicles/edit_special_vehicles.html.erb
@@ -85,7 +85,7 @@
                     </td>
                     <td>
                       <%= fs.label :use_place %>
-                      <%= fs.text_field :use_place, maxlength: 100, placeholder: "100文字以内", class: "form-control" %>
+                      <%= fs.text_field :use_place, placeholder: "100文字以内", class: "form-control" %>
                     </td>
                     <td>
                       <%= fs.label :lease_type %>

--- a/app/views/users/orders/field_special_vehicles/edit_special_vehicles.html.erb
+++ b/app/views/users/orders/field_special_vehicles/edit_special_vehicles.html.erb
@@ -1,0 +1,100 @@
+<% provide(:title, "現場特殊車両編集") %>
+<% provide(:btn_text, "更新") %>
+
+<div class="card">
+  <div class="card-body table-responsive p-0">
+    <table class="table text-nowrap">
+      <tbody>
+        <td>
+          <%= link_to "戻る", users_order_field_special_vehicles_path, class: "btn btn-md btn-default" %>
+        </td>
+        <td>
+          <%= link_to "入場作業員", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
+          <%= link_to "車両", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
+          <%= link_to "特殊車両", users_order_field_special_vehicles_path(@order), class: "btn btn-md btn-success" %>
+          <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
+          <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
+        </td>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<section class="content">
+  <div class="col-md-12">
+    <%= form_with model: @order, url: update_special_vehicles_users_order_field_special_vehicles_path, method: :patch, local: true do |f| %>
+      <div class="card">
+        <div class="card-body table-responsive p-0">
+          <table class="table text-nowrap">
+            </thead>
+            <tbody>
+              <% @field_special_vehicles.each do |field_special_vehicle| %>
+                <%= f.fields_for "field_special_vehicles[]", field_special_vehicle do |fs| %>
+                  <tr style="border-bottom: 0px #fff;">
+                    <td> 
+                      <%= fs.label :vehicle_name %><br>
+                      <%= field_special_vehicle.vehicle_name %>
+                    </td>
+                    <td>
+                      <%= fs.label :driver_name %><br>
+                      <%= fs.select :driver_worker_id, @current_business.workers.pluck(:name, :id), { prompt: '選択してください' }, { class: "form-control" } %>
+                    </td>
+                    <td colspan="2"></td>
+                  </tr>
+                  <tr style="border-bottom: 0px #fff;">
+                    <td>
+                      <%= fs.label :vehicle_type %><br>
+                      <%= fs.select :vehicle_type, FieldSpecialVehicle.vehicle_types_i18n.invert, { prompt: true }, { class: "form-control" } %>
+                    </td>
+                    <td>
+                      <%= fs.label :carry_on_company_name %>
+                      <%= fs.text_field :carry_on_company_name, class: "form-control" %>
+                    </td>
+                    <td>
+                      <%= fs.label :owning_company_name %>
+                      <%= fs.text_field :owning_company_name, class: "form-control" %>
+                    </td>
+                    <td>
+                      <%= fs.label :use_company_name %>
+                      <%= fs.text_field :use_company_name, class: "form-control" %>
+                    </td>
+                  </tr>
+                  <tr style="border: 0px #fff;">
+                    <td>
+                      <%= fs.label :carry_on_date %>
+                      <%= fs.date_field :carry_on_date, class: "form-control" %>
+                    </td>
+                    <td>
+                      <%= fs.label :carry_out_date %>
+                      <%= fs.date_field :carry_out_date, class: "form-control" %>
+                    </td>
+                    <td>
+                      <%= fs.label :use_place %>
+                      <%= fs.text_field :use_place, class: "form-control" %>
+                    </td>
+                    <td>
+                      <%= fs.label :lease_type %>
+                      <%= fs.select :lease_type, FieldSpecialVehicle.lease_types_i18n.invert, { prompt: true }, { class: "form-control" } %>
+                    </td>
+                  </tr>
+                  <tr style="border-top: 0px #fff;">
+                    <td colspan="2" >
+                      <%= fs.label :contact_prevention %>
+                      <%= fs.text_area :contact_prevention, maxlength: 40, placeholder: "40文字以内", class: "form-control" %>
+                    </td>
+                    <td colspan="2">
+                      <%= fs.label :precautions %>
+                      <%= fs.text_area :precautions, maxlength: 500, placeholder: "500文字以内", class: "form-control" %>
+                    </td>
+                  </tr>
+                <% end %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <%= f.submit yield(:btn_text), class: "btn btn-md btn-block btn-primary" %>
+      <br>
+    <% end %>
+  </div>
+</section>

--- a/app/views/users/orders/field_special_vehicles/edit_special_vehicles.html.erb
+++ b/app/views/users/orders/field_special_vehicles/edit_special_vehicles.html.erb
@@ -85,7 +85,7 @@
                     </td>
                     <td>
                       <%= fs.label :use_place %>
-                      <%= fs.text_field :use_place, class: "form-control" %>
+                      <%= fs.text_field :use_place, maxlength: 100, placeholder: "100文字以内", class: "form-control" %>
                     </td>
                     <td>
                       <%= fs.label :lease_type %>

--- a/app/views/users/orders/field_special_vehicles/edit_special_vehicles.html.erb
+++ b/app/views/users/orders/field_special_vehicles/edit_special_vehicles.html.erb
@@ -48,15 +48,30 @@
                     </td>
                     <td>
                       <%= fs.label :carry_on_company_name %>
-                      <%= fs.text_field :carry_on_company_name, class: "form-control" %>
+                      <%= fs.text_field :carry_on_company_name, list: 'carry_on', class: "form-control" %>
+                      <datalist id="carry_on">
+                        <% @carry_on_companies.each do |company| %>
+                        <option><%= company %></option>
+                        <% end %>
+                      </datalist>
                     </td>
                     <td>
                       <%= fs.label :owning_company_name %>
-                      <%= fs.text_field :owning_company_name, class: "form-control" %>
+                      <%= fs.text_field :owning_company_name, list: 'owning', class: "form-control" %>
+                      <datalist id="owning">
+                        <% @owning_companies.each do |company| %>
+                        <option><%= company %></option>
+                        <% end %>
+                      </datalist>
                     </td>
                     <td>
                       <%= fs.label :use_company_name %>
-                      <%= fs.text_field :use_company_name, class: "form-control" %>
+                      <%= fs.text_field :use_company_name, list: 'use', class: "form-control" %>
+                      <datalist id="use">
+                        <% @use_companies.each do |company| %>
+                        <option><%= company %></option>
+                        <% end %>
+                      </datalist>
                     </td>
                   </tr>
                   <tr style="border: 0px #fff;">

--- a/app/views/users/orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/orders/field_special_vehicles/index.html.erb
@@ -40,3 +40,61 @@
     </div>
   </div>
 </section>
+
+<br>
+<% if @field_special_vehicles.present? %>
+  <section class="content">
+    <div class="col-md-12">
+      <div class="card">
+        <div class="card-body table-responsive p-0">
+          <table class="table text-nowrap">
+            <tbody>
+              <% @field_special_vehicles.each do |field_special_vehicle| %>
+                <tr style="border-bottom: 0px #fff;">
+                  <td>
+                    <%#= FieldCar.human_attribute_name(:car_name) %><br>
+                    <%#= not_input_display(field_car.car_name) %>
+                  </td>
+                  <td>
+                    <%#= FieldCar.human_attribute_name(:driver_name) %><br>
+                    <%#= not_input_display(field_car.driver_name) %>
+                  </td>
+                  <td>
+                    <%#= FieldCar.human_attribute_name(:usage_period_start) %><br>
+                    <%#= not_input_display(field_car.usage_period_start) %>
+                  </td>
+                  <td>
+                    <%#= FieldCar.human_attribute_name(:usage_period_end) %><br>
+                    <%#= not_input_display(field_car.usage_period_end) %>
+                  </td>
+                  <td>
+                    <%#= link_to "削除", users_order_field_car_path(@order, field_car), method: :delete, data: { confirm: "#{field_car.car_name}を削除します。本当によろしいですか？" }, class: "btn btn-md btn-danger" %>
+                  </td>
+                </tr>
+                <tr style="border-top: 0px #fff;">
+                  <td>
+                    <%#= FieldCar.human_attribute_name(:starting_point) %><br>
+                    <%#= not_input_display(field_car.starting_point) %>
+                  </td>
+                  <td>
+                    <%#= FieldCar.human_attribute_name(:waypoint_first) %><br>
+                    <%#= not_input_display(field_car.waypoint_first) %>
+                  </td>
+                  <td>
+                    <%#= FieldCar.human_attribute_name(:waypoint_second) %><br>
+                    <%#= not_input_display(field_car.waypoint_second) %>
+                  </td>
+                  <td>
+                    <%#= FieldCar.human_attribute_name(:arrival_point) %><br>
+                    <%#= not_input_display(field_car.arrival_point) %>
+                  </td>
+                  <td></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/views/users/orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/orders/field_special_vehicles/index.html.erb
@@ -59,12 +59,15 @@
                     <%= FieldSpecialVehicle.human_attribute_name(:driver_name) %><br>
                     <%= not_input_display(field_special_vehicle.driver_name) %>
                   </td>
-                  <td colspan="2"></td>
+                  <td></td>
+                  <td>
+                    <%= link_to "削除", users_order_field_special_vehicle_path(@order, field_special_vehicle), method: :delete, data: { confirm: "#{field_special_vehicle.vehicle_name}を削除します。本当によろしいですか？" }, class: "btn btn-md btn-danger" %>
+                  </td>
                 </tr>
                 <tr style="border: 0px #fff;">
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:vehicle_type) %><br>
-                    <%= not_input_display(field_special_vehicle.vehicle_type) %>
+                    <%= not_input_display(field_special_vehicle.vehicle_type_i18n) %>
                   </td>
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:carry_on_company_name) %><br>
@@ -94,7 +97,7 @@
                   </td>
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:lease_type) %><br>
-                    <%= not_input_display(field_special_vehicle.lease_type) %>
+                    <%= not_input_display(field_special_vehicle.lease_type_i18n) %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/users/orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/orders/field_special_vehicles/index.html.erb
@@ -82,7 +82,7 @@
                     <%= not_input_display(field_special_vehicle.use_company_name) %>
                   </td>
                 </tr>
-                <tr style="border-top: 0px #fff;">
+                <tr style="border: 0px #fff;">
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:carry_on_date) %><br>
                     <%= not_input_display(field_special_vehicle.carry_on_date) %>
@@ -98,6 +98,16 @@
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:lease_type) %><br>
                     <%= not_input_display(field_special_vehicle.lease_type_i18n) %>
+                  </td>
+                </tr>
+                <tr style="border-top: 0px #fff;">
+                  <td colspan="2">
+                    <%= FieldSpecialVehicle.human_attribute_name(:contact_prevention) %><br>
+                    <%= not_input_display(field_special_vehicle.contact_prevention) %>
+                  </td>
+                  <td colspan="2">
+                    <%= FieldSpecialVehicle.human_attribute_name(:precautions) %><br>
+                    <%= not_input_display(field_special_vehicle.precautions) %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/users/orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/orders/field_special_vehicles/index.html.erb
@@ -1,0 +1,42 @@
+<% provide(:title,  "現場特殊車両一覧") %>
+
+<div class="card">
+  <div class="card-body table-responsive p-0">
+    <table class="table text-nowrap">
+      <tbody>
+        <td>
+          <%= link_to "現場情報詳細", users_order_path(@order), class: "btn btn-md btn-default" %>
+          <%= link_to "現場情報一覧", users_orders_path(@order), class: "btn btn-md btn-default" %>
+        </td>
+        <td>
+          <%= link_to "入場作業員", users_order_field_workers_path(@order), class: "btn btn-md btn-success" %>
+          <%= link_to "車両", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
+          <%= link_to "特殊車両", users_order_field_special_vehicles_path(@order), class: "btn btn-md btn-success" %>
+          <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
+          <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
+        </td>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<section class="content">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-body">
+        <%= form_with url: users_order_field_special_vehicles_path, method: :post, local: true do |f| %>
+          <%= f.label "追加する特殊車両を選択してください。" %>
+          <div class="pb-1">
+            <%= f.collection_select :special_vehicle_ids, @special_vehicle, :id, :name, { include_hidden: false }, { required: true, multiple: true, class: "multiple-select", style: "width: 100%" } %>
+          </div>
+          <div>
+            <%= f.submit "現場特殊車両追加", class: "btn btn-md btn-primary" %>
+            <% if @field_special_vehicles.present? %>
+              <%= link_to "現場特殊車両情報編集", edit_special_vehicles_users_order_field_special_vehicles_path(@order), class: "btn btn-md btn-success" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/users/orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/orders/field_special_vehicles/index.html.erb
@@ -52,43 +52,60 @@
               <% @field_special_vehicles.each do |field_special_vehicle| %>
                 <tr style="border-bottom: 0px #fff;">
                   <td>
-                    <%#= FieldCar.human_attribute_name(:car_name) %><br>
-                    <%#= not_input_display(field_car.car_name) %>
+                    <%= FieldSpecialVehicle.human_attribute_name(:vehicle_name) %><br>
+                    <%= field_special_vehicle.vehicle_name %>
                   </td>
                   <td>
-                    <%#= FieldCar.human_attribute_name(:driver_name) %><br>
-                    <%#= not_input_display(field_car.driver_name) %>
+                    <%= FieldSpecialVehicle.human_attribute_name(:driver_name) %><br>
+                    <%= not_input_display(field_special_vehicle.driver_name) %>
+                  </td>
+                  <td colspan="2"></td>
+                </tr>
+                <tr style="border: 0px #fff;">
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:vehicle_type) %><br>
+                    <%= not_input_display(field_special_vehicle.vehicle_type) %>
                   </td>
                   <td>
-                    <%#= FieldCar.human_attribute_name(:usage_period_start) %><br>
-                    <%#= not_input_display(field_car.usage_period_start) %>
+                    <%= FieldSpecialVehicle.human_attribute_name(:carry_on_company_name) %><br>
+                    <%= not_input_display(field_special_vehicle.carry_on_company_name) %>
                   </td>
                   <td>
-                    <%#= FieldCar.human_attribute_name(:usage_period_end) %><br>
-                    <%#= not_input_display(field_car.usage_period_end) %>
+                    <%= FieldSpecialVehicle.human_attribute_name(:owning_company_name) %><br>
+                    <%= not_input_display(field_special_vehicle.owning_company_name) %>
                   </td>
                   <td>
-                    <%#= link_to "削除", users_order_field_car_path(@order, field_car), method: :delete, data: { confirm: "#{field_car.car_name}を削除します。本当によろしいですか？" }, class: "btn btn-md btn-danger" %>
+                    <%= FieldSpecialVehicle.human_attribute_name(:use_company_name) %><br>
+                    <%= not_input_display(field_special_vehicle.use_company_name) %>
+                  </td>
+                </tr>
+                <tr style="border: 0px #fff;">
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:carry_on_date) %><br>
+                    <%= not_input_display(field_special_vehicle.carry_on_date) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:carry_out_date) %><br>
+                    <%= not_input_display(field_special_vehicle.carry_out_date) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:use_place) %><br>
+                    <%= not_input_display(field_special_vehicle.use_place) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:lease_type) %><br>
+                    <%= not_input_display(field_special_vehicle.lease_type) %>
                   </td>
                 </tr>
                 <tr style="border-top: 0px #fff;">
-                  <td>
-                    <%#= FieldCar.human_attribute_name(:starting_point) %><br>
-                    <%#= not_input_display(field_car.starting_point) %>
+                  <td colspan="2">
+                    <%= FieldSpecialVehicle.human_attribute_name(:contact_prevention) %><br>
+                    <%= field_special_vehicle.contact_prevention %>
                   </td>
-                  <td>
-                    <%#= FieldCar.human_attribute_name(:waypoint_first) %><br>
-                    <%#= not_input_display(field_car.waypoint_first) %>
+                  <td colspan="2">
+                    <%= FieldSpecialVehicle.human_attribute_name(:precautions) %><br>
+                    <%= not_input_display(field_special_vehicle.precautions) %>
                   </td>
-                  <td>
-                    <%#= FieldCar.human_attribute_name(:waypoint_second) %><br>
-                    <%#= not_input_display(field_car.waypoint_second) %>
-                  </td>
-                  <td>
-                    <%#= FieldCar.human_attribute_name(:arrival_point) %><br>
-                    <%#= not_input_display(field_car.arrival_point) %>
-                  </td>
-                  <td></td>
                 </tr>
               <% end %>
             </tbody>

--- a/app/views/users/orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/orders/field_special_vehicles/index.html.erb
@@ -79,7 +79,7 @@
                     <%= not_input_display(field_special_vehicle.use_company_name) %>
                   </td>
                 </tr>
-                <tr style="border: 0px #fff;">
+                <tr style="border-top: 0px #fff;">
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:carry_on_date) %><br>
                     <%= not_input_display(field_special_vehicle.carry_on_date) %>
@@ -95,16 +95,6 @@
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:lease_type) %><br>
                     <%= not_input_display(field_special_vehicle.lease_type) %>
-                  </td>
-                </tr>
-                <tr style="border-top: 0px #fff;">
-                  <td colspan="2">
-                    <%= FieldSpecialVehicle.human_attribute_name(:contact_prevention) %><br>
-                    <%= field_special_vehicle.contact_prevention %>
-                  </td>
-                  <td colspan="2">
-                    <%= FieldSpecialVehicle.human_attribute_name(:precautions) %><br>
-                    <%= not_input_display(field_special_vehicle.precautions) %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/users/orders/field_workers/edit_workers.html.erb
+++ b/app/views/users/orders/field_workers/edit_workers.html.erb
@@ -10,8 +10,8 @@
         </td>
         <td>
           <%= link_to "入場作業員", users_order_field_workers_path(@order), class: "btn btn-md btn-success" %>
-          <%= link_to "車両", "#", class: "btn btn-md btn-success" %>
-          <%= link_to "特殊車両", "#", class: "btn btn-md btn-success" %>
+          <%= link_to "車両", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
+          <%= link_to "特殊車両", users_order_field_special_vehicles_path(@order), class: "btn btn-md btn-success" %>
           <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
           <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
         </td>

--- a/app/views/users/orders/field_workers/index.html.erb
+++ b/app/views/users/orders/field_workers/index.html.erb
@@ -11,7 +11,7 @@
         <td>
           <%= link_to "入場作業員", users_order_field_workers_path(@order), class: "btn btn-md btn-success" %>
           <%= link_to "車両", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
-          <%= link_to "特殊車両", "#", class: "btn btn-md btn-success" %>
+          <%= link_to "特殊車両", users_order_field_special_vehicles_path(@order), class: "btn btn-md btn-success" %>
           <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
           <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
         </td>

--- a/app/views/users/orders/show.html.erb
+++ b/app/views/users/orders/show.html.erb
@@ -12,7 +12,7 @@
           <td>
             <%= link_to "入場作業員", users_order_field_workers_path(@order), class: "btn btn-md btn-success" %>
             <%= link_to "車両", users_order_field_cars_path(@order), class: "btn btn-md btn-success" %>
-            <%= link_to "特殊車両", "#", class: "btn btn-md btn-success" %>
+            <%= link_to "特殊車両", users_order_field_special_vehicles_path(@order), class: "btn btn-md btn-success" %>
             <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
             <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
           </td>

--- a/app/views/users/request_orders/field_special_vehicles/edit_special_vehicles.html.erb
+++ b/app/views/users/request_orders/field_special_vehicles/edit_special_vehicles.html.erb
@@ -85,7 +85,7 @@
                     </td>
                     <td>
                       <%= fs.label :use_place %>
-                      <%= fs.text_field :use_place, maxlength: 100, placeholder: "100文字以内", class: "form-control" %>
+                      <%= fs.text_field :use_place, placeholder: "100文字以内", class: "form-control" %>
                     </td>
                     <td>
                       <%= fs.label :lease_type %>

--- a/app/views/users/request_orders/field_special_vehicles/edit_special_vehicles.html.erb
+++ b/app/views/users/request_orders/field_special_vehicles/edit_special_vehicles.html.erb
@@ -85,7 +85,7 @@
                     </td>
                     <td>
                       <%= fs.label :use_place %>
-                      <%= fs.text_field :use_place, class: "form-control" %>
+                      <%= fs.text_field :use_place, maxlength: 100, placeholder: "100文字以内", class: "form-control" %>
                     </td>
                     <td>
                       <%= fs.label :lease_type %>

--- a/app/views/users/request_orders/field_special_vehicles/edit_special_vehicles.html.erb
+++ b/app/views/users/request_orders/field_special_vehicles/edit_special_vehicles.html.erb
@@ -1,0 +1,115 @@
+<% provide(:title, "現場特殊車両編集") %>
+<% provide(:btn_text, "更新") %>
+
+<div class="card">
+  <div class="card-body table-responsive p-0">
+    <table class="table text-nowrap">
+      <tbody>
+        <td>
+          <%= link_to "戻る", users_request_order_field_special_vehicles_path, class: "btn btn-md btn-default" %>
+        </td>
+        <td>
+          <%= link_to "入場作業員", users_request_order_field_cars_path(@request_order), class: "btn btn-md btn-success" %>
+          <%= link_to "車両", users_request_order_field_cars_path(@request_order), class: "btn btn-md btn-success" %>
+          <%= link_to "特殊車両", users_request_order_field_special_vehicles_path(@request_order), class: "btn btn-md btn-success" %>
+          <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
+          <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
+        </td>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<section class="content">
+  <div class="col-md-12">
+    <%= form_with model: @request_order, url: update_special_vehicles_users_request_order_field_special_vehicles_path, method: :patch, local: true do |f| %>
+      <div class="card">
+        <div class="card-body table-responsive p-0">
+          <table class="table text-nowrap">
+            </thead>
+            <tbody>
+              <% @field_special_vehicles.each do |field_special_vehicle| %>
+                <%= f.fields_for "field_special_vehicles[]", field_special_vehicle do |fs| %>
+                  <tr style="border-bottom: 0px #fff;">
+                    <td> 
+                      <%= fs.label :vehicle_name %><br>
+                      <%= field_special_vehicle.vehicle_name %>
+                    </td>
+                    <td>
+                      <%= fs.label :driver_name %><br>
+                      <%= fs.select :driver_worker_id, @current_business.workers.pluck(:name, :id), { prompt: '選択してください' }, { class: "form-control" } %>
+                    </td>
+                    <td colspan="2"></td>
+                  </tr>
+                  <tr style="border-bottom: 0px #fff;">
+                    <td>
+                      <%= fs.label :vehicle_type %><br>
+                      <%= fs.select :vehicle_type, FieldSpecialVehicle.vehicle_types_i18n.invert, { prompt: true }, { class: "form-control" } %>
+                    </td>
+                    <td>
+                      <%= fs.label :carry_on_company_name %>
+                      <%= fs.text_field :carry_on_company_name, list: 'carry_on', class: "form-control" %>
+                      <datalist id="carry_on">
+                        <% @carry_on_companies.each do |company| %>
+                        <option><%= company %></option>
+                        <% end %>
+                      </datalist>
+                    </td>
+                    <td>
+                      <%= fs.label :owning_company_name %>
+                      <%= fs.text_field :owning_company_name, list: 'owning', class: "form-control" %>
+                      <datalist id="owning">
+                        <% @owning_companies.each do |company| %>
+                        <option><%= company %></option>
+                        <% end %>
+                      </datalist>
+                    </td>
+                    <td>
+                      <%= fs.label :use_company_name %>
+                      <%= fs.text_field :use_company_name, list: 'use', class: "form-control" %>
+                      <datalist id="use">
+                        <% @use_companies.each do |company| %>
+                        <option><%= company %></option>
+                        <% end %>
+                      </datalist>
+                    </td>
+                  </tr>
+                  <tr style="border: 0px #fff;">
+                    <td>
+                      <%= fs.label :carry_on_date %>
+                      <%= fs.date_field :carry_on_date, class: "form-control" %>
+                    </td>
+                    <td>
+                      <%= fs.label :carry_out_date %>
+                      <%= fs.date_field :carry_out_date, class: "form-control" %>
+                    </td>
+                    <td>
+                      <%= fs.label :use_place %>
+                      <%= fs.text_field :use_place, class: "form-control" %>
+                    </td>
+                    <td>
+                      <%= fs.label :lease_type %>
+                      <%= fs.select :lease_type, FieldSpecialVehicle.lease_types_i18n.invert, { prompt: true }, { class: "form-control" } %>
+                    </td>
+                  </tr>
+                  <tr style="border-top: 0px #fff;">
+                    <td colspan="2" >
+                      <%= fs.label :contact_prevention %>
+                      <%= fs.text_area :contact_prevention, maxlength: 40, placeholder: "40文字以内", class: "form-control" %>
+                    </td>
+                    <td colspan="2">
+                      <%= fs.label :precautions %>
+                      <%= fs.text_area :precautions, maxlength: 500, placeholder: "500文字以内", class: "form-control" %>
+                    </td>
+                  </tr>
+                <% end %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <%= f.submit yield(:btn_text), class: "btn btn-md btn-block btn-primary" %>
+      <br>
+    <% end %>
+  </div>
+</section>

--- a/app/views/users/request_orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/request_orders/field_special_vehicles/index.html.erb
@@ -1,0 +1,110 @@
+<% provide(:title,  "現場特殊車両一覧") %>
+
+<div class="card">
+  <div class="card-body table-responsive p-0">
+    <table class="table text-nowrap">
+      <tbody>
+        <td>
+          <%= link_to "現場情報詳細", users_request_order_path(@request_order), class: "btn btn-md btn-default" %>
+          <%= link_to "現場情報一覧", users_request_orders_path(@request_order), class: "btn btn-md btn-default" %>
+        </td>
+        <td>
+          <%= link_to "入場作業員", users_request_order_field_workers_path(@request_order), class: "btn btn-md btn-success" %>
+          <%= link_to "車両", users_request_order_field_cars_path(@request_order), class: "btn btn-md btn-success" %>
+          <%= link_to "特殊車両", users_request_order_field_special_vehicles_path(@request_order), class: "btn btn-md btn-success" %>
+          <%= link_to "機械", "#", class: "btn btn-md btn-success" %>
+          <%= link_to "溶剤", "#", class: "btn btn-md btn-success" %>
+        </td>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<section class="content">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-body">
+        <%= form_with url: users_request_order_field_special_vehicles_path, method: :post, local: true do |f| %>
+          <%= f.label "追加する特殊車両を選択してください。" %>
+          <div class="pb-1">
+            <%= f.collection_select :special_vehicle_ids, @special_vehicle, :id, :name, { include_hidden: false }, { required: true, multiple: true, class: "multiple-select", style: "width: 100%" } %>
+          </div>
+          <div>
+            <%= f.submit "現場特殊車両追加", class: "btn btn-md btn-primary" %>
+            <% if @field_special_vehicles.present? %>
+              <%= link_to "現場特殊車両情報編集", edit_special_vehicles_users_request_order_field_special_vehicles_path(@request_order), class: "btn btn-md btn-success" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>
+
+<br>
+<% if @field_special_vehicles.present? %>
+  <section class="content">
+    <div class="col-md-12">
+      <div class="card">
+        <div class="card-body table-responsive p-0">
+          <table class="table text-nowrap">
+            <tbody>
+              <% @field_special_vehicles.each do |field_special_vehicle| %>
+                <tr style="border-bottom: 0px #fff;">
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:vehicle_name) %><br>
+                    <%= field_special_vehicle.vehicle_name %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:driver_name) %><br>
+                    <%= not_input_display(field_special_vehicle.driver_name) %>
+                  </td>
+                  <td></td>
+                  <td>
+                    <%= link_to "削除", users_request_order_field_special_vehicle_path(@request_order, field_special_vehicle), method: :delete, data: { confirm: "#{field_special_vehicle.vehicle_name}を削除します。本当によろしいですか？" }, class: "btn btn-md btn-danger" %>                    
+                  </td>
+                </tr>
+                <tr style="border: 0px #fff;">
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:vehicle_type) %><br>
+                    <%= not_input_display(field_special_vehicle.vehicle_type_i18n) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:carry_on_company_name) %><br>
+                    <%= not_input_display(field_special_vehicle.carry_on_company_name) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:owning_company_name) %><br>
+                    <%= not_input_display(field_special_vehicle.owning_company_name) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:use_company_name) %><br>
+                    <%= not_input_display(field_special_vehicle.use_company_name) %>
+                  </td>
+                </tr>
+                <tr style="border-top: 0px #fff;">
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:carry_on_date) %><br>
+                    <%= not_input_display(field_special_vehicle.carry_on_date) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:carry_out_date) %><br>
+                    <%= not_input_display(field_special_vehicle.carry_out_date) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:use_place) %><br>
+                    <%= not_input_display(field_special_vehicle.use_place) %>
+                  </td>
+                  <td>
+                    <%= FieldSpecialVehicle.human_attribute_name(:lease_type) %><br>
+                    <%= not_input_display(field_special_vehicle.lease_type_i18n) %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/views/users/request_orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/request_orders/field_special_vehicles/index.html.erb
@@ -82,7 +82,7 @@
                     <%= not_input_display(field_special_vehicle.use_company_name) %>
                   </td>
                 </tr>
-                <tr style="border-top: 0px #fff;">
+                <tr style="border: 0px #fff;">
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:carry_on_date) %><br>
                     <%= not_input_display(field_special_vehicle.carry_on_date) %>
@@ -100,6 +100,15 @@
                     <%= not_input_display(field_special_vehicle.lease_type_i18n) %>
                   </td>
                 </tr>
+                <td colspan="2">
+                  <%= FieldSpecialVehicle.human_attribute_name(:contact_prevention) %><br>
+                  <%= not_input_display(field_special_vehicle.contact_prevention) %>
+                </td>
+                <td colspan="2">
+                  <%= FieldSpecialVehicle.human_attribute_name(:precautions) %><br>
+                  <%= not_input_display(field_special_vehicle.precautions) %>
+                </td>
+              </tr>
               <% end %>
             </tbody>
           </table>

--- a/app/views/users/request_orders/show.html.erb
+++ b/app/views/users/request_orders/show.html.erb
@@ -72,7 +72,7 @@
                   <td>
                     <%= link_to "入場作業員", users_request_order_field_workers_path(@request_order), class: "btn btn-sm btn-success" %>
                     <%= link_to "車両", users_request_order_field_cars_path(@request_order), class: "btn btn-sm btn-success" %>
-                    <%= link_to "特殊車両", "#", class: "btn btn-sm btn-success" %>
+                    <%= link_to "特殊車両", users_request_order_field_special_vehicles_path(@request_order), class: "btn btn-sm btn-success" %>
                     <%= link_to "機械", "#", class: "btn btn-sm btn-success" %>
                     <%= link_to "溶剤", "#", class: "btn btn-sm btn-success" %>
                   </td>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -166,6 +166,13 @@ ja:
         doc_22nd: 参考様式第５号(作業間連絡調整書)
         doc_23rd: 全建統一様式第８号(安全ミーティング報告書)
         doc_24th: 参考資料第４号(新規入場者調査票)
+    field_special_vehicle:
+      vehicle_type:
+        crane: 移動式クレーン
+        construction: 車両系建設機械
+      lease_type:
+        own: 自社
+        lease: リース
     news:
       status:
         draft: 下書き

--- a/config/locales/model_ja.yml
+++ b/config/locales/model_ja.yml
@@ -107,6 +107,19 @@ ja:
         waypoint_first: 経由地1
         waypoint_second: 経由地2
         arrival_point: 目的地(至)
+      field_special_vehicle:
+        driver_name: 運転者名
+        vehicle_name: 特殊車両名
+        vehicle_type: 区分
+        carry_on_company_name: 持込会社名
+        owning_company_name: 所有会社名
+        use_company_name: 使用会社名
+        carry_on_date: 持込年月日
+        carry_out_date: 搬出予定年月日
+        use_place: 使用場所
+        lease_type: リース区分
+        contact_prevention: 接触防止措置等
+        precautions: 機械等の特性・その他その使用上注意すべき事項
       field_worker:
         admission_worker_name: 作業員名
         admission_date_start: 入場年月日(始期)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,12 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
           patch 'update_cars'
         end
       end
+      resources :field_special_vehicles, except: %i[new show edit update], module: :orders, param: :uuid do
+        collection do
+          get 'edit_special_vehicles'
+          patch 'update_special_vehicles'
+        end
+      end
       resources :field_workers, except: %i[new show edit update], module: :orders, param: :uuid do
         collection do
           get 'edit_workers'
@@ -66,6 +72,12 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
         collection do
           get 'edit_cars'
           patch 'update_cars'
+        end
+      end
+      resources :field_special_vehicles, except: %i[new show edit update], module: :request_orders, param: :uuid do
+        collection do
+          get 'edit_special_vehicles'
+          patch 'update_special_vehicles'
         end
       end
       resources :field_workers, except: %i[new show edit update], module: :request_orders, param: :uuid do

--- a/db/migrate/20220909052619_create_field_special_vehicles.rb
+++ b/db/migrate/20220909052619_create_field_special_vehicles.rb
@@ -2,6 +2,11 @@ class CreateFieldSpecialVehicles < ActiveRecord::Migration[6.1]
   def change
     create_table :field_special_vehicles do |t|
       t.string :uuid, null: false
+      t.integer :driver_worker_id
+      t.string :driver_name
+      t.string :driver_license
+      t.string :vehicle_name, null: false
+      t.json :content, null: false
       t.integer :vehicle_type
       t.string :carry_on_company_name
       t.string :owning_company_name
@@ -10,8 +15,8 @@ class CreateFieldSpecialVehicles < ActiveRecord::Migration[6.1]
       t.date :carry_out_date
       t.string :use_place
       t.integer :lease_type
+      t.string :contact_prevention
       t.string :precautions
-      t.json :content
       t.references :field_special_vehicleable, polymorphic: true
       
       t.timestamps

--- a/db/migrate/20220909052619_create_field_special_vehicles.rb
+++ b/db/migrate/20220909052619_create_field_special_vehicles.rb
@@ -1,0 +1,20 @@
+class CreateFieldSpecialVehicles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :field_special_vehicles do |t|
+      t.string :uuid, null: false
+      t.integer :vehicle_type, null: false
+      t.string :carry_on_company_name, null: false
+      t.string :owning_company_name, null: false
+      t.string :use_company_name, null: false
+      t.date :carry_on_date, null: false
+      t.date :carry_out_date, null: false
+      t.string :use_place, null: false
+      t.integer :lease_type, null: false
+      t.string :precautions
+      t.json :content
+      t.references :field_special_vehicleable, polymorphic: true
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220909052619_create_field_special_vehicles.rb
+++ b/db/migrate/20220909052619_create_field_special_vehicles.rb
@@ -2,14 +2,14 @@ class CreateFieldSpecialVehicles < ActiveRecord::Migration[6.1]
   def change
     create_table :field_special_vehicles do |t|
       t.string :uuid, null: false
-      t.integer :vehicle_type, null: false
-      t.string :carry_on_company_name, null: false
-      t.string :owning_company_name, null: false
-      t.string :use_company_name, null: false
-      t.date :carry_on_date, null: false
-      t.date :carry_out_date, null: false
-      t.string :use_place, null: false
-      t.integer :lease_type, null: false
+      t.integer :vehicle_type
+      t.string :carry_on_company_name
+      t.string :owning_company_name
+      t.string :use_company_name
+      t.date :carry_on_date
+      t.date :carry_out_date
+      t.string :use_place
+      t.integer :lease_type
       t.string :precautions
       t.json :content
       t.references :field_special_vehicleable, polymorphic: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -179,6 +179,11 @@ ActiveRecord::Schema.define(version: 2022_09_09_052619) do
 
   create_table "field_special_vehicles", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "uuid", null: false
+    t.integer "driver_worker_id"
+    t.string "driver_name"
+    t.string "driver_license"
+    t.string "vehicle_name", null: false
+    t.json "content", null: false
     t.integer "vehicle_type"
     t.string "carry_on_company_name"
     t.string "owning_company_name"
@@ -187,8 +192,8 @@ ActiveRecord::Schema.define(version: 2022_09_09_052619) do
     t.date "carry_out_date"
     t.string "use_place"
     t.integer "lease_type"
+    t.string "contact_prevention"
     t.string "precautions"
-    t.json "content"
     t.string "field_special_vehicleable_type"
     t.bigint "field_special_vehicleable_id"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_31_081413) do
+ActiveRecord::Schema.define(version: 2022_09_09_052619) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "namespace"
@@ -175,6 +175,25 @@ ActiveRecord::Schema.define(version: 2022_08_31_081413) do
     t.string "driver_address"
     t.date "driver_birth_day_on"
     t.index ["field_carable_type", "field_carable_id"], name: "index_field_cars_on_field_carable"
+  end
+
+  create_table "field_special_vehicles", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.integer "vehicle_type", null: false
+    t.string "carry_on_company_name", null: false
+    t.string "owning_company_name", null: false
+    t.string "use_company_name", null: false
+    t.date "carry_on_date", null: false
+    t.date "carry_out_date", null: false
+    t.string "use_place", null: false
+    t.integer "lease_type", null: false
+    t.string "precautions"
+    t.json "content"
+    t.string "field_special_vehicleable_type"
+    t.bigint "field_special_vehicleable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["field_special_vehicleable_type", "field_special_vehicleable_id"], name: "index_field_special_vehicles_on_field_special_vehicleable"
   end
 
   create_table "field_workers", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -179,14 +179,14 @@ ActiveRecord::Schema.define(version: 2022_09_09_052619) do
 
   create_table "field_special_vehicles", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "uuid", null: false
-    t.integer "vehicle_type", null: false
-    t.string "carry_on_company_name", null: false
-    t.string "owning_company_name", null: false
-    t.string "use_company_name", null: false
-    t.date "carry_on_date", null: false
-    t.date "carry_out_date", null: false
-    t.string "use_place", null: false
-    t.integer "lease_type", null: false
+    t.integer "vehicle_type"
+    t.string "carry_on_company_name"
+    t.string "owning_company_name"
+    t.string "use_company_name"
+    t.date "carry_on_date"
+    t.date "carry_out_date"
+    t.string "use_place"
+    t.integer "lease_type"
     t.string "precautions"
     t.json "content"
     t.string "field_special_vehicleable_type"

--- a/spec/factories/field_special_vehicles.rb
+++ b/spec/factories/field_special_vehicles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :field_special_vehicle do
+    
+  end
+end

--- a/spec/factories/field_special_vehicles.rb
+++ b/spec/factories/field_special_vehicles.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     field_special_vehicleable_type { 'Order' }
     association :field_special_vehicleable, factory: :order
     uuid { SecureRandom.uuid }
+    sequence(:vehicle_name) { |n| "vehicle_name#{n}" }
+    sequence(:content) { |n| { "id": n + 1 } }
     vehicle_type { 1 }
     sequence(:carry_on_company_name) { |n| "carry_on_company_name#{n}" }
     sequence(:owning_company_name) { |n| "owning_company_name#{n}" }
@@ -17,6 +19,8 @@ FactoryBot.define do
     field_special_vehicleable_type { 'RequestOrder' }
     association :field_special_vehicleable, factory: :request_order
     uuid { SecureRandom.uuid }
+    sequence(:vehicle_name) { |n| "vehicle_name#{n}" }
+    sequence(:content) { |n| { "id": n + 1 } }
     vehicle_type { 1 }
     sequence(:carry_on_company_name) { |n| "carry_on_company_name#{n}" }
     sequence(:owning_company_name) { |n| "owning_company_name#{n}" }

--- a/spec/factories/field_special_vehicles.rb
+++ b/spec/factories/field_special_vehicles.rb
@@ -1,5 +1,29 @@
 FactoryBot.define do
-  factory :field_special_vehicle do
-    
+  factory :order_field_special_vehicle, class: 'FieldSpecialVehicle' do
+    field_special_vehicleable_type { 'Order' }
+    association :field_special_vehicleable, factory: :order
+    uuid { SecureRandom.uuid }
+    vehicle_type { 1 }
+    sequence(:carry_on_company_name) { |n| "carry_on_company_name#{n}" }
+    sequence(:owning_company_name) { |n| "owning_company_name#{n}" }
+    sequence(:use_company_name) { |n| "use_company_name#{n}" }
+    carry_on_date { '2022-01-01' }
+    carry_out_date { '2022-01-01' }
+    sequence(:use_place) { |n| "use_place#{n}" }
+    lease_type { 1 }
+  end
+
+  factory :request_order_field_special_vehicle, class: 'FieldSpecialVehicle' do
+    field_special_vehicleable_type { 'RequestOrder' }
+    association :field_special_vehicleable, factory: :request_order
+    uuid { SecureRandom.uuid }
+    vehicle_type { 1 }
+    sequence(:carry_on_company_name) { |n| "carry_on_company_name#{n}" }
+    sequence(:owning_company_name) { |n| "owning_company_name#{n}" }
+    sequence(:use_company_name) { |n| "use_company_name#{n}" }
+    carry_on_date { '2022-01-01' }
+    carry_out_date { '2022-01-01' }
+    sequence(:use_place) { |n| "use_place#{n}" }
+    lease_type { 1 }
   end
 end

--- a/spec/models/field_special_vehicle_spec.rb
+++ b/spec/models/field_special_vehicle_spec.rb
@@ -1,5 +1,182 @@
 require 'rails_helper'
 
 RSpec.describe FieldSpecialVehicle, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:order_field_special_vehicle) { build(:order_field_special_vehicle) }
+  let(:request_order_field_special_vehicle) { build(:request_order_field_special_vehicle) }
+
+  describe 'order側バリデーションについて' do
+    subject { order_field_special_vehicle }
+
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
+
+    describe '#vehicle_type' do
+      context '存在しない場合' do
+        before(:each) { subject.vehicle_type = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#carry_on_company_name' do
+      context '存在しない場合' do
+        before(:each) { subject.carry_on_company_name = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#owning_company_name' do
+      context '存在しない場合' do
+        before(:each) { subject.owning_company_name = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#use_company_name' do
+      context '存在しない場合' do
+        before(:each) { subject.use_company_name = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#carry_on_date' do
+      context '存在しない場合' do
+        before(:each) { subject.carry_on_date = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#carry_out_date' do
+      context '存在しない場合' do
+        before(:each) { subject.carry_out_date = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#use_place' do
+      context '存在しない場合' do
+        before(:each) { subject.use_place = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#lease_type' do
+      context '存在しない場合' do
+        before(:each) { subject.lease_type = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+  end
+
+  describe 'request_order側バリデーションについて' do
+    subject { request_order_field_special_vehicle }
+
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
+
+    describe '#vehicle_type' do
+      context '存在しない場合' do
+        before(:each) { subject.vehicle_type = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#carry_on_company_name' do
+      context '存在しない場合' do
+        before(:each) { subject.carry_on_company_name = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#owning_company_name' do
+      context '存在しない場合' do
+        before(:each) { subject.owning_company_name = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#use_company_name' do
+      context '存在しない場合' do
+        before(:each) { subject.use_company_name = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#carry_on_date' do
+      context '存在しない場合' do
+        before(:each) { subject.carry_on_date = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#carry_out_date' do
+      context '存在しない場合' do
+        before(:each) { subject.carry_out_date = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#use_place' do
+      context '存在しない場合' do
+        before(:each) { subject.use_place = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#lease_type' do
+      context '存在しない場合' do
+        before(:each) { subject.lease_type = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+  end
 end

--- a/spec/models/field_special_vehicle_spec.rb
+++ b/spec/models/field_special_vehicle_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FieldSpecialVehicle, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/field_special_vehicle_spec.rb
+++ b/spec/models/field_special_vehicle_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FieldSpecialVehicle, type: :model do
     it 'バリデーションが通ること' do
       expect(subject).to be_valid
     end
-    
+
     describe '#content' do
       context '存在しない場合' do
         before(:each) { subject.content = nil }
@@ -24,6 +24,60 @@ RSpec.describe FieldSpecialVehicle, type: :model do
     describe '#vehicle_name' do
       context '存在しない場合' do
         before(:each) { subject.vehicle_name = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#use_place' do
+      context '100文字の場合' do
+        before(:each) { subject.use_place = 'a' * 100 }
+
+        it 'バリデーションが通ること' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context '101文字の場合' do
+        before(:each) { subject.use_place = 'a' * 101 }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#contact_prevention' do
+      context '40文字の場合' do
+        before(:each) { subject.contact_prevention = 'a' * 40 }
+
+        it 'バリデーションが通ること' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context '41文字の場合' do
+        before(:each) { subject.contact_prevention = 'a' * 41 }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#precautions' do
+      context '500文字の場合' do
+        before(:each) { subject.precautions = 'a' * 500 }
+
+        it 'バリデーションが通ること' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context '501文字の場合' do
+        before(:each) { subject.precautions = 'a' * 501 }
 
         it 'バリデーションに落ちること' do
           expect(subject).to be_invalid
@@ -52,6 +106,60 @@ RSpec.describe FieldSpecialVehicle, type: :model do
     describe '#vehicle_name' do
       context '存在しない場合' do
         before(:each) { subject.vehicle_name = nil }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#use_place' do
+      context '100文字の場合' do
+        before(:each) { subject.use_place = 'a' * 100 }
+
+        it 'バリデーションが通ること' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context '101文字の場合' do
+        before(:each) { subject.use_place = 'a' * 101 }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#contact_prevention' do
+      context '40文字の場合' do
+        before(:each) { subject.contact_prevention = 'a' * 40 }
+
+        it 'バリデーションが通ること' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context '41文字の場合' do
+        before(:each) { subject.contact_prevention = 'a' * 41 }
+
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    describe '#precautions' do
+      context '500文字の場合' do
+        before(:each) { subject.precautions = 'a' * 500 }
+
+        it 'バリデーションが通ること' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context '501文字の場合' do
+        before(:each) { subject.precautions = 'a' * 501 }
 
         it 'バリデーションに落ちること' do
           expect(subject).to be_invalid

--- a/spec/models/field_special_vehicle_spec.rb
+++ b/spec/models/field_special_vehicle_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe FieldSpecialVehicle, type: :model do
     it 'バリデーションが通ること' do
       expect(subject).to be_valid
     end
-
-    describe '#vehicle_type' do
+    
+    describe '#content' do
       context '存在しない場合' do
-        before(:each) { subject.vehicle_type = nil }
+        before(:each) { subject.content = nil }
 
         it 'バリデーションに落ちること' do
           expect(subject).to be_invalid
@@ -21,69 +21,9 @@ RSpec.describe FieldSpecialVehicle, type: :model do
       end
     end
 
-    describe '#carry_on_company_name' do
+    describe '#vehicle_name' do
       context '存在しない場合' do
-        before(:each) { subject.carry_on_company_name = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#owning_company_name' do
-      context '存在しない場合' do
-        before(:each) { subject.owning_company_name = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#use_company_name' do
-      context '存在しない場合' do
-        before(:each) { subject.use_company_name = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#carry_on_date' do
-      context '存在しない場合' do
-        before(:each) { subject.carry_on_date = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#carry_out_date' do
-      context '存在しない場合' do
-        before(:each) { subject.carry_out_date = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#use_place' do
-      context '存在しない場合' do
-        before(:each) { subject.use_place = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#lease_type' do
-      context '存在しない場合' do
-        before(:each) { subject.lease_type = nil }
+        before(:each) { subject.vehicle_name = nil }
 
         it 'バリデーションに落ちること' do
           expect(subject).to be_invalid
@@ -99,9 +39,9 @@ RSpec.describe FieldSpecialVehicle, type: :model do
       expect(subject).to be_valid
     end
 
-    describe '#vehicle_type' do
+    describe '#content' do
       context '存在しない場合' do
-        before(:each) { subject.vehicle_type = nil }
+        before(:each) { subject.content = nil }
 
         it 'バリデーションに落ちること' do
           expect(subject).to be_invalid
@@ -109,69 +49,9 @@ RSpec.describe FieldSpecialVehicle, type: :model do
       end
     end
 
-    describe '#carry_on_company_name' do
+    describe '#vehicle_name' do
       context '存在しない場合' do
-        before(:each) { subject.carry_on_company_name = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#owning_company_name' do
-      context '存在しない場合' do
-        before(:each) { subject.owning_company_name = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#use_company_name' do
-      context '存在しない場合' do
-        before(:each) { subject.use_company_name = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#carry_on_date' do
-      context '存在しない場合' do
-        before(:each) { subject.carry_on_date = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#carry_out_date' do
-      context '存在しない場合' do
-        before(:each) { subject.carry_out_date = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#use_place' do
-      context '存在しない場合' do
-        before(:each) { subject.use_place = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
-    describe '#lease_type' do
-      context '存在しない場合' do
-        before(:each) { subject.lease_type = nil }
+        before(:each) { subject.vehicle_name = nil }
 
         it 'バリデーションに落ちること' do
           expect(subject).to be_invalid

--- a/spec/requests/field_special_vehicles_spec.rb
+++ b/spec/requests/field_special_vehicles_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "FieldSpecialVehicles", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/field_special_vehicles_spec.rb
+++ b/spec/requests/field_special_vehicles_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "FieldSpecialVehicles", type: :request do
-  describe "GET /index" do
+RSpec.describe 'FieldSpecialVehicles', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
### 概要
- 特殊車両関係書類用の現場特殊車両モデル作成

### タスク
- [ ] なし
- [x] あり https://trello.com/c/WjFIvsut

### 実装内容・手法
- FieldSpecialVehicle モデル作成
- Order(親)、RequestOrder(親)、FieldSpecialVehicle(子)としてポリモーフィック関連付けを使用
  OrderモデルとRequestOrderモデルがFieldSpecialVehicleモデルを共有する
[Railsガイドポリモーフィック関連付け](https://railsguides.jp/association_basics.html#%E3%83%9D%E3%83%AA%E3%83%A2%E3%83%BC%E3%83%95%E3%82%A3%E3%83%83%E3%82%AF%E9%96%A2%E9%80%A3%E4%BB%98%E3%81%91)
- 現場特殊車両はまとめて選択して一括で登録できる
  (同じ特殊車両が重複登録されないように、すでに登録されている特殊車両は選択欄に表示しない)。
現場特殊車両を登録した際、特殊車両(SpecialVehicle)情報をcontentカラムにjson形式でまとめて自動的に保存させる。
![無題](https://user-images.githubusercontent.com/52871417/190096229-6f8b68d1-39d9-49eb-9535-b7d4194c5921.jpg)


- その他のSpecialVehicle情報にないデータは編集画面で一括入力できる。
- モデルspec作成

### 実装画像などあれば添付する
登録前一覧画面
![一覧](https://user-images.githubusercontent.com/52871417/190099153-d1c2df38-013f-4cc4-bc78-35040c0eb75c.png)

編集画面
![編集](https://user-images.githubusercontent.com/52871417/190334384-bdb399b9-2186-4ddd-8ce4-392e755143a0.png)

登録後一覧画面
![一覧2](https://user-images.githubusercontent.com/52871417/190334421-abd335b3-d7fd-4b8e-8004-a2433bfd49d4.png)

