### PR TITLE
書類作成【(7)安全衛生管理に関する契約書(再下請会社用)】

### DIFF
--- a/app/javascript/stylesheets/users/doc_7th.scss
+++ b/app/javascript/stylesheets/users/doc_7th.scss
@@ -1,0 +1,296 @@
+.ritz .waffle .doc_7_s11 {
+  border: none;
+  background-color: #ffffff;
+  text-align: right;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s0 {
+  border: none;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s5 {
+  border: none;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s4 {
+  border: none;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s18 {
+  border: none;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s9 {
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s15 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ccffcc;
+  text-align: center;
+  -webkit-text-decoration-skip: none;
+  text-decoration-skip-ink: none;
+  font-family: 'Arial';
+  font-size: 10pt;
+  vertical-align: bottom;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s14 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s7 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s12 {
+  border-top: 1px SOLID #ffffff;
+  border-right: 1px SOLID #ccffcc;
+  border-left: 1px SOLID #ccffcc;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ccffcc;
+  text-align: center;
+  -webkit-text-decoration-skip: none;
+  text-decoration-skip-ink: none;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s1 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s3 {
+  border: none;
+  background-color: #ffffff;
+  text-align: right;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: top;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s13 {
+  border: none;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 12pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s17 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  font-weight: bold;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 16pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s8 {
+  border-top: 1px SOLID #ffffff;
+  border-right: 1px SOLID #ccffcc;
+  border-left: 1px SOLID #ccffcc;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ccffcc;
+  text-align: center;
+  -webkit-text-decoration-skip: none;
+  text-decoration-skip-ink: none;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s6 {
+  border: none;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s16 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  font-weight: bold;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 24pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s2 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: bottom;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s10 {
+  border-top: none;
+  border-right: 1px SOLID #ccffcc;
+  border-left: 1px SOLID #ccffcc;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ccffcc;
+  text-align: center;
+  -webkit-text-decoration-skip: none;
+  text-decoration-skip-ink: none;
+  font-family: 'Arial';
+  font-size: 12pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_7_s18 {
+  border: none;
+  background-color: #ffffff;
+}
+
+.ritz .waffle .doc_7_s19 {
+  border: none;
+  background-color: #ffffff;
+}
+
+.ritz .waffle .doc_7_s20 {
+  border: none;
+  background-color: #ffffff;
+}
+
+.doc_7_sheet {
+  width: 250mm;
+  height: 297mm;
+  margin-bottom: 100px;
+  size: A4;
+}

--- a/app/views/users/documents/doc_7th/_show.html.erb
+++ b/app/views/users/documents/doc_7th/_show.html.erb
@@ -1,2 +1,904 @@
 <!-- (7)安全衛生管理に関する契約書(再下請会社用) -->
-(7)安全衛生管理に関する契約書(再下請会社用)
+<div id="doc_13" class="document-outer">
+  <div class="document-inner">
+    <section class="doc_7_sheet">
+      <div class="ritz grid-container" dir="ltr">
+        <table class="waffle" cellspacing="0" cellpadding="0" style="width: 100%; zoom: 100%;">
+          <tbody style="border: none;">
+            <tr>
+              <th class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0" colspan="20"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px;">
+              <th id="1127441738R0" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s2"></td>
+              <td class="doc_7_s3 softmerge">
+                <div class="doc_7_softmerge-inner" style="width:49px;left:-12px">(再下請会社用)</div>
+              </td>
+              <td class="doc_7_s4"></td>
+              <td class="doc_7_s4"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R1" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R2" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s8" colspan="5">「提出日（西暦）」7-001</td>
+              <td class="doc_7_s7"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R3" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s9" colspan="2" rowspan="2">会 社 名</td>
+              <td class="doc_7_s10" colspan="5" rowspan="2">「元請会社名」7-002</td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R4" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s11" colspan="5"></td>
+              <td class="doc_7_s7"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R5" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R6" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s9" colspan="2" rowspan="2">工 事 名 称</td>
+              <td class="doc_7_s10" colspan="8" rowspan="2">元請会社の「工事名」7-003</td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R7" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R8" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R9" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s9" colspan="4" rowspan="2">統括安全衛生責任者</td>
+              <td class="doc_7_s12" colspan="5" rowspan="2">元請会社の「統括安全衛生責任者名」7-004</td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s13"></td>
+              <td class="doc_7_s13"></td>
+              <td class="doc_7_s13"></td>
+              <td class="doc_7_s13"></td>
+              <td class="doc_7_s13"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R10" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s14">殿</td>
+              <td class="doc_7_s5"></td>
+              <td class="doc_7_s9" colspan="2" rowspan="2">一次会社名</td>
+              <td class="doc_7_s10" colspan="6" rowspan="2">「一次会社名」7-005</td>
+              <td class="doc_7_s7"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R11" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R12" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s7"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R13" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s9" colspan="2" rowspan="2">会　社　名</td>
+              <td class="doc_7_s10" colspan="6" rowspan="2">「会社名」7-006 </td>
+              <td class="doc_7_s7"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R14" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R15" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R13" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s9" colspan="2" rowspan="2">住　　　所</td>
+              <td class="doc_7_s10" colspan="6" rowspan="2">「住所」7-007</td>
+              <td class="doc_7_s7"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R14" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R15" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R16" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s9" colspan="2" rowspan="2">代　表　者</td>
+              <td class="doc_7_s10" colspan="5" rowspan="2">「代表者名」7-008</td>
+              <td class="doc_7_s15" rowspan="2">㊞7-009</td>
+              <td class="doc_7_s7"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R17" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+              <td class="doc_7_s6"></td>
+
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R18" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R19" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R20" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s16" colspan="16" rowspan="2">安 全 衛 生 管 理 に 関 す る 契 約 書</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R21" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R22" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+              <td class="doc_7_s17"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R23" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R24" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R25" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s6" colspan="18">　　　　貴社の発注に係る上記工事の施工にあたり、下記事項を実施するとともに、労務・</td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R26" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s6" colspan="18">　　　　安全衛生に関する法令並びに貴社との基本契約書、注文書及び貴社の諸規則を順守し、</td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R27" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s6" colspan="18">　　　　労働災害の防止及び職業性疾病の予防をはかることを確約します。なお、当社の協力</td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R28" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s6" colspan="18">　　　　会社に対しても上述の措置を行わせます。</td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R29" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R30" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s7" colspan="19">記</td>
+              <td class="doc_7_s7"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R31" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R32" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">1</td>
+              <td class="doc_7_s0" colspan="15">労働者を雇入れた際及び定期に、労働安全衛生法にもとづく健康診断を必ず実施します。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R33" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">2</td>
+              <td class="doc_7_s0" colspan="16">労働安全衛生法にもとづき、安全衛生推進者、安全衛生責任者（職長兼務）、作業主任者、</td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R34" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s18"></td>
+              <td class="doc_7_s0" colspan="15">作業指揮者等の責任者・担当者を選任し、安全作業に努めます。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R35" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">3</td>
+              <td class="doc_7_s0" colspan="15">貴工事に新たに入場させる作業員には所定の新規入場教育を行います。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R36" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">4</td>
+              <td class="doc_7_s0" colspan="15">資格を要する業務には必ず有資格者を配置します。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R37" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">5</td>
+              <td class="doc_7_s0" colspan="15">女子・年少者には労働基準法（女年則）に定められた基準に基づいて作業を行わせます。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R38" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">6</td>
+              <td class="doc_7_s0" colspan="15">高年齢者の作業員を入場させる場合には、本人の健康状態を十分に確認し、高年齢者作業</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R39" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1"></td>
+              <td class="doc_7_s0" colspan="15">申告書を提出した上で作業を行わせます。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R40" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">7</td>
+              <td class="doc_7_s0" colspan="15">作業員には作業にふさわしい服装をさせ、保護帽・安全帯その他必要な保護具を正しく着用・</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R41" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0" colspan="15">使用させます。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R42" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">8</td>
+              <td class="doc_7_s0" colspan="15">現場内に設けられている手摺、開口部の蓋、ネット等の安全設備は無断で取り外し、変更は</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R43" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0" colspan="15">させません。なお、届出て取外した場合であっても必ず復旧させます。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R44" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">9</td>
+              <td class="doc_7_s0" colspan="15">現場では作業場所、通路等の整理整頓に努めさせ、毎日の作業終了後には後片付けを励行させ</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R45" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0" colspan="15">ます。退場時には異常の有無を含め作業結果を工事事務所に報告します。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R46" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">10</td>
+              <td class="doc_7_s0" colspan="15">貴工事の安全衛生協議会、安全工程打合せ、朝礼等には必ず出席させ、決定事項、打ち合わせ・</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R47" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0" colspan="15">指示事項を実施させます。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R48" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">11</td>
+              <td class="doc_7_s0" colspan="15">施工期間中は、定期的に自主安全パトロールを行い、当社傘下作業員の安全衛生指導にあたり</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R49" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0" colspan="15">ます。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s18" style="height: 19px">
+              <th id="1127441738R50" class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px"></div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s1">12</td>
+              <td class="doc_7_s0" colspan="15">労働安全衛生法に定めのある届出、貴工事の安全衛生管理上必要とする内容については、</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s19" style="height: 19px">
+              <th class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px">&emsp;</div>
+              </th>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0" colspan="15">遅滞なく報告いたします。</td>
+              <td class="doc_7_s0"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s19" style="height: 19px">
+              <th class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px">&emsp;</div>
+              </th>
+              <td class="doc_7_s0" colspan="19"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+            <tr class="doc_7_s19" style="height: 19px">
+              <th class="doc_7_s20" style="height: 19px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 19px">&emsp;</div>
+              </th>
+              <td class="doc_7_s0" colspan="19"></td>
+              <td class="doc_7_s0"></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/users/documents/doc_7th/_show.pdf.erb
+++ b/app/views/users/documents/doc_7th/_show.pdf.erb
@@ -1,1 +1,1124 @@
 <!-- (7)安全衛生管理に関する契約書(再下請会社用) -->
+<!-- (7)安全衛生管理に関する契約書(再下請会社用) -->
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+
+<body style="font-family: Noto Sans JP, Hiragino Kaku Gothic ProN, Meiryo, sans-serif;">
+  <div class="ritz grid-container" dir="ltr">
+    <table class="waffle" cellspacing="0" cellpadding="0">
+      <tbody style="border: none;">
+        <tr class="s18" style="height: 19px;">
+          <th id="1127441738R0" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s2"></td>
+          <td class="s3 softmerge">
+            <div class="softmerge-inner" style="width:49px;left:-12px">(再下請会社用)</div>
+          </td>
+          <td class="s4"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R1" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R2" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s5"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s8" colspan="5">「提出日（西暦）」7-001</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R3" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s9" colspan="2" rowspan="2">会 社 名</td>
+          <td class="s10" colspan="5" rowspan="2">「元請会社名」7-002</td>
+          <td class="s5"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R4" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s11" colspan="5"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R5" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R6" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s9" colspan="2" rowspan="2">工 事 名 称</td>
+          <td class="s10" colspan="8" rowspan="2">元請会社の「工事名」7-003</td>
+          <td class="s5"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R7" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s5"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R8" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R9" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s9" colspan="4" rowspan="2">統括安全衛生責任者</td>
+          <td class="s12" colspan="5" rowspan="2">元請会社の「統括安全衛生責任者名」7-004</td>
+          <td class="s6"></td>
+          <td class="s5"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s13"></td>
+          <td class="s13"></td>
+          <td class="s13"></td>
+          <td class="s13"></td>
+          <td class="s13"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R10" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s14">殿</td>
+          <td class="s5"></td>
+          <td class="s9" colspan="2" rowspan="2">一次会社名</td>
+          <td class="s10" colspan="6" rowspan="2">「一次会社名」7-005</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R11" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R12" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s7"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R13" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s9" colspan="2" rowspan="2">会　社　名</td>
+          <td class="s10" colspan="6" rowspan="2">「会社名」7-006</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R14" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R15" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R13" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s9" colspan="2" rowspan="2">住　　　所</td>
+          <td class="s10" colspan="6" rowspan="2">「住所」7-007</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R14" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R15" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R16" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s9" colspan="2" rowspan="2">代　表　者</td>
+          <td class="s10" colspan="5" rowspan="2">「代表者名」7-008</td>
+          <td class="s15" rowspan="2">印7-009</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R17" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+          <td class="s6"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R18" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s1"></td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R19" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R20" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s16" colspan="16" rowspan="2">安 全 衛 生 管 理 に 関 す る 契 約 書</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R21" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R22" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+          <td class="s17"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R23" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R24" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R25" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s6" colspan="18">　　　　貴社の発注に係る上記工事の施工にあたり、下記事項を実施するとともに、労務・</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R26" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s6" colspan="18">　　　　安全衛生に関する法令並びに貴社との基本契約書、注文書及び貴社の諸規則を順守し、</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R27" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s6" colspan="18">　　　　労働災害の防止及び職業性疾病の予防をはかることを確約します。なお、当社の協力</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R28" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s6" colspan="18">　　　　会社に対しても上述の措置を行わせます。</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R29" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R30" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s7" colspan="19">記</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R31" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R32" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">1</td>
+          <td class="s0" colspan="15">労働者を雇入れた際及び定期に、労働安全衛生法にもとづく健康診断を必ず実施します。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R33" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">2</td>
+          <td class="s0" colspan="16">労働安全衛生法にもとづき、安全衛生推進者、安全衛生責任者（職長兼務）、作業主任者、</td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R34" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s18"></td>
+          <td class="s0" colspan="15">作業指揮者等の責任者・担当者を選任し、安全作業に努めます。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R35" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">3</td>
+          <td class="s0" colspan="15">貴工事に新たに入場させる作業員には所定の新規入場教育を行います。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R36" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">4</td>
+          <td class="s0" colspan="15">資格を要する業務には必ず有資格者を配置します。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R37" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">5</td>
+          <td class="s0" colspan="15">女子・年少者には労働基準法（女年則）に定められた基準に基づいて作業を行わせます。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R38" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">6</td>
+          <td class="s0" colspan="15">高年齢者の作業員を入場させる場合には、本人の健康状態を十分に確認し、高年齢者作業</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R39" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1"></td>
+          <td class="s0" colspan="15">申告書を提出した上で作業を行わせます。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R40" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">7</td>
+          <td class="s0" colspan="15">作業員には作業にふさわしい服装をさせ、保護帽・安全帯その他必要な保護具を正しく着用・</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R41" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0" colspan="15">使用させます。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R42" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">8</td>
+          <td class="s0" colspan="15">現場内に設けられている手摺、開口部の蓋、ネット等の安全設備は無断で取り外し、変更は</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R43" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0" colspan="15">させません。なお、届出て取外した場合であっても必ず復旧させます。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R44" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">9</td>
+          <td class="s0" colspan="15">現場では作業場所、通路等の整理整頓に努めさせ、毎日の作業終了後には後片付けを励行させ</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R45" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0" colspan="15">ます。退場時には異常の有無を含め作業結果を工事事務所に報告します。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R46" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">10</td>
+          <td class="s0" colspan="15">貴工事の安全衛生協議会、安全工程打合せ、朝礼等には必ず出席させ、決定事項、打ち合わせ・</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R47" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0" colspan="15">指示事項を実施させます。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R48" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">11</td>
+          <td class="s0" colspan="15">施工期間中は、定期的に自主安全パトロールを行い、当社傘下作業員の安全衛生指導にあたり</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R49" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0" colspan="15">ます。</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s18" style="height: 19px">
+          <th id="1127441738R50" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px"></div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s1">12</td>
+          <td class="s0" colspan="15">労働安全衛生法に定めのある届出、貴工事の安全衛生管理上必要とする内容については、</td>
+          <td class="s0"></td>
+        </tr>
+        <tr class="s19" style="height: 19px">
+          <th id="1127441738R51" class="s20" style="height: 19px;" class="row-headers-background">
+            <div class="row-header-wrapper" style="line-height: 19px">&emsp;</div>
+          </th>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0"></td>
+          <td class="s0" colspan="15">遅滞なく報告いたします。</td>
+          <td class="s0"></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+
+<style>
+  .ritz .waffle a {
+    color: inherit;
+  }
+
+  .ritz .waffle .s11 {
+    border: none;
+    background-color: #ffffff;
+    text-align: right;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s0 {
+    border: none;
+    background-color: #ffffff;
+    text-align: left;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 11pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s5 {
+    border: none;
+    background-color: #ffffff;
+    text-align: left;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: middle;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s4 {
+    border: none;
+    background-color: #ffffff;
+    text-align: left;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 11pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s18 {
+    border: none;
+    background-color: #ffffff;
+    text-align: left;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 11pt;
+    vertical-align: middle;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s9 {
+    border-top: none;
+    border-left: none;
+    border-right: none;
+    border-bottom: 1px SOLID #000000;
+    background-color: #ffffff;
+    text-align: center;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s15 {
+    border-top: none;
+    border-right: none;
+    border-left: none;
+    border-bottom: 1px SOLID #000000;
+    background-color: #ccffcc;
+    text-align: center;
+    -webkit-text-decoration-skip: none;
+    text-decoration-skip-ink: none;
+    font-family: 'Arial';
+    font-size: 10pt;
+    vertical-align: bottom;
+    white-space: normal;
+    overflow: hidden;
+    word-wrap: break-word;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s14 {
+    border-top: none;
+    border-right: none;
+    border-left: none;
+    border-bottom: 1px SOLID #000000;
+    background-color: #ffffff;
+    text-align: left;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: middle;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s7 {
+    border: none;
+    background-color: #ffffff;
+    text-align: center;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s12 {
+    border-top: 1px SOLID #ffffff;
+    border-right: 1px SOLID #ccffcc;
+    border-left: 1px SOLID #ccffcc;
+    border-bottom: 1px SOLID #000000;
+    background-color: #ccffcc;
+    text-align: center;
+    -webkit-text-decoration-skip: none;
+    text-decoration-skip-ink: none;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: middle;
+    white-space: normal;
+    overflow: hidden;
+    word-wrap: break-word;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s1 {
+    border: none;
+    background-color: #ffffff;
+    text-align: center;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 11pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s3 {
+    border: none;
+    background-color: #ffffff;
+    text-align: right;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 11pt;
+    vertical-align: top;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s13 {
+    border: none;
+    background-color: #ffffff;
+    text-align: left;
+    color: #000000;
+    font-family: 'docs-Calibri', Arial;
+    font-size: 12pt;
+    vertical-align: middle;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s17 {
+    border: none;
+    background-color: #ffffff;
+    text-align: center;
+    font-weight: bold;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 16pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s8 {
+    border-top: 1px SOLID #ffffff;
+    border-right: 1px SOLID #ccffcc;
+    border-left: 1px SOLID #ccffcc;
+    border-bottom: 1px SOLID #000000;
+    background-color: #ccffcc;
+    text-align: center;
+    -webkit-text-decoration-skip: none;
+    text-decoration-skip-ink: none;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s6 {
+    border: none;
+    background-color: #ffffff;
+    text-align: left;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s16 {
+    border: none;
+    background-color: #ffffff;
+    text-align: center;
+    font-weight: bold;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 24pt;
+    vertical-align: middle;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s2 {
+    border: none;
+    background-color: #ffffff;
+    text-align: center;
+    color: #000000;
+    font-family: 'Arial';
+    font-size: 11pt;
+    vertical-align: bottom;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s10 {
+    border-top: none;
+    border-right: 1px SOLID #ccffcc;
+    border-left: 1px SOLID #ccffcc;
+    border-bottom: 1px SOLID #000000;
+    background-color: #ccffcc;
+    text-align: center;
+    -webkit-text-decoration-skip: none;
+    text-decoration-skip-ink: none;
+    font-family: 'Arial';
+    font-size: 12pt;
+    vertical-align: middle;
+    white-space: nowrap;
+    direction: ltr;
+    padding: 0px 3px 0px 3px;
+  }
+
+  .ritz .waffle .s18 {
+    border: none;
+    background-color: #ffffff;
+  }
+
+  .ritz .waffle .s19 {
+    border: none;
+    background-color: #ffffff;
+  }
+
+  .ritz .waffle .s20 {
+    border: none;
+    background-color: #ffffff;
+  }
+</style>

--- a/app/views/users/documents/doc_7th/_show.pdf.erb
+++ b/app/views/users/documents/doc_7th/_show.pdf.erb
@@ -1,5 +1,4 @@
 <!-- (7)安全衛生管理に関する契約書(再下請会社用) -->
-<!-- (7)安全衛生管理に関する契約書(再下請会社用) -->
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 


### PR DESCRIPTION
### 概要
- 安全衛生管理に関する契約書(再下請会社用)のページを作成

### タスク
- [ ] なし
- [x] あり https://trello.com/c/V9vSc0fB

### 実装内容・手法
- (7)安全衛生管理に関する契約書(再下請会社用)のHTMLとPDF画面を作成
- 対象ファイル
app/views/users/documents/doc_7th/_show.html.erb
app/views/users/documents/doc_7th/_show.pdf.erb

### 実装画像などあれば添付する
- 安全衛生管理に関する契約書(再下請会社用) 詳細画面
![FireShot Capture 026 - Documents - localhost](https://user-images.githubusercontent.com/52871417/194794687-6e3ad673-e7d3-4681-b1aa-7cf8ffed90b4.png)

- 安全衛生管理に関する契約書(再下請会社用) PDF
[安全衛生管理に関する契約書(再下請会社用).pdf](https://github.com/kensuma-1122/kensuma/files/9743194/default.pdf)

