### PR TITLE
移動式クレーン/車両系建設機械等使用届に情報を反映させる

### DIFF
--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -129,7 +129,7 @@ module Users
           subcon_post_code:                               current_business.post_code,                                        # 会社郵便番号
           subcon_phone_number:                            current_business.phone_number,                                     # 会社電話番号
           subcon_carrier_up_id:                           current_business.carrier_up_id,                                    # 事業所ID(キャリアアップ)
-          subcon_representative_name:                     current_business.representative_name,                              # 代表者社名
+          subcon_representative_name:                     current_business.representative_name,                              # 代表者名
           subcon_health_insurance_status:                 current_business.business_health_insurance_status,                 # 健康保険加入状況
           subcon_health_insurance_association:            current_business.business_health_insurance_association,            # 健康保険会社
           subcon_health_insurance_office_number:          current_business.business_health_insurance_office_number,          # 健康保険番号

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -6,7 +6,7 @@ module DocumentsHelper
     elsif document_info.ancestors.count > 1
       RequestOrder.find(document_info.ancestor_ids[-2]).content['subcon_name']
     elsif document_info.ancestors.count == 1
-      document_info.content['subcon_name']
+      document_info.content.nil? ? nil : document_info.content['subcon_name']
     end
   end
 
@@ -254,6 +254,15 @@ module DocumentsHelper
       fires.first.fire_managements.map(&:id).include?(num) ? tag.span(name, class: :fire_check) : name
     else
       name
+    end
+  end
+
+  # document.contentの日付データ表示
+  def doc_content_date(date)
+    if action_name == 'edit'
+      date.nil? ? '' : date # nilの場合のstrftime表示エラー回避
+    else
+      date.nil? || date == [''] || date == '' ? '年　月　日' : date.first.to_date&.strftime('%Y年%-m月%-d日')
     end
   end
 end

--- a/app/views/users/documents/doc_13th/_show.html.erb
+++ b/app/views/users/documents/doc_13th/_show.html.erb
@@ -325,9 +325,15 @@
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s20"></td>
-              <td class="doc_13_s23" dir="ltr" colspan="14" rowspan="3">「所有会社名」13-101</td>
-              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">「代表者名」13-102</td>
-              <td class="doc_13_s24" dir="ltr" colspan="2" rowspan="3">㊞13-261</td>
+              <td class="doc_13_s23" dir="ltr" colspan="14" rowspan="3">
+                <%= field_special_vehicle.owning_company_name %> <!-- 13-101 所有会社名 -->
+              </td>
+              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">
+                <!-- 13-102 代表者名 ※未実装※ -->
+              </td>
+              <td class="doc_13_s24" dir="ltr" colspan="2" rowspan="3">
+                ㊞ <!-- 13-261 印 -->
+              </td>
               <td class="doc_13_s5"></td>
               <td class="doc_13_s22" colspan="7">(２) 移動式クレーン</td>
             </tr>
@@ -1405,10 +1411,14 @@
               <td class="doc_13_s8" colspan="6" rowspan="4">任 意 保 険</td>
               <td class="doc_13_s8" colspan="4" rowspan="4">加入額</td>
               <td class="doc_13_s8" colspan="3" rowspan="2">対人</td>
-              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対人」13-030</td>
+              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">
+                <%= field_special_vehicle.content&.[]("personal_insurance") %> <!-- 13-030 任意保険加入額・対人 -->
+              </td>
               <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
               <td class="doc_13_s8" colspan="3" rowspan="2">搭乗者</td>
-              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・搭乗者」13-032</td>
+              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">
+                <%= field_special_vehicle.content&.[]("passenger_insurance") %> <!-- 13-032 任意保険加入額・搭乗者 -->
+              </td>
               <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
               <td class="doc_13_s8" colspan="7" rowspan="2">有 効 期 限</td>
               <td class="doc_13_s4"></td>
@@ -1419,14 +1429,22 @@
               <td class="doc_13_s28" rowspan="3">点検日</td>
               <td class="doc_13_s42" colspan="6">年 月 日</td>
               <td class="doc_13_s28" rowspan="3">点検者</td>
-              <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">「(a)点検年月日」13-256</td>
-              <td class="doc_13_s43" dir="ltr" rowspan="3">㊞13-262</td>
+              <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">
+                <!-- 13-256 (a)点検年月日 ※未実装※ -->
+              </td>
+              <td class="doc_13_s43" dir="ltr" rowspan="3">
+                ㊞ <!-- 13-262 印 -->
+              </td>
               <td class="doc_13_s21" rowspan="3">(b)</td>
               <td class="doc_13_s28" rowspan="3">点検日</td>
               <td class="doc_13_s42" colspan="6">年 月 日</td>
               <td class="doc_13_s28" rowspan="3">点検者</td>
-              <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">「(b)点検者名」13-258</td>
-              <td class="doc_13_s43" dir="ltr" rowspan="3">㊞13-263</td>
+              <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">
+                <!-- 13-258 (b)点検者名 ※未実装※ -->
+              </td>
+              <td class="doc_13_s43" dir="ltr" rowspan="3">
+                ㊞ <!-- 13-263 印 -->
+              </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s22" colspan="7">(40) 鉄骨切断機</td>
             </tr>
@@ -1439,8 +1457,12 @@
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s20"></td>
-              <td class="doc_13_s38" dir="ltr" colspan="6" rowspan="2">「(a)点検年月日」13-255</td>
-              <td class="doc_13_s38" dir="ltr" colspan="6" rowspan="2">「(b)点検年月日」13-257</td>
+              <td class="doc_13_s38" dir="ltr" colspan="6" rowspan="2">
+                <!-- 13-255 (a)点検年月日 ※未実装※ --> 
+              </td>
+              <td class="doc_13_s38" dir="ltr" colspan="6" rowspan="2">
+                <!-- 13-257 (b)点検年月日 ※未実装※ -->
+              </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s22" colspan="7">(41) 解体用つかみ機</td>
             </tr>
@@ -1450,12 +1472,18 @@
               </th>
               <td class="doc_13_s7"></td>
               <td class="doc_13_s8" colspan="3" rowspan="2">対物</td>
-              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対物」13-031</td>
+              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">
+                <%= field_special_vehicle.content&.[]("objective_insurance") %> <!-- 13-031 任意保険加入額・対物 -->
+              </td>
               <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
               <td class="doc_13_s8" colspan="3" rowspan="2">その他</td>
-              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・その他」13-033</td>
+              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">
+                <%= field_special_vehicle.content&.[]("other_insurance") %> <!-- 13-033 任意保険加入額・その他 -->
+              </td>
               <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
-              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="2">「有効期限」13-034</td>
+              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="2">
+                <%= field_special_vehicle.content&.[]("exp_date_insurance").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-034 有効期限 -->
+              </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
@@ -1544,7 +1572,9 @@
               </th>
               <td class="doc_13_s7"></td>
               <td class="doc_13_s8" colspan="6" rowspan="8">機械等の特性<br> ・その他その<br> 使用上注意す<br> べき事項</td>
-              <td class="doc_13_s23" dir="ltr" colspan="31" rowspan="8">「機械等の特性・その他その使用上注意すべき事項」13-036</td>
+              <td class="doc_13_s23" dir="ltr" colspan="31" rowspan="8">
+                <%= field_special_vehicle.precautions %> <!-- 13-036 機械等の特性・その他その使用上注意すべき事項 -->
+              </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
@@ -1751,10 +1781,18 @@
               </th>
               <td class="doc_13_s7"></td>
               <td class="doc_13_s8" colspan="2" rowspan="3">担当者</td>
-              <td class="doc_13_s23" dir="ltr" colspan="11" rowspan="3">「元請確認欄・担当者」13-037</td>
-              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">「受付番号」13-038</td>
-              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3">「受付確認年月日」13-039</td>
-              <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3">「受付確認者」13-040</td>
+              <td class="doc_13_s23" dir="ltr" colspan="11" rowspan="3">
+                <!-- 13-037 元請確認欄・担当者 ※未実装※ -->
+              </td>
+              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">
+                <!-- 13-038 受付番号 ※未実装※ -->
+              </td>
+              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3">
+                <!-- 13-039 受付確認年月日 ※未実装※ -->
+              </td>
+              <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3">
+                <!-- 13-040 受付確認者 ※未実装※ -->
+              </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>

--- a/app/views/users/documents/doc_13th/_show.html.erb
+++ b/app/views/users/documents/doc_13th/_show.html.erb
@@ -1,1803 +1,1851 @@
 <!-- (13)全建統一様式第9号([移動式クレーン／車両系建設機械等]使用届) -->
-<div id="doc_13" style="overflow: auto;">
-  <section class="doc_13_sheet">
-    <div class="ritz grid-container" dir="ltr">
-      <table class="waffle no-grid" style="width: 100%; zoom: 50%;">
-        <tbody>
-          <tr style="height: 22px">
-            <th id="1612125903R0" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s1"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R1" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="9">全建統一様式第９号</td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R2" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s9" colspan="7" rowspan="2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s10" dir="ltr" colspan="8">「提出日（西暦）」13-001</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s11" colspan="5" rowspan="2">持込時の点検表</td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s12" colspan="6"></td>
-            <td class="doc_13_s12" colspan="10"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s13"></td>
-            <td class="doc_13_s13"></td>
-            <td class="doc_13_s13"></td>
-            <td class="doc_13_s13"></td>
-            <td class="doc_13_s13"></td>
-            <td class="doc_13_s13"></td>
-            <td class="doc_13_s13"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R3" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s14" colspan="9" rowspan="2">移動式クレーン</td>
-            <td class="doc_13_s15" colspan="2" rowspan="4">等</td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s15" colspan="4" rowspan="4">使用届</td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s16"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s16"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s17" colspan="7">機 械 名</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R4" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s18" colspan="6" rowspan="2"></td>
-            <td class="doc_13_s19"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s21" colspan="14">所 有 会 社 名</td>
-            <td class="doc_13_s21" colspan="14">代 表 者 名</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(１) クレーン</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R5" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s18"></td>
-            <td class="doc_13_s18"></td>
-            <td class="doc_13_s18"></td>
-            <td class="doc_13_s19"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s14" colspan="9" rowspan="2">車両系建設機械</td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s23" dir="ltr" colspan="14" rowspan="3">「所有会社名」13-101</td>
-            <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">「代表者名」13-102</td>
-            <td class="doc_13_s24" dir="ltr" colspan="2" rowspan="3">㊞13-261</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(２) 移動式クレーン</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R6" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s6"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(３) デリック</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R7" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(４) エレベーター</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R8" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0" colspan="5" rowspan="2">事業所の名称</td>
-            <td class="doc_13_s25" dir="ltr" colspan="13" rowspan="2">
-              <%= document_site_info.site_name %> <!-- 13-003 事業所名(現場名) -->
-            </td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s0" colspan="5" rowspan="2">一次会社名</td>
-            <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">
-              <%= primary_subcon_name(document_info) %> <!-- 13-005 一次会社名 -->
-            </td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s21" colspan="14">移動式クレーン等</td>
-            <td class="doc_13_s21" colspan="14">車両系建設機械等</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(５) 建設用リフト</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R9" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s21" colspan="10" rowspan="2">点検事項</td>
-            <td class="doc_13_s21" colspan="4">点検結果</td>
-            <td class="doc_13_s21" colspan="10" rowspan="2">点検事項</td>
-            <td class="doc_13_s21" colspan="4">点検結果</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(６) 高所作業車</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R10" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s0" colspan="5" rowspan="2">所 長 名</td>
-            <td class="doc_13_s26" dir="ltr" colspan="11" rowspan="2">
-              <%= document_site_info.site_agent_name %> <!-- 13-004 元請会社の現場代理人名 -->
-            </td>
-            <td class="doc_13_s1" colspan="2" rowspan="2">殿</td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s0" colspan="5">持込会社名</td>
-            <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">
-              <%= document_info.content&.[]('subcon_name') %> <!-- 13-007 持込会社名(自社名) -->
-            </td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s21" colspan="2">(a)</td>
-            <td class="doc_13_s21" colspan="2">(b)</td>
-            <td class="doc_13_s21" colspan="2">(a)</td>
-            <td class="doc_13_s21" colspan="2">(b)</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(７) ゴンドラ</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R11" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s0"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s0">（</td>
-            <td class="doc_13_s27" dir="ltr" colspan="3">
-              <%= sc_hierarchy(document_info) %> <!-- 13-006 次 -->
-            </td>
-            <td class="doc_13_s0">）</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s28" colspan="2" rowspan="17">Ａクレーン部（上部旋回体）</td>
-            <td class="doc_13_s28" rowspan="5">安全装置</td>
-            <td class="doc_13_s29" colspan="7">巻過防止装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-111</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-183</td>
-            <td class="doc_13_s28" colspan="2" rowspan="10">Ｄ安全装置</td>
-            <td class="doc_13_s28" rowspan="6">各種ロック</td>
-            <td class="doc_13_s29" colspan="7">旋回</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-147</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-219</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(８) ブル・ドーザー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R12" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s0" colspan="5" rowspan="2">代 表 者 名</td>
-            <td class="doc_13_s25" dir="ltr" colspan="10" rowspan="2">
-              <%= document_info.content&.[]('subcon_representative_name') %> <!-- 13-008 持込会社の代表者名 -->
-            </td>
-            <td class="doc_13_s31" dir="ltr" colspan="2" rowspan="2">㊞13-259</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">過負荷防止装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-112</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-184</td>
-            <td class="doc_13_s29" colspan="7">バケット</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-148</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-220</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(９) モーター・グレーダー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R13" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">フックのはずれ止め</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-113</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-185</td>
-            <td class="doc_13_s29" colspan="7">ブーム・アーム</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-149</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-221</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(10) トラクターショベル</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R14" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s0" colspan="5" rowspan="2">電　　話</td>
-            <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">持込会社の「電話番号」13-009</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">起伏装置制御</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-114</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-186</td>
-            <td class="doc_13_s32" dir="ltr" colspan="7">「追加項目内容①」13-103</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-150</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-222</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(11) ずり積機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R15" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">旋回警報装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-115</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-187</td>
-            <td class="doc_13_s32" dir="ltr" colspan="7">「追加項目内容②」13-104</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-151</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-223</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(12) スクレーパー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R16" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s2"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s28" rowspan="9">制御装置・作業装置</td>
-            <td class="doc_13_s29" colspan="7">主巻・補巻</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-116</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-188</td>
-            <td class="doc_13_s32" dir="ltr" colspan="7">「追加項目内容③」13-105</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-152</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-224</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(13) スクレープ・ドーザー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R17" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3" colspan="37">このたび、下記機械等を裏面の点検表により、点検整備のうえ持込・使用しますので、お届けします。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">起伏・旋回</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-117</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-189</td>
-            <td class="doc_13_s29" colspan="8">警報装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-153</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-225</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(14) パワー・ショベル</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R18" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s3" colspan="37">なお、使用に際しては関係法令に定められた事項を遵守します。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">クラッチ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-118</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-190</td>
-            <td class="doc_13_s29" colspan="8">アウトリガー</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-154</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-226</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(15) ドラグ・ショベル</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R19" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s3"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s11"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">ブレーキ・ロック</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-119</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-191</td>
-            <td class="doc_13_s29" colspan="8">ヘッドガード</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-155</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-227</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">　（油圧ショベル）</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R20" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="20" rowspan="2">使用会社名</td>
-            <td class="doc_13_s8" colspan="17" rowspan="2">代表者名</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">ジブ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-120</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-192</td>
-            <td class="doc_13_s29" colspan="8">照明</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-156</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-228</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(16) ドラグライン</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R21" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">滑車</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-121</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-193</td>
-            <td class="doc_13_s28" colspan="2" rowspan="10">Ｅ作業装置</td>
-            <td class="doc_13_s29" colspan="8">操作装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-157</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-229</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(17) クラムシェル</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R22" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s23" colspan="20" rowspan="3"></td>
-            <td class="doc_13_s25" dir="ltr" colspan="15" rowspan="3">使用会社の「代表者名」13-011</td>
-            <td class="doc_13_s24" dir="ltr" colspan="2" rowspan="3">㊞13-260</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">フック・バケット</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-122</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-194</td>
-            <td class="doc_13_s29" colspan="8">バケット・ブレード</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-158</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-230</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(18) バケット掘削機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R23" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">ワイヤロープ・チェーン</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-123</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-195</td>
-            <td class="doc_13_s29" colspan="8">ブーム・アーム</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-159</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-231</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(19) トレンチャー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R24" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">玉掛用具</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-124</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-196</td>
-            <td class="doc_13_s29" colspan="8">ジブ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-160</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-232</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(20) コンクリート圧砕機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R25" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s33"></td>
-            <td class="doc_13_s34" colspan="6" rowspan="3"></td>
-            <td class="doc_13_s8" colspan="5" rowspan="3">名　称</td>
-            <td class="doc_13_s8" colspan="7" rowspan="3">メーカー</td>
-            <td class="doc_13_s8" colspan="12" rowspan="3">規　格 ・ 性　能</td>
-            <td class="doc_13_s8" colspan="3" rowspan="3">製造年</td>
-            <td class="doc_13_s8" colspan="4" rowspan="3">管理番号<br> (整理番号)</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s28" rowspan="3">その他</td>
-            <td class="doc_13_s29" colspan="7">操作装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-125</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-197</td>
-            <td class="doc_13_s29" colspan="8">リーダ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-161</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-233</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(21) くい打機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R26" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s33"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">性能表示</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-126</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-198</td>
-            <td class="doc_13_s29" colspan="8">ハンマ・オーガ・バイブロ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-162</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-234</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(22) くい抜機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R27" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s33"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">照明</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-127</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-199</td>
-            <td class="doc_13_s29" colspan="8">油圧駆動装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-163</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-235</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(23) アース・ドリル</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R28" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="6" rowspan="3">機　　械</td>
-            <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3">「機械の名称」13-012</td>
-            <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3">「機械のメーカー」13-013</td>
-            <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">「機械の規格・性能」13-014</td>
-            <td class="doc_13_s37" dir="ltr" colspan="2" rowspan="3">「機械の製造年」13-015</td>
-            <td class="doc_13_s34" rowspan="3">年</td>
-            <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">「機械の管理番号(整理番号)」13-016</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s28" colspan="2" rowspan="14">Ｂ車両部（下部走行体）</td>
-            <td class="doc_13_s28" rowspan="5">走行部</td>
-            <td class="doc_13_s29" colspan="7">ブレーキ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-128</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-200</td>
-            <td class="doc_13_s29" colspan="8">ワイヤロープ・チェーン</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-164</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-236</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(24) リバース・サーキュレー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R29" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">クラッチ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-129</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-201</td>
-            <td class="doc_13_s29" colspan="8">吊り具等</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-165</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-237</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">ション・ドリル</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R30" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">ハンドル</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-130</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-202</td>
-            <td class="doc_13_s29" colspan="8">滑車</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-166</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-238</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(25) せん孔機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R31" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="6" rowspan="2">持 込 年 月 日</td>
-            <td class="doc_13_s23" dir="ltr" colspan="7" rowspan="2">「持込年月日」13-017</td>
-            <td class="doc_13_s8" colspan="5" rowspan="4">使用場所</td>
-            <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="4">「使用場所」13-019</td>
-            <td class="doc_13_s8" colspan="7" rowspan="2">自社・リースの区別</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">タイヤ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-131</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-203</td>
-            <td class="doc_13_s28" colspan="2" rowspan="7">Ｆ走行部</td>
-            <td class="doc_13_s29" colspan="8">ブレーキ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-167</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-239</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(26) アース・オーガー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R32" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35" colspan="2" rowspan="4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">クローラ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-132</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-204</td>
-            <td class="doc_13_s29" colspan="8">駐車ブレーキ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-168</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-240</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(27) ペーパー・ドレーン・</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R33" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="6" rowspan="2">搬出予定年月日</td>
-            <td class="doc_13_s38" dir="ltr" colspan="7" rowspan="2">「搬出予定年月日」13-018</td>
-            <td class="doc_13_s23" colspan="7" rowspan="2">自社・リース</td>
-            <td class="doc_13_s0" rowspan="2"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s28" rowspan="9">安全装置等</td>
-            <td class="doc_13_s29" colspan="7">警報装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-133</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-205</td>
-            <td class="doc_13_s29" colspan="8">ブレーキロック</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-169</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-241</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">　　マシン</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R34" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">各種ミラー</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-134</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-206</td>
-            <td class="doc_13_s29" colspan="8">クラッチ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-170</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-242</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(28) 地下連続壁施工機械</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R35" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="6" rowspan="6">運　転　者<br> （取　扱　者）</td>
-            <td class="doc_13_s8" colspan="12" rowspan="2">氏 名</td>
-            <td class="doc_13_s8" colspan="19" rowspan="2">資 格 の 種 類</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">方向指示器</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-135</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-207</td>
-            <td class="doc_13_s29" colspan="8">操縦装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-171</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-243</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(29) ローラー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R36" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">前後照灯</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-136</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-208</td>
-            <td class="doc_13_s29" colspan="8">タイヤ・鉄輪</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-172</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-244</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(30) クローラドリル</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R37" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="2">「入場する作業員名」13-021</td>
-            <td class="doc_13_s23" dir="ltr" colspan="19" rowspan="2">「資格の種類」13-022</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">左折プロテクター</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-137</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-209</td>
-            <td class="doc_13_s29" colspan="8">クローラ</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-173</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-245</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(31) ドリルジャンボ</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R38" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">アウトリガー</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-138</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-210</td>
-            <td class="doc_13_s28" colspan="2" rowspan="5">Ｇ電気装置</td>
-            <td class="doc_13_s29" colspan="8">配電盤</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-174</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-246</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(32) ロードヘッダー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R39" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="2">「入場する作業員名」13-023</td>
-            <td class="doc_13_s23" dir="ltr" colspan="19" rowspan="2">「資格の種類」13-024</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">昇降装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-139</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-211</td>
-            <td class="doc_13_s29" colspan="8">配線</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-175</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-247</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(33) アスファルトフイニッ</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R40" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">ベッセル</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-140</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-212</td>
-            <td class="doc_13_s29" colspan="8">絶縁</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-176</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-248</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">　　シャー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R41" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s39"></td>
-            <td class="doc_13_s40" colspan="2" rowspan="6">自主検査　有効期限<br></td>
-            <td class="doc_13_s8" colspan="2" rowspan="4">定 期</td>
-            <td class="doc_13_s8" colspan="2" rowspan="2">年次</td>
-            <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">「自主検査有効期限・定期・年次」13-025</td>
-            <td class="doc_13_s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
-            <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">「移動式クレーン等の性能検査有効期限」13-028</td>
-            <td class="doc_13_s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
-            <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">「自動車検査証有効期限」13-029</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s35"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">後方監視装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-141</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-213</td>
-            <td class="doc_13_s29" colspan="8">アース</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-177</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-249</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(34) スタビライザ</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R42" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s39"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s28" colspan="2" rowspan="5">Ｃゴンドラ</td>
-            <td class="doc_13_s28" rowspan="5"></td>
-            <td class="doc_13_s29" colspan="7">突りょう</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-142</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-214</td>
-            <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目④」13-106</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-178</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-250</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(35) ロードプレーナ</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R43" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s39"></td>
-            <td class="doc_13_s8" colspan="2" rowspan="2">月次</td>
-            <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">「自主検査有効期限・定期・月次」13-026</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">作業床</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-143</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-215</td>
-            <td class="doc_13_s28" colspan="2" rowspan="4">Ｈその他</td>
-            <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目⑤」13-107</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-179</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-251</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(36) ロードカッター</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R44" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s39"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">昇降装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-144</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-216</td>
-            <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目⑥」13-108</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-180</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-252</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(37) コンクリート吹付機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R45" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s39"></td>
-            <td class="doc_13_s8" colspan="4" rowspan="2">特 定</td>
-            <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">「自主検査有効期限・特定」13-027</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">電気装置</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-145</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-217</td>
-            <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目⑦」13-109</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-181</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-253</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(38) ボーリングマシーン</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R46" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s39"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s29" colspan="7">ワイヤ・ライフライン</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-146</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-218</td>
-            <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目⑧」13-110</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-182</td>
-            <td class="doc_13_s30" dir="ltr" colspan="2">13-254</td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s22" colspan="7">(39) ブレーカ</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R47" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="6" rowspan="4">任 意 保 険</td>
-            <td class="doc_13_s8" colspan="4" rowspan="4">加入額</td>
-            <td class="doc_13_s8" colspan="3" rowspan="2">対人</td>
-            <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対人」13-030</td>
-            <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
-            <td class="doc_13_s8" colspan="3" rowspan="2">搭乗者</td>
-            <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・搭乗者」13-032</td>
-            <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
-            <td class="doc_13_s8" colspan="7" rowspan="2">有 効 期 限</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s21" rowspan="3">(a)</td>
-            <td class="doc_13_s28" rowspan="3">点検日</td>
-            <td class="doc_13_s42" colspan="6">年 月 日</td>
-            <td class="doc_13_s28" rowspan="3">点検者</td>
-            <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">「(a)点検年月日」13-256</td>
-            <td class="doc_13_s43" dir="ltr" rowspan="3">㊞13-262</td>
-            <td class="doc_13_s21" rowspan="3">(b)</td>
-            <td class="doc_13_s28" rowspan="3">点検日</td>
-            <td class="doc_13_s42" colspan="6">年 月 日</td>
-            <td class="doc_13_s28" rowspan="3">点検者</td>
-            <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">「(b)点検者名」13-258</td>
-            <td class="doc_13_s43" dir="ltr" rowspan="3">㊞13-263</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(40) 鉄骨切断機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R48" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s38" dir="ltr" colspan="6" rowspan="2">「(a)点検年月日」13-255</td>
-            <td class="doc_13_s38" dir="ltr" colspan="6" rowspan="2">「(b)点検年月日」13-257</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(41) 解体用つかみ機</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R49" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="3" rowspan="2">対物</td>
-            <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対物」13-031</td>
-            <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
-            <td class="doc_13_s8" colspan="3" rowspan="2">その他</td>
-            <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・その他」13-033</td>
-            <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
-            <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="2">「有効期限」13-034</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s20"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(42) 重ダンプトラック</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R50" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s5"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(43) ダンプトラック</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R51" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="6" rowspan="2">接触防止措置等</td>
-            <td class="doc_13_s23" dir="ltr" colspan="31" rowspan="2">「有効期限」13-035</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s45" colspan="2">（注）</td>
-            <td class="doc_13_s45" colspan="2">１．</td>
-            <td class="doc_13_s22" colspan="24">持込機械等の届け出は、当該機械を持ち込む会社（貸与を受けた会社が下請の場合</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(44) トラックミキサー</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R52" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22" colspan="2"></td>
-            <td class="doc_13_s22" colspan="24">はその会社）の代表者が所長に届け出ること。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(45) 散水車</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R53" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="6" rowspan="8">機械等の特性<br> ・その他その<br> 使用上注意す<br> べき事項</td>
-            <td class="doc_13_s23" dir="ltr" colspan="31" rowspan="8">「機械等の特性・その他その使用上注意すべき事項」13-036</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s45" colspan="2">２．</td>
-            <td class="doc_13_s22" colspan="24">点検表の点検結果欄には、該当する箇所へ✔印を記入すること。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(46) 不整地運搬車</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R54" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s45" colspan="2">３．</td>
-            <td class="doc_13_s22" colspan="24">自社の点検表にて点検したものは、その点検表を貼付する（転記の必要はなし）。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(47) コンクリートポンプ車</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R55" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s45" colspan="2">４．</td>
-            <td class="doc_13_s22" colspan="24">機械名（１）から（６）まではＡ、Ｂ欄を、（７）はＣ欄を、（８）から（42）ま</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22" colspan="7">(48) その他</td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R56" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22" colspan="2"></td>
-            <td class="doc_13_s22" colspan="24">ではＤ、Ｅ、Ｆ、Ｇ欄を、（43）から（47）まではＢ欄を、（48）はＢ、Ｄ、Ｅ欄</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R57" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22" colspan="2"></td>
-            <td class="doc_13_s22" colspan="24">を使用して点検すること。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R58" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s45" colspan="2">５．</td>
-            <td class="doc_13_s22" colspan="24">点検結果の（ａ）は、機械所有会社の確認欄とし、（ｂ）は持込会社又は機械使用</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R59" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22"></td>
-            <td class="doc_13_s22" colspan="2"></td>
-            <td class="doc_13_s22" colspan="24">会社の確認欄とする。元請が確認するときは、（ｂ）欄を利用すること。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R60" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s45" colspan="2">６．</td>
-            <td class="doc_13_s22" colspan="24">場内搬入後、持込機械届済証を当該機械に貼付すること。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R61" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="13" rowspan="2">元 請 確 認 欄</td>
-            <td class="doc_13_s8" colspan="12" rowspan="2">受 付 番 号</td>
-            <td class="doc_13_s8" colspan="12" rowspan="2">受 付 確 認 者</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s45" colspan="2">７．</td>
-            <td class="doc_13_s22" colspan="24">直近に実施した特定（年次）及び月例の定期自主検査帳票の写し、任意保険（移動</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R62" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s45" colspan="2"></td>
-            <td class="doc_13_s22" colspan="24">式クレーンの場合）の写しを必ず添付すること。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R63" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s8" colspan="2" rowspan="3">担当者</td>
-            <td class="doc_13_s23" dir="ltr" colspan="11" rowspan="3">「元請確認欄・担当者」13-037</td>
-            <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">「受付番号」13-038</td>
-            <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3">「受付確認年月日」13-039</td>
-            <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3">「受付確認者」13-040</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s45" colspan="2">８．</td>
-            <td class="doc_13_s22" colspan="24">資格を必要とする建設機械運転者等には作業中、必ず運転免許等の資格証を携帯さ</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R64" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s45" colspan="2"></td>
-            <td class="doc_13_s22" colspan="24">せること。</td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-          <tr style="height: 22px">
-            <th id="1612125903R65" style="height: 22px;" class="row-headers-background">
-              <div class="row-header-wrapper" style="line-height: 22px"></div>
-            </th>
-            <td class="doc_13_s7"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s44"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s46"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s47"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-            <td class="doc_13_s4"></td>
-          </tr>
-        </tbody>
-      </table>
-      <div class="doc_13th_image">
-        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAABkCAYAAAA8AQ3AAAAFFElEQVR4Xu3XPy+kexjH4Z9kQyIhJKYYU/AK6DRK7wWVQkQkiskUOtTiBWkVOg0SfxITIjQG8RyzOVtxCs99cmdn95Jstth83Y/rmXxih4ovAgQIDIjA0IA8p8ckQIBAESwfAgIEBkZAsAbmVXlQAgQEy2eAAIGBERCsgXlVHpQAAcHyGSBAYGAEBGtgXpUHJUBAsHwGCBAYGAHBGphX5UEJEKgdrL29ver6+rr0/zw9PZWLi4svNU9OTmrf8HoIEPi9BRYXF6vHx8cvH7LRaJRms1mmpqZKq9Uqm5ub4RZ8+xvMzc1Vp6enZXp6uszMzJTR0dGfDzM+Pl6qqvr04B9h+/aN3/sVeToCBH4JbG1tVb1e70uQbrdb7u/vS//f+7/QXF5elre3t7KwsFCOjo5qdaHOqNrY2Ci7u7t1tt40AQJ/sUCn06na7XZfoFY/6ox+Hvw4XGf7F78qPzoBAv8K9P8rVqsfdUaC5XNHgEAtgcPDw2p5edlvWLX0jAgQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIH/QaD6+B5Ddb5PnVHVbrdLp9Ops63zjDYECPwhAvv7+9X6+nr/p6nVjzqjant7u+zs7NTZ/iHsfgwCBH4JHBwc9H9j+vT1+vparq6uSq/XK91ut9ze3pbj4+Py/v5e7u7uavXj26NGo1GNjY2VpaWl0v97ZGSktFqtMjw8XKrq83OvrKx8+4aPAgECgyEwMTFRPTw8fPmwH60ozWaz/Pjxo8zOzpbJyckyPz9f1tbWajeh1nB1dbU6OzsrNzc35fn5uZyfn5eXl5f/Eq51YzBel6ckQCBTQEwytd0iQCAkIFghPmMCBDIFBCtT2y0CBEICghXiMyZAIFNAsDK13SJAICQgWCE+YwIEMgUEK1PbLQIEQgKCFeIzJkAgU0CwMrXdIkAgJCBYIT5jAgQyBQQrU9stAgRCAoIV4jMmQCBTQLAytd0iQCAk8A8IBa+DqEh0OQAAAABJRU5ErkJggg==">
+<% document_info.field_special_vehicles.each do |field_special_vehicle| %>
+  <div id="doc_13" style="overflow: auto;">
+    <section class="doc_13_sheet">
+      <div class="ritz grid-container" dir="ltr">
+        <table class="waffle no-grid" style="width: 100%; zoom: 50%;">
+          <tbody>
+            <tr style="height: 22px">
+              <th id="1612125903R0" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s1"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R1" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="9">全建統一様式第９号</td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R2" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s9" colspan="7" rowspan="2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s10" dir="ltr" colspan="8">「提出日（西暦）」13-001</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s11" colspan="5" rowspan="2">持込時の点検表</td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s12" colspan="6"></td>
+              <td class="doc_13_s12" colspan="10"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s13"></td>
+              <td class="doc_13_s13"></td>
+              <td class="doc_13_s13"></td>
+              <td class="doc_13_s13"></td>
+              <td class="doc_13_s13"></td>
+              <td class="doc_13_s13"></td>
+              <td class="doc_13_s13"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R3" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s14" colspan="9" rowspan="2">移動式クレーン</td>
+              <td class="doc_13_s15" colspan="2" rowspan="4">等</td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s15" colspan="4" rowspan="4">使用届</td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s16"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s16"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s17" colspan="7">機 械 名</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R4" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s18" colspan="6" rowspan="2"></td>
+              <td class="doc_13_s19"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s21" colspan="14">所 有 会 社 名</td>
+              <td class="doc_13_s21" colspan="14">代 表 者 名</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(１) クレーン</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R5" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s18"></td>
+              <td class="doc_13_s18"></td>
+              <td class="doc_13_s18"></td>
+              <td class="doc_13_s19"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s14" colspan="9" rowspan="2">車両系建設機械</td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s23" dir="ltr" colspan="14" rowspan="3">「所有会社名」13-101</td>
+              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">「代表者名」13-102</td>
+              <td class="doc_13_s24" dir="ltr" colspan="2" rowspan="3">㊞13-261</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(２) 移動式クレーン</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R6" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s6"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(３) デリック</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R7" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(４) エレベーター</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R8" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0" colspan="5" rowspan="2">事業所の名称</td>
+              <td class="doc_13_s25" dir="ltr" colspan="13" rowspan="2">
+                <%= document_site_info.site_name %> <!-- 13-003 事業所名(現場名) -->
+              </td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s0" colspan="5" rowspan="2">一次会社名</td>
+              <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">
+                <%= primary_subcon_name(document_info) %> <!-- 13-005 一次会社名 -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s21" colspan="14">移動式クレーン等</td>
+              <td class="doc_13_s21" colspan="14">車両系建設機械等</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(５) 建設用リフト</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R9" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s21" colspan="10" rowspan="2">点検事項</td>
+              <td class="doc_13_s21" colspan="4">点検結果</td>
+              <td class="doc_13_s21" colspan="10" rowspan="2">点検事項</td>
+              <td class="doc_13_s21" colspan="4">点検結果</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(６) 高所作業車</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R10" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s0" colspan="5" rowspan="2">所 長 名</td>
+              <td class="doc_13_s26" dir="ltr" colspan="11" rowspan="2">
+                <%= document_site_info.site_agent_name %> <!-- 13-004 元請会社の現場代理人名 -->
+              </td>
+              <td class="doc_13_s1" colspan="2" rowspan="2">殿</td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s0" colspan="5">持込会社名</td>
+              <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">
+                <%= document_info.content&.[]('subcon_name') %> <!-- 13-007 持込会社名(自社名) -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s21" colspan="2">(a)</td>
+              <td class="doc_13_s21" colspan="2">(b)</td>
+              <td class="doc_13_s21" colspan="2">(a)</td>
+              <td class="doc_13_s21" colspan="2">(b)</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(７) ゴンドラ</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R11" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s0"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s0">（</td>
+              <td class="doc_13_s27" dir="ltr" colspan="3">
+                <%= sc_hierarchy(document_info) %> <!-- 13-006 次 -->
+              </td>
+              <td class="doc_13_s0">）</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s28" colspan="2" rowspan="17">Ａクレーン部（上部旋回体）</td>
+              <td class="doc_13_s28" rowspan="5">安全装置</td>
+              <td class="doc_13_s29" colspan="7">巻過防止装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-111</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-183</td>
+              <td class="doc_13_s28" colspan="2" rowspan="10">Ｄ安全装置</td>
+              <td class="doc_13_s28" rowspan="6">各種ロック</td>
+              <td class="doc_13_s29" colspan="7">旋回</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-147</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-219</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(８) ブル・ドーザー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R12" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s0" colspan="5" rowspan="2">代 表 者 名</td>
+              <td class="doc_13_s25" dir="ltr" colspan="10" rowspan="2">
+                <%= document_info.content&.[]('subcon_representative_name') %> <!-- 13-008 持込会社の代表者名 -->
+              </td>
+              <td class="doc_13_s31" dir="ltr" colspan="2" rowspan="2">
+                ㊞ <!-- 13-259 印 -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">過負荷防止装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-112</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-184</td>
+              <td class="doc_13_s29" colspan="7">バケット</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-148</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-220</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(９) モーター・グレーダー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R13" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">フックのはずれ止め</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-113</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-185</td>
+              <td class="doc_13_s29" colspan="7">ブーム・アーム</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-149</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-221</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(10) トラクターショベル</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R14" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s0" colspan="5" rowspan="2">電　　話</td>
+              <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">
+                <%= document_info.content&.[]('subcon_phone_number') %> <!-- 13-009 持込会社の電話番号 -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">起伏装置制御</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-114</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-186</td>
+              <td class="doc_13_s32" dir="ltr" colspan="7">「追加項目内容①」13-103</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-150</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-222</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(11) ずり積機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R15" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">旋回警報装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-115</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-187</td>
+              <td class="doc_13_s32" dir="ltr" colspan="7">「追加項目内容②」13-104</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-151</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-223</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(12) スクレーパー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R16" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s2"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s28" rowspan="9">制御装置・作業装置</td>
+              <td class="doc_13_s29" colspan="7">主巻・補巻</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-116</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-188</td>
+              <td class="doc_13_s32" dir="ltr" colspan="7">「追加項目内容③」13-105</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-152</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-224</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(13) スクレープ・ドーザー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R17" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3" colspan="37">このたび、下記機械等を裏面の点検表により、点検整備のうえ持込・使用しますので、お届けします。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">起伏・旋回</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-117</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-189</td>
+              <td class="doc_13_s29" colspan="8">警報装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-153</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-225</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(14) パワー・ショベル</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R18" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s3" colspan="37">なお、使用に際しては関係法令に定められた事項を遵守します。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">クラッチ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-118</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-190</td>
+              <td class="doc_13_s29" colspan="8">アウトリガー</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-154</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-226</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(15) ドラグ・ショベル</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R19" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s3"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s11"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">ブレーキ・ロック</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-119</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-191</td>
+              <td class="doc_13_s29" colspan="8">ヘッドガード</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-155</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-227</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">　（油圧ショベル）</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R20" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="20" rowspan="2">使用会社名</td>
+              <td class="doc_13_s8" colspan="17" rowspan="2">代表者名</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">ジブ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-120</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-192</td>
+              <td class="doc_13_s29" colspan="8">照明</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-156</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-228</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(16) ドラグライン</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R21" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">滑車</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-121</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-193</td>
+              <td class="doc_13_s28" colspan="2" rowspan="10">Ｅ作業装置</td>
+              <td class="doc_13_s29" colspan="8">操作装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-157</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-229</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(17) クラムシェル</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R22" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s23" colspan="20" rowspan="3">
+                <%= field_special_vehicle.use_company_name %> <!-- 使用会社名 -->
+              </td>
+              <td class="doc_13_s25" dir="ltr" colspan="15" rowspan="3">
+                <%= %> <!-- 13-011 使用会社の代表者名 -->
+              </td>
+              <td class="doc_13_s24" dir="ltr" colspan="2" rowspan="3">
+                ㊞ <!-- 印 13-260 -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">フック・バケット</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-122</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-194</td>
+              <td class="doc_13_s29" colspan="8">バケット・ブレード</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-158</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-230</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(18) バケット掘削機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R23" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">ワイヤロープ・チェーン</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-123</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-195</td>
+              <td class="doc_13_s29" colspan="8">ブーム・アーム</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-159</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-231</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(19) トレンチャー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R24" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">玉掛用具</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-124</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-196</td>
+              <td class="doc_13_s29" colspan="8">ジブ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-160</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-232</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(20) コンクリート圧砕機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R25" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s33"></td>
+              <td class="doc_13_s34" colspan="6" rowspan="3"></td>
+              <td class="doc_13_s8" colspan="5" rowspan="3">名　称</td>
+              <td class="doc_13_s8" colspan="7" rowspan="3">メーカー</td>
+              <td class="doc_13_s8" colspan="12" rowspan="3">規　格 ・ 性　能</td>
+              <td class="doc_13_s8" colspan="3" rowspan="3">製造年</td>
+              <td class="doc_13_s8" colspan="4" rowspan="3">管理番号<br> (整理番号)</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s28" rowspan="3">その他</td>
+              <td class="doc_13_s29" colspan="7">操作装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-125</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-197</td>
+              <td class="doc_13_s29" colspan="8">リーダ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-161</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-233</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(21) くい打機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R26" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s33"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">性能表示</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-126</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-198</td>
+              <td class="doc_13_s29" colspan="8">ハンマ・オーガ・バイブロ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-162</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-234</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(22) くい抜機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R27" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s33"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">照明</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-127</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-199</td>
+              <td class="doc_13_s29" colspan="8">油圧駆動装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-163</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-235</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(23) アース・ドリル</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R28" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="6" rowspan="3">機　　械</td>
+              <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3">
+                <%= field_special_vehicle.vehicle_name %> <!-- 13-012 機械の名称 -->
+              </td>
+              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3">
+                <%= field_special_vehicle.content&.[]("maker") %> <!-- 13-013 機械のメーカー -->
+              </td>
+              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">
+                <%= field_special_vehicle.content&.[]("standards_performance") %> <!-- 13-014 機械の規格・性能 -->
+              </td>
+              <td class="doc_13_s37" dir="ltr" colspan="2" rowspan="3">
+                <%= field_special_vehicle.content&.[]("year_manufactured")[0..3] %> <!-- 13-015 機械の製造年 -->
+              </td>
+              <td class="doc_13_s34" rowspan="3">年</td>
+              <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">
+                <%= field_special_vehicle.content&.[]("control_number") %> <!-- 13-016 機械の管理番号(整理番号) -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s28" colspan="2" rowspan="14">Ｂ車両部（下部走行体）</td>
+              <td class="doc_13_s28" rowspan="5">走行部</td>
+              <td class="doc_13_s29" colspan="7">ブレーキ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-128</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-200</td>
+              <td class="doc_13_s29" colspan="8">ワイヤロープ・チェーン</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-164</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-236</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(24) リバース・サーキュレー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R29" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">クラッチ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-129</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-201</td>
+              <td class="doc_13_s29" colspan="8">吊り具等</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-165</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-237</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">ション・ドリル</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R30" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">ハンドル</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-130</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-202</td>
+              <td class="doc_13_s29" colspan="8">滑車</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-166</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-238</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(25) せん孔機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R31" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="6" rowspan="2">持 込 年 月 日</td>
+              <td class="doc_13_s23" dir="ltr" colspan="7" rowspan="2">
+                <%= document_date(field_special_vehicle.carry_on_date) %> <!-- 13-017 持込年月日 -->
+              </td>
+              <td class="doc_13_s8" colspan="5" rowspan="4">使用場所</td>
+              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="4">
+                <%= field_special_vehicle.use_place %> <!-- 13-019 使用場所 -->
+              </td>
+              <td class="doc_13_s8" colspan="7" rowspan="2">自社・リースの区別</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">タイヤ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-131</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-203</td>
+              <td class="doc_13_s28" colspan="2" rowspan="7">Ｆ走行部</td>
+              <td class="doc_13_s29" colspan="8">ブレーキ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-167</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-239</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(26) アース・オーガー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R32" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35" colspan="2" rowspan="4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">クローラ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-132</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-204</td>
+              <td class="doc_13_s29" colspan="8">駐車ブレーキ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-168</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-240</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(27) ペーパー・ドレーン・</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R33" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="6" rowspan="2">搬出予定年月日</td>
+              <td class="doc_13_s23" dir="ltr" colspan="7" rowspan="2">
+                <%= document_date(field_special_vehicle.carry_out_date) %> <!-- 13-018 搬出予定年月日 -->
+              </td>
+              <td class="doc_13_s23" colspan="7" rowspan="2">自社・リース</td>
+              <td class="doc_13_s0" rowspan="2"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s28" rowspan="9">安全装置等</td>
+              <td class="doc_13_s29" colspan="7">警報装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-133</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-205</td>
+              <td class="doc_13_s29" colspan="8">ブレーキロック</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-169</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-241</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">　　マシン</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R34" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">各種ミラー</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-134</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-206</td>
+              <td class="doc_13_s29" colspan="8">クラッチ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-170</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-242</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(28) 地下連続壁施工機械</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R35" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="6" rowspan="6">運　転　者<br> （取　扱　者）</td>
+              <td class="doc_13_s8" colspan="12" rowspan="2">氏 名</td>
+              <td class="doc_13_s8" colspan="19" rowspan="2">資 格 の 種 類</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">方向指示器</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-135</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-207</td>
+              <td class="doc_13_s29" colspan="8">操縦装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-171</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-243</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(29) ローラー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R36" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">前後照灯</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-136</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-208</td>
+              <td class="doc_13_s29" colspan="8">タイヤ・鉄輪</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-172</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-244</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(30) クローラドリル</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R37" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="2">
+                <%= field_special_vehicle.driver_name %> <!-- 13-021 入場する作業員名(運転者名・正) -->
+              </td>
+              <td class="doc_13_s23" dir="ltr" colspan="19" rowspan="2">
+                <%= field_special_vehicle.driver_license.split[0][0..20] %>　<!-- 13-022 資格の種類 --> 
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">左折プロテクター</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-137</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-209</td>
+              <td class="doc_13_s29" colspan="8">クローラ</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-173</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-245</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(31) ドリルジャンボ</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R38" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">アウトリガー</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-138</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-210</td>
+              <td class="doc_13_s28" colspan="2" rowspan="5">Ｇ電気装置</td>
+              <td class="doc_13_s29" colspan="8">配電盤</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-174</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-246</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(32) ロードヘッダー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R39" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="2">
+                <!-- 13-023 入場する作業員名 ※未実装※ -->
+              </td>
+              <td class="doc_13_s23" dir="ltr" colspan="19" rowspan="2">
+                <!--13-024 資格の種類 ※未実装※ -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">昇降装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-139</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-211</td>
+              <td class="doc_13_s29" colspan="8">配線</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-175</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-247</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(33) アスファルトフイニッ</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R40" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">ベッセル</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-140</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-212</td>
+              <td class="doc_13_s29" colspan="8">絶縁</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-176</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-248</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">　　シャー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R41" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s39"></td>
+              <td class="doc_13_s40" colspan="2" rowspan="6">自主検査　有効期限<br></td>
+              <td class="doc_13_s8" colspan="2" rowspan="4">定 期</td>
+              <td class="doc_13_s8" colspan="2" rowspan="2">年次</td>
+              <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
+                <%= field_special_vehicle.content&.[]("check_exp_date_year").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-025 自主検査有効期限・定期・年次 -->
+              </td>
+              <td class="doc_13_s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
+              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
+                <%= field_special_vehicle.content&.[]("check_exp_date_machine").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
+              </td>
+              <td class="doc_13_s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
+              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
+                <%= field_special_vehicle.content&.[]("check_exp_date_car").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-029 自動車検査証有効期限 -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s35"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">後方監視装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-141</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-213</td>
+              <td class="doc_13_s29" colspan="8">アース</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-177</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-249</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(34) スタビライザ</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R42" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s39"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s28" colspan="2" rowspan="5">Ｃゴンドラ</td>
+              <td class="doc_13_s28" rowspan="5"></td>
+              <td class="doc_13_s29" colspan="7">突りょう</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-142</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-214</td>
+              <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目④」13-106</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-178</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-250</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(35) ロードプレーナ</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R43" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s39"></td>
+              <td class="doc_13_s8" colspan="2" rowspan="2">月次</td>
+              <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
+                <%= field_special_vehicle.content&.[]("check_exp_date_month").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-026 自主検査有効期限・定期・月次 -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">作業床</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-143</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-215</td>
+              <td class="doc_13_s28" colspan="2" rowspan="4">Ｈその他</td>
+              <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目⑤」13-107</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-179</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-251</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(36) ロードカッター</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R44" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s39"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">昇降装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-144</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-216</td>
+              <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目⑥」13-108</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-180</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-252</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(37) コンクリート吹付機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R45" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s39"></td>
+              <td class="doc_13_s8" colspan="4" rowspan="2">特 定</td>
+              <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
+                <%= field_special_vehicle.content&.[]("check_exp_date_specific").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-027 自主検査有効期限・特定 -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">電気装置</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-145</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-217</td>
+              <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目⑦」13-109</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-181</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-253</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(38) ボーリングマシーン</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R46" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s39"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s29" colspan="7">ワイヤ・ライフライン</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-146</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-218</td>
+              <td class="doc_13_s41" dir="ltr" colspan="8">「追加項目⑧」13-110</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-182</td>
+              <td class="doc_13_s30" dir="ltr" colspan="2">13-254</td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s22" colspan="7">(39) ブレーカ</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R47" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="6" rowspan="4">任 意 保 険</td>
+              <td class="doc_13_s8" colspan="4" rowspan="4">加入額</td>
+              <td class="doc_13_s8" colspan="3" rowspan="2">対人</td>
+              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対人」13-030</td>
+              <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
+              <td class="doc_13_s8" colspan="3" rowspan="2">搭乗者</td>
+              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・搭乗者」13-032</td>
+              <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
+              <td class="doc_13_s8" colspan="7" rowspan="2">有 効 期 限</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s21" rowspan="3">(a)</td>
+              <td class="doc_13_s28" rowspan="3">点検日</td>
+              <td class="doc_13_s42" colspan="6">年 月 日</td>
+              <td class="doc_13_s28" rowspan="3">点検者</td>
+              <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">「(a)点検年月日」13-256</td>
+              <td class="doc_13_s43" dir="ltr" rowspan="3">㊞13-262</td>
+              <td class="doc_13_s21" rowspan="3">(b)</td>
+              <td class="doc_13_s28" rowspan="3">点検日</td>
+              <td class="doc_13_s42" colspan="6">年 月 日</td>
+              <td class="doc_13_s28" rowspan="3">点検者</td>
+              <td class="doc_13_s24" dir="ltr" colspan="4" rowspan="3">「(b)点検者名」13-258</td>
+              <td class="doc_13_s43" dir="ltr" rowspan="3">㊞13-263</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(40) 鉄骨切断機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R48" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s38" dir="ltr" colspan="6" rowspan="2">「(a)点検年月日」13-255</td>
+              <td class="doc_13_s38" dir="ltr" colspan="6" rowspan="2">「(b)点検年月日」13-257</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(41) 解体用つかみ機</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R49" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="3" rowspan="2">対物</td>
+              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対物」13-031</td>
+              <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
+              <td class="doc_13_s8" colspan="3" rowspan="2">その他</td>
+              <td class="doc_13_s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・その他」13-033</td>
+              <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
+              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="2">「有効期限」13-034</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s20"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(42) 重ダンプトラック</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R50" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s5"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(43) ダンプトラック</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R51" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="6" rowspan="2">接触防止措置等</td>
+              <td class="doc_13_s23" dir="ltr" colspan="31" rowspan="2">
+                <%= field_special_vehicle.contact_prevention %> <!-- 13-035 接触防止措置等 -->
+              </td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s45" colspan="2">（注）</td>
+              <td class="doc_13_s45" colspan="2">１．</td>
+              <td class="doc_13_s22" colspan="24">持込機械等の届け出は、当該機械を持ち込む会社（貸与を受けた会社が下請の場合</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(44) トラックミキサー</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R52" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22" colspan="2"></td>
+              <td class="doc_13_s22" colspan="24">はその会社）の代表者が所長に届け出ること。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(45) 散水車</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R53" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="6" rowspan="8">機械等の特性<br> ・その他その<br> 使用上注意す<br> べき事項</td>
+              <td class="doc_13_s23" dir="ltr" colspan="31" rowspan="8">「機械等の特性・その他その使用上注意すべき事項」13-036</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s45" colspan="2">２．</td>
+              <td class="doc_13_s22" colspan="24">点検表の点検結果欄には、該当する箇所へ✔印を記入すること。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(46) 不整地運搬車</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R54" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s45" colspan="2">３．</td>
+              <td class="doc_13_s22" colspan="24">自社の点検表にて点検したものは、その点検表を貼付する（転記の必要はなし）。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(47) コンクリートポンプ車</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R55" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s45" colspan="2">４．</td>
+              <td class="doc_13_s22" colspan="24">機械名（１）から（６）まではＡ、Ｂ欄を、（７）はＣ欄を、（８）から（42）ま</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22" colspan="7">(48) その他</td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R56" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22" colspan="2"></td>
+              <td class="doc_13_s22" colspan="24">ではＤ、Ｅ、Ｆ、Ｇ欄を、（43）から（47）まではＢ欄を、（48）はＢ、Ｄ、Ｅ欄</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R57" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22" colspan="2"></td>
+              <td class="doc_13_s22" colspan="24">を使用して点検すること。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R58" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s45" colspan="2">５．</td>
+              <td class="doc_13_s22" colspan="24">点検結果の（ａ）は、機械所有会社の確認欄とし、（ｂ）は持込会社又は機械使用</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R59" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22"></td>
+              <td class="doc_13_s22" colspan="2"></td>
+              <td class="doc_13_s22" colspan="24">会社の確認欄とする。元請が確認するときは、（ｂ）欄を利用すること。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R60" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s45" colspan="2">６．</td>
+              <td class="doc_13_s22" colspan="24">場内搬入後、持込機械届済証を当該機械に貼付すること。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R61" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="13" rowspan="2">元 請 確 認 欄</td>
+              <td class="doc_13_s8" colspan="12" rowspan="2">受 付 番 号</td>
+              <td class="doc_13_s8" colspan="12" rowspan="2">受 付 確 認 者</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s45" colspan="2">７．</td>
+              <td class="doc_13_s22" colspan="24">直近に実施した特定（年次）及び月例の定期自主検査帳票の写し、任意保険（移動</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R62" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s45" colspan="2"></td>
+              <td class="doc_13_s22" colspan="24">式クレーンの場合）の写しを必ず添付すること。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R63" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s8" colspan="2" rowspan="3">担当者</td>
+              <td class="doc_13_s23" dir="ltr" colspan="11" rowspan="3">「元請確認欄・担当者」13-037</td>
+              <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">「受付番号」13-038</td>
+              <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3">「受付確認年月日」13-039</td>
+              <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3">「受付確認者」13-040</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s45" colspan="2">８．</td>
+              <td class="doc_13_s22" colspan="24">資格を必要とする建設機械運転者等には作業中、必ず運転免許等の資格証を携帯さ</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R64" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s45" colspan="2"></td>
+              <td class="doc_13_s22" colspan="24">せること。</td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+            <tr style="height: 22px">
+              <th id="1612125903R65" style="height: 22px;" class="row-headers-background">
+                <div class="row-header-wrapper" style="line-height: 22px"></div>
+              </th>
+              <td class="doc_13_s7"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s44"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s46"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s47"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+              <td class="doc_13_s4"></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="doc_13th_image">
+          <!-- <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAABkCAYAAAA8AQ3AAAAFFElEQVR4Xu3XPy+kexjH4Z9kQyIhJKYYU/AK6DRK7wWVQkQkiskUOtTiBWkVOg0SfxITIjQG8RyzOVtxCs99cmdn95Jstth83Y/rmXxih4ovAgQIDIjA0IA8p8ckQIBAESwfAgIEBkZAsAbmVXlQAgQEy2eAAIGBERCsgXlVHpQAAcHyGSBAYGAEBGtgXpUHJUBAsHwGCBAYGAHBGphX5UEJEKgdrL29ver6+rr0/zw9PZWLi4svNU9OTmrf8HoIEPi9BRYXF6vHx8cvH7LRaJRms1mmpqZKq9Uqm5ub4RZ8+xvMzc1Vp6enZXp6uszMzJTR0dGfDzM+Pl6qqvr04B9h+/aN3/sVeToCBH4JbG1tVb1e70uQbrdb7u/vS//f+7/QXF5elre3t7KwsFCOjo5qdaHOqNrY2Ci7u7t1tt40AQJ/sUCn06na7XZfoFY/6ox+Hvw4XGf7F78qPzoBAv8K9P8rVqsfdUaC5XNHgEAtgcPDw2p5edlvWLX0jAgQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIH/QaD6+B5Ddb5PnVHVbrdLp9Ops63zjDYECPwhAvv7+9X6+nr/p6nVjzqjant7u+zs7NTZ/iHsfgwCBH4JHBwc9H9j+vT1+vparq6uSq/XK91ut9ze3pbj4+Py/v5e7u7uavXj26NGo1GNjY2VpaWl0v97ZGSktFqtMjw8XKrq83OvrKx8+4aPAgECgyEwMTFRPTw8fPmwH60ozWaz/Pjxo8zOzpbJyckyPz9f1tbWajeh1nB1dbU6OzsrNzc35fn5uZyfn5eXl5f/Eq51YzBel6ckQCBTQEwytd0iQCAkIFghPmMCBDIFBCtT2y0CBEICghXiMyZAIFNAsDK13SJAICQgWCE+YwIEMgUEK1PbLQIEQgKCFeIzJkAgU0CwMrXdIkAgJCBYIT5jAgQyBQQrU9stAgRCAoIV4jMmQCBTQLAytd0iQCAk8A8IBa+DqEh0OQAAAABJRU5ErkJggg=="> -->
+        </div>
       </div>
-    </div>
-  </section>
-</div>
+    </section>
+  </div>
+<% end %>

--- a/app/views/users/documents/doc_13th/_show.html.erb
+++ b/app/views/users/documents/doc_13th/_show.html.erb
@@ -1194,7 +1194,7 @@
                 <%= field_special_vehicle.driver_name %> <!-- 13-021 入場する作業員名(運転者名・正) -->
               </td>
               <td class="doc_13_s23" dir="ltr" colspan="19" rowspan="2">
-                <%= field_special_vehicle.driver_license.split[0][0..20] %>　<!-- 13-022 資格の種類 --> 
+                <%= field_special_vehicle.driver_license.split[0][0..20] if field_special_vehicle.driver_license %>　<!-- 13-022 資格の種類 --> 
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s35"></td>

--- a/app/views/users/documents/doc_13th/_show.html.erb
+++ b/app/views/users/documents/doc_13th/_show.html.erb
@@ -419,11 +419,15 @@
             </th>
             <td class="doc_13_s0"></td>
             <td class="doc_13_s0" colspan="5" rowspan="2">事業所の名称</td>
-            <td class="doc_13_s25" dir="ltr" colspan="13" rowspan="2">「事業所名（現場名）」13-003</td>
+            <td class="doc_13_s25" dir="ltr" colspan="13" rowspan="2">
+              <%= document_site_info.site_name %> <!-- 13-003 事業所名(現場名) -->
+            </td>
             <td class="doc_13_s2"></td>
             <td class="doc_13_s2"></td>
             <td class="doc_13_s0" colspan="5" rowspan="2">一次会社名</td>
-            <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">「一次会社名」13-005</td>
+            <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">
+              <%= primary_subcon_name(document_info) %> <!-- 13-005 一次会社名 -->
+            </td>
             <td class="doc_13_s4"></td>
             <td class="doc_13_s4"></td>
             <td class="doc_13_s4"></td>
@@ -457,12 +461,16 @@
             </th>
             <td class="doc_13_s0"></td>
             <td class="doc_13_s0" colspan="5" rowspan="2">所 長 名</td>
-            <td class="doc_13_s26" dir="ltr" colspan="11" rowspan="2">元請会社の「各会社の現場代理人名」13-004</td>
+            <td class="doc_13_s26" dir="ltr" colspan="11" rowspan="2">
+              <%= document_site_info.site_agent_name %> <!-- 13-004 元請会社の現場代理人名 -->
+            </td>
             <td class="doc_13_s1" colspan="2" rowspan="2">殿</td>
             <td class="doc_13_s2"></td>
             <td class="doc_13_s2"></td>
             <td class="doc_13_s0" colspan="5">持込会社名</td>
-            <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">「持込会社名」13-007</td>
+            <td class="doc_13_s25" dir="ltr" colspan="12" rowspan="2">
+              <%= document_info.content&.[]('subcon_name') %> <!-- 13-007 持込会社名(自社名) -->
+            </td>
             <td class="doc_13_s4"></td>
             <td class="doc_13_s4"></td>
             <td class="doc_13_s4"></td>
@@ -482,8 +490,9 @@
             <td class="doc_13_s2"></td>
             <td class="doc_13_s2"></td>
             <td class="doc_13_s0">（</td>
-            <td class="doc_13_s27" dir="ltr" colspan="2">13-006</td>
-            <td class="doc_13_s0">次</td>
+            <td class="doc_13_s27" dir="ltr" colspan="3">
+              <%= sc_hierarchy(document_info) %> <!-- 13-006 次 -->
+            </td>
             <td class="doc_13_s0">）</td>
             <td class="doc_13_s4"></td>
             <td class="doc_13_s4"></td>
@@ -528,7 +537,9 @@
             <td class="doc_13_s2"></td>
             <td class="doc_13_s2"></td>
             <td class="doc_13_s0" colspan="5" rowspan="2">代 表 者 名</td>
-            <td class="doc_13_s25" dir="ltr" colspan="10" rowspan="2">持込会社の「代表者名」13-008</td>
+            <td class="doc_13_s25" dir="ltr" colspan="10" rowspan="2">
+              <%= document_info.content&.[]('subcon_representative_name') %> <!-- 13-008 持込会社の代表者名 -->
+            </td>
             <td class="doc_13_s31" dir="ltr" colspan="2" rowspan="2">㊞13-259</td>
             <td class="doc_13_s4"></td>
             <td class="doc_13_s4"></td>

--- a/app/views/users/documents/doc_13th/_show.pdf.erb
+++ b/app/views/users/documents/doc_13th/_show.pdf.erb
@@ -49,7 +49,9 @@
             <td class="s3"></td>
             <td class="s3"></td>
             <td class="s3"></td>
-            <td class="s4">&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;</td> <!-- 中心調整 -->
+            <td class="s4">
+              &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
+            </td> <!-- 中心調整 -->
             <td class="s4"></td>
             <td class="s5"></td>
             <td class="s5"></td>
@@ -327,9 +329,15 @@
             <td class="s4"></td>
             <td class="s4"></td>
             <td class="s20"></td>
-            <td class="s23" dir="ltr" colspan="14" rowspan="3">「所有会社名」13-101</td>
-            <td class="s23" dir="ltr" colspan="12" rowspan="3">「代表者名」13-102</td>
-            <td class="s24" dir="ltr" colspan="2" rowspan="3">印13-261</td>
+            <td class="s23" dir="ltr" colspan="14" rowspan="3">
+              <%= field_special_vehicle.owning_company_name %> <!-- 13-101 所有会社名 -->
+            </td>
+            <td class="s23" dir="ltr" colspan="12" rowspan="3">
+              <!-- 13-102 代表者名 ※未実装※ -->
+            </td>
+            <td class="s24" dir="ltr" colspan="2" rowspan="3">
+              印 <!-- 13-261 印 -->
+            </td>
             <td class="s5"></td>
             <td class="s22" colspan="7">(２) 移動式クレーン</td>
           </tr>
@@ -1408,10 +1416,14 @@
             <td class="s8" colspan="6" rowspan="4">任 意 保 険</td>
             <td class="s8" colspan="4" rowspan="4">加入額</td>
             <td class="s8" colspan="3" rowspan="2">対人</td>
-            <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対人」13-030</td>
+            <td class="s31" dir="ltr" colspan="5" rowspan="2">
+              <%= field_special_vehicle.content&.[]("personal_insurance") %> <!-- 13-030 任意保険加入額・対人 -->
+            </td>
             <td class="s8" colspan="2" rowspan="2">千円</td>
             <td class="s8" colspan="3" rowspan="2">搭乗者</td>
-            <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・搭乗者」13-032</td>
+            <td class="s31" dir="ltr" colspan="5" rowspan="2">
+              <%= field_special_vehicle.content&.[]("passenger_insurance") %> <!-- 13-032 任意保険加入額・搭乗者 -->
+            </td>
             <td class="s8" colspan="2" rowspan="2">千円</td>
             <td class="s8" colspan="7" rowspan="2">有 効 期 限</td>
             <td class="s4"></td>
@@ -1422,14 +1434,22 @@
             <td class="s28" rowspan="3">点検日</td>
             <td class="s42" colspan="6">年 月 日</td>
             <td class="s28" rowspan="3">点検者</td>
-            <td class="s24" dir="ltr" colspan="4" rowspan="3">「(a)点検年月日」13-256</td>
-            <td class="s43" dir="ltr" rowspan="3">印13-262</td>
+            <td class="s24" dir="ltr" colspan="4" rowspan="3">
+              <!-- 13-256 (a)点検年月日 ※未実装※ -->
+            </td>
+            <td class="s43" dir="ltr" rowspan="3">
+              印 <!-- 13-262 印 -->
+            </td>
             <td class="s21" rowspan="3">(b)</td>
             <td class="s28" rowspan="3">点検日</td>
             <td class="s42" colspan="6">年 月 日</td>
             <td class="s28" rowspan="3">点検者</td>
-            <td class="s24" dir="ltr" colspan="4" rowspan="3">「(b)点検者名」13-258</td>
-            <td class="s43" dir="ltr" rowspan="3">印13-263</td>
+            <td class="s24" dir="ltr" colspan="4" rowspan="3">
+              <!-- 13-258 (b)点検者名 ※未実装※ -->
+            </td>
+            <td class="s43" dir="ltr" rowspan="3">
+              印 <!-- 13-263 印 -->
+            </td>
             <td class="s4"></td>
             <td class="s22" colspan="7">(40) 鉄骨切断機</td>
           </tr>
@@ -1442,8 +1462,12 @@
             <td class="s4"></td>
             <td class="s4"></td>
             <td class="s20"></td>
-            <td class="s38" dir="ltr" colspan="6" rowspan="2">「(a)点検年月日」13-255</td>
-            <td class="s38" dir="ltr" colspan="6" rowspan="2">「(b)点検年月日」13-257</td>
+            <td class="s38" dir="ltr" colspan="6" rowspan="2">
+              <!-- 13-255 (a)点検年月日 ※未実装※ --> 
+            </td>
+            <td class="s38" dir="ltr" colspan="6" rowspan="2">
+              <!-- 13-257 (b)点検年月日 ※未実装※ -->
+            </td>
             <td class="s4"></td>
             <td class="s22" colspan="7">(41) 解体用つかみ機</td>
           </tr>
@@ -1453,12 +1477,18 @@
             </th>
             <td class="s7"></td>
             <td class="s8" colspan="3" rowspan="2">対物</td>
-            <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対物」13-031</td>
+            <td class="s31" dir="ltr" colspan="5" rowspan="2">
+              <%= field_special_vehicle.content&.[]("objective_insurance") %> <!-- 13-031 任意保険加入額・対物 -->
+            </td>
             <td class="s8" colspan="2" rowspan="2">千円</td>
             <td class="s8" colspan="3" rowspan="2">その他</td>
-            <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・その他」13-033</td>
+            <td class="s31" dir="ltr" colspan="5" rowspan="2">
+              <%= field_special_vehicle.content&.[]("other_insurance") %> <!-- 13-033 任意保険加入額・その他 -->
+            </td>
             <td class="s8" colspan="2" rowspan="2">千円</td>
-            <td class="s36" dir="ltr" colspan="7" rowspan="2">「有効期限」13-034</td>
+            <td class="s36" dir="ltr" colspan="7" rowspan="2">
+              <%= field_special_vehicle.content&.[]("exp_date_insurance").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-034 有効期限 -->
+            </td>
             <td class="s4"></td>
             <td class="s4"></td>
             <td class="s4"></td>
@@ -1547,7 +1577,9 @@
             </th>
             <td class="s7"></td>
             <td class="s8" colspan="6" rowspan="8">機械等の特性<br> ・その他その<br> 使用上注意す<br> べき事項</td>
-            <td class="s23" dir="ltr" colspan="31" rowspan="8">「機械等の特性・その他その使用上注意すべき事項」13-036</td>
+            <td class="s23" dir="ltr" colspan="31" rowspan="8">
+              <%= field_special_vehicle.precautions %> <!-- 13-036 機械等の特性・その他その使用上注意すべき事項 -->
+            </td>
             <td class="s4"></td>
             <td class="s4"></td>
             <td class="s4"></td>
@@ -1754,10 +1786,18 @@
             </th>
             <td class="s7"></td>
             <td class="s8" colspan="2" rowspan="3">担当者</td>
-            <td class="s23" dir="ltr" colspan="11" rowspan="3">「元請確認欄・担当者」13-037</td>
-            <td class="s23" dir="ltr" colspan="12" rowspan="3">「受付番号」13-038</td>
-            <td class="s36" dir="ltr" colspan="7" rowspan="3">「受付確認年月日」13-039</td>
-            <td class="s36" dir="ltr" colspan="5" rowspan="3">「受付確認者」13-040</td>
+            <td class="s23" dir="ltr" colspan="11" rowspan="3">
+              <!-- 13-037 元請確認欄・担当者 ※未実装※ -->
+            </td>
+            <td class="s23" dir="ltr" colspan="12" rowspan="3">
+              <!-- 13-038 受付番号 ※未実装※ -->
+            </td>
+            <td class="s36" dir="ltr" colspan="7" rowspan="3">
+              <!-- 13-039 受付確認年月日 ※未実装※ -->
+            </td>
+            <td class="s36" dir="ltr" colspan="5" rowspan="3">
+              <!-- 13-040 受付確認者 ※未実装※ -->
+            </td>
             <td class="s4"></td>
             <td class="s4"></td>
             <td class="s4"></td>

--- a/app/views/users/documents/doc_13th/_show.pdf.erb
+++ b/app/views/users/documents/doc_13th/_show.pdf.erb
@@ -2,1807 +2,1855 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 
-<body style="font-family: Noto Sans JP, Hiragino Kaku Gothic ProN, Meiryo, sans-serif;">
-  <div class="ritz grid-container" dir="ltr">
-    <table class="waffle no-grid" cellspacing="0" cellpadding="0">
-      <tbody>
-        <tr style="height: 22px">
-          <th id="1612125903R0" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px">&emsp;</div>
-          </th>
-          <td class="s0"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s4">&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;</td> <!-- 中心調整 -->
-          <td class="s4"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R1" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="12">全建統一様式第９号</td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R2" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s6"></td>
-          <td class="s9" colspan="7" rowspan="2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s10" dir="ltr" colspan="8">「提出日（西暦）」13-001</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s11" colspan="5" rowspan="2">持込時の点検表</td>
-          <td class="s3"></td>
-          <td class="s12" colspan="6"></td>
-          <td class="s12" colspan="10"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s4"></td>
-          <td class="s13"></td>
-          <td class="s13"></td>
-          <td class="s13"></td>
-          <td class="s13"></td>
-          <td class="s13"></td>
-          <td class="s13"></td>
-          <td class="s13"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R3" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s14" colspan="9" rowspan="2">移動式クレーン</td>
-          <td class="s15" colspan="2" rowspan="4">　等</td>
-          <td class="s0"></td>
-          <td class="s15" colspan="4" rowspan="4">使用届</td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s16"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s16"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s4"></td>
-          <td class="s17" colspan="7">機 械 名</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R4" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s18" colspan="6" rowspan="2"></td>
-          <td class="s19"></td>
-          <td class="s6"></td>
-          <td class="s0"></td>
-          <td class="s3"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s21" colspan="14">所 有 会 社 名</td>
-          <td class="s21" colspan="14">代 表 者 名</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(１) クレーン</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R5" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s18"></td>
-          <td class="s18"></td>
-          <td class="s18"></td>
-          <td class="s19"></td>
-          <td class="s6"></td>
-          <td class="s14" colspan="9" rowspan="2">車両系建設機械</td>
-          <td class="s2"></td>
-          <td class="s3"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s23" dir="ltr" colspan="14" rowspan="3">「所有会社名」13-101</td>
-          <td class="s23" dir="ltr" colspan="12" rowspan="3">「代表者名」13-102</td>
-          <td class="s24" dir="ltr" colspan="2" rowspan="3">印13-261</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(２) 移動式クレーン</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R6" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(３) デリック</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R7" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(４) エレベーター</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R8" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s0"></td>
-          <td class="s0" colspan="5" rowspan="2">事業所の名称</td>
-          <td class="s25" dir="ltr" colspan="13" rowspan="2">
-            <%= document_site_info.site_name %> <!-- 13-003 事業所名(現場名) -->
-          </td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s0" colspan="5" rowspan="2">一次会社名</td>
-          <td class="s25" dir="ltr" colspan="12" rowspan="2">
-            <%= primary_subcon_name(document_info) %> <!-- 13-005 一次会社名 -->
-          </td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s21" colspan="14">移動式クレーン等</td>
-          <td class="s21" colspan="14">車両系建設機械等</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(５) 建設用リフト</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R9" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s0"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s21" colspan="10" rowspan="2">点検事項</td>
-          <td class="s21" colspan="4">点検結果</td>
-          <td class="s21" colspan="10" rowspan="2">点検事項</td>
-          <td class="s21" colspan="4">点検結果</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(６) 高所作業車</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R10" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s0"></td>
-          <td class="s0" colspan="5" rowspan="2">所 長 名</td>
-          <td class="s26" dir="ltr" colspan="11" rowspan="2">
-            <%= document_site_info.site_agent_name %> <!-- 13-004 元請会社の現場代理人名 -->
-          </td>
-          <td class="s1" colspan="2" rowspan="2">殿</td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s0" colspan="5">持込会社名</td>
-          <td class="s25" dir="ltr" colspan="12" rowspan="2">
-            <%= document_info.content&.[]('subcon_name') %> <!-- 13-007 持込会社名(自社名) -->
-          </td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s21" colspan="2">(a)</td>
-          <td class="s21" colspan="2">(b)</td>
-          <td class="s21" colspan="2">(a)</td>
-          <td class="s21" colspan="2">(b)</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(７) ゴンドラ</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R11" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s0"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s0">（</td>
-          <td class="s27" dir="ltr" colspan="3">
-            <%= sc_hierarchy(document_info) %> <!-- 13-006 次 -->
-            &emsp;&emsp;
-          </td>
-          <td class="s0">）</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s28" colspan="2" rowspan="17">Ａクレーン部（上部旋回体）</td>
-          <td class="s28" rowspan="5">安全装置</td>
-          <td class="s29" colspan="7">巻過防止装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-111</td>
-          <td class="s30" dir="ltr" colspan="2">13-183</td>
-          <td class="s28" colspan="2" rowspan="10">Ｄ安全装置</td>
-          <td class="s28" rowspan="6">各種ロック</td>
-          <td class="s29" colspan="7">旋回</td>
-          <td class="s30" dir="ltr" colspan="2">13-147</td>
-          <td class="s30" dir="ltr" colspan="2">13-219</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(８) ブル・ドーザー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R12" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s0" colspan="5" rowspan="2">代 表 者 名</td>
-          <td class="s25" dir="ltr" colspan="10" rowspan="2">
-            <%= document_info.content&.[]('subcon_representative_name') %> <!-- 13-008 持込会社の代表者名 -->
-          </td>
-          <td class="s31" dir="ltr" colspan="2" rowspan="2">印13-259</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">過負荷防止装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-112</td>
-          <td class="s30" dir="ltr" colspan="2">13-184</td>
-          <td class="s29" colspan="7">バケット</td>
-          <td class="s30" dir="ltr" colspan="2">13-148</td>
-          <td class="s30" dir="ltr" colspan="2">13-220</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(９) モーター・グレーダー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R13" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">フックのはずれ止め</td>
-          <td class="s30" dir="ltr" colspan="2">13-113</td>
-          <td class="s30" dir="ltr" colspan="2">13-185</td>
-          <td class="s29" colspan="7">ブーム・アーム</td>
-          <td class="s30" dir="ltr" colspan="2">13-149</td>
-          <td class="s30" dir="ltr" colspan="2">13-221</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(10) トラクターショベル</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R14" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s0" colspan="5" rowspan="2">電　　話</td>
-          <td class="s25" dir="ltr" colspan="12" rowspan="2">持込会社の「電話番号」13-009</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">起伏装置制御</td>
-          <td class="s30" dir="ltr" colspan="2">13-114</td>
-          <td class="s30" dir="ltr" colspan="2">13-186</td>
-          <td class="s32" dir="ltr" colspan="7">「追加項目内容①」13-103</td>
-          <td class="s30" dir="ltr" colspan="2">13-150</td>
-          <td class="s30" dir="ltr" colspan="2">13-222</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(11) ずり積機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R15" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">旋回警報装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-115</td>
-          <td class="s30" dir="ltr" colspan="2">13-187</td>
-          <td class="s32" dir="ltr" colspan="7">「追加項目内容②」13-104</td>
-          <td class="s30" dir="ltr" colspan="2">13-151</td>
-          <td class="s30" dir="ltr" colspan="2">13-223</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(12) スクレーパー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R16" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s2"></td>
-          <td class="s2"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s28" rowspan="9">制御装置・作業装置</td>
-          <td class="s29" colspan="7">主巻・補巻</td>
-          <td class="s30" dir="ltr" colspan="2">13-116</td>
-          <td class="s30" dir="ltr" colspan="2">13-188</td>
-          <td class="s32" dir="ltr" colspan="7">「追加項目内容③」13-105</td>
-          <td class="s30" dir="ltr" colspan="2">13-152</td>
-          <td class="s30" dir="ltr" colspan="2">13-224</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(13) スクレープ・ドーザー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R17" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3" colspan="37">このたび、下記機械等を裏面の点検表により、点検整備のうえ持込・使用しますので、お届けします。</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">起伏・旋回</td>
-          <td class="s30" dir="ltr" colspan="2">13-117</td>
-          <td class="s30" dir="ltr" colspan="2">13-189</td>
-          <td class="s29" colspan="8">警報装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-153</td>
-          <td class="s30" dir="ltr" colspan="2">13-225</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(14) パワー・ショベル</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R18" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s3" colspan="37">なお、使用に際しては関係法令に定められた事項を遵守します。</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">クラッチ</td>
-          <td class="s30" dir="ltr" colspan="2">13-118</td>
-          <td class="s30" dir="ltr" colspan="2">13-190</td>
-          <td class="s29" colspan="8">アウトリガー</td>
-          <td class="s30" dir="ltr" colspan="2">13-154</td>
-          <td class="s30" dir="ltr" colspan="2">13-226</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(15) ドラグ・ショベル</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R19" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s3"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s11"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">ブレーキ・ロック</td>
-          <td class="s30" dir="ltr" colspan="2">13-119</td>
-          <td class="s30" dir="ltr" colspan="2">13-191</td>
-          <td class="s29" colspan="8">ヘッドガード</td>
-          <td class="s30" dir="ltr" colspan="2">13-155</td>
-          <td class="s30" dir="ltr" colspan="2">13-227</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">　（油圧ショベル）</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R20" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="20" rowspan="2">使用会社名</td>
-          <td class="s8" colspan="17" rowspan="2">代表者名</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">ジブ</td>
-          <td class="s30" dir="ltr" colspan="2">13-120</td>
-          <td class="s30" dir="ltr" colspan="2">13-192</td>
-          <td class="s29" colspan="8">照明</td>
-          <td class="s30" dir="ltr" colspan="2">13-156</td>
-          <td class="s30" dir="ltr" colspan="2">13-228</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(16) ドラグライン</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R21" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">滑車</td>
-          <td class="s30" dir="ltr" colspan="2">13-121</td>
-          <td class="s30" dir="ltr" colspan="2">13-193</td>
-          <td class="s28" colspan="2" rowspan="10">Ｅ作業装置</td>
-          <td class="s29" colspan="8">操作装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-157</td>
-          <td class="s30" dir="ltr" colspan="2">13-229</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(17) クラムシェル</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R22" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s23" colspan="20" rowspan="3"></td>
-          <td class="s25" dir="ltr" colspan="15" rowspan="3">使用会社の「代表者名」13-011</td>
-          <td class="s24" dir="ltr" colspan="2" rowspan="3">印13-260</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">フック・バケット</td>
-          <td class="s30" dir="ltr" colspan="2">13-122</td>
-          <td class="s30" dir="ltr" colspan="2">13-194</td>
-          <td class="s29" colspan="8">バケット・ブレード</td>
-          <td class="s30" dir="ltr" colspan="2">13-158</td>
-          <td class="s30" dir="ltr" colspan="2">13-230</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(18) バケット掘削機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R23" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">ワイヤロープ・チェーン</td>
-          <td class="s30" dir="ltr" colspan="2">13-123</td>
-          <td class="s30" dir="ltr" colspan="2">13-195</td>
-          <td class="s29" colspan="8">ブーム・アーム</td>
-          <td class="s30" dir="ltr" colspan="2">13-159</td>
-          <td class="s30" dir="ltr" colspan="2">13-231</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(19) トレンチャー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R24" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">玉掛用具</td>
-          <td class="s30" dir="ltr" colspan="2">13-124</td>
-          <td class="s30" dir="ltr" colspan="2">13-196</td>
-          <td class="s29" colspan="8">ジブ</td>
-          <td class="s30" dir="ltr" colspan="2">13-160</td>
-          <td class="s30" dir="ltr" colspan="2">13-232</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(20) コンクリート圧砕機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R25" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s33"></td>
-          <td class="s34" colspan="6" rowspan="3"></td>
-          <td class="s8" colspan="5" rowspan="3">名　称</td>
-          <td class="s8" colspan="7" rowspan="3">メーカー</td>
-          <td class="s8" colspan="12" rowspan="3">規　格 ・ 性　能</td>
-          <td class="s8" colspan="3" rowspan="3">製造年</td>
-          <td class="s8" colspan="4" rowspan="3">管理番号<br> (整理番号)</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s28" rowspan="3">その他</td>
-          <td class="s29" colspan="7">操作装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-125</td>
-          <td class="s30" dir="ltr" colspan="2">13-197</td>
-          <td class="s29" colspan="8">リーダ</td>
-          <td class="s30" dir="ltr" colspan="2">13-161</td>
-          <td class="s30" dir="ltr" colspan="2">13-233</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(21) くい打機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R26" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s33"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">性能表示</td>
-          <td class="s30" dir="ltr" colspan="2">13-126</td>
-          <td class="s30" dir="ltr" colspan="2">13-198</td>
-          <td class="s29" colspan="8">ハンマ・オーガ・バイブロ</td>
-          <td class="s30" dir="ltr" colspan="2">13-162</td>
-          <td class="s30" dir="ltr" colspan="2">13-234</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(22) くい抜機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R27" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s33"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">照明</td>
-          <td class="s30" dir="ltr" colspan="2">13-127</td>
-          <td class="s30" dir="ltr" colspan="2">13-199</td>
-          <td class="s29" colspan="8">油圧駆動装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-163</td>
-          <td class="s30" dir="ltr" colspan="2">13-235</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(23) アース・ドリル</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R28" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="6" rowspan="3">機　　械</td>
-          <td class="s36" dir="ltr" colspan="5" rowspan="3">「機械の名称」13-012</td>
-          <td class="s36" dir="ltr" colspan="7" rowspan="3">「機械のメーカー」13-013</td>
-          <td class="s23" dir="ltr" colspan="12" rowspan="3">「機械の規格・性能」13-014</td>
-          <td class="s37" dir="ltr" colspan="2" rowspan="3">「機械の製造年」13-015</td>
-          <td class="s34" rowspan="3">年</td>
-          <td class="s24" dir="ltr" colspan="4" rowspan="3">「機械の管理番号(整理番号)」13-016</td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s28" colspan="2" rowspan="14">Ｂ車両部（下部走行体）</td>
-          <td class="s28" rowspan="5">走行部</td>
-          <td class="s29" colspan="7">ブレーキ</td>
-          <td class="s30" dir="ltr" colspan="2">13-128</td>
-          <td class="s30" dir="ltr" colspan="2">13-200</td>
-          <td class="s29" colspan="8">ワイヤロープ・チェーン</td>
-          <td class="s30" dir="ltr" colspan="2">13-164</td>
-          <td class="s30" dir="ltr" colspan="2">13-236</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(24) リバース・サーキュレー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R29" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">クラッチ</td>
-          <td class="s30" dir="ltr" colspan="2">13-129</td>
-          <td class="s30" dir="ltr" colspan="2">13-201</td>
-          <td class="s29" colspan="8">吊り具等</td>
-          <td class="s30" dir="ltr" colspan="2">13-165</td>
-          <td class="s30" dir="ltr" colspan="2">13-237</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">ション・ドリル</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R30" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">ハンドル</td>
-          <td class="s30" dir="ltr" colspan="2">13-130</td>
-          <td class="s30" dir="ltr" colspan="2">13-202</td>
-          <td class="s29" colspan="8">滑車</td>
-          <td class="s30" dir="ltr" colspan="2">13-166</td>
-          <td class="s30" dir="ltr" colspan="2">13-238</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(25) せん孔機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R31" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="6" rowspan="2">持 込 年 月 日</td>
-          <td class="s23" dir="ltr" colspan="7" rowspan="2">「持込年月日」13-017</td>
-          <td class="s8" colspan="5" rowspan="4">使用場所</td>
-          <td class="s23" dir="ltr" colspan="12" rowspan="4">「使用場所」13-019</td>
-          <td class="s8" colspan="7" rowspan="2">自社・リースの区別</td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">タイヤ</td>
-          <td class="s30" dir="ltr" colspan="2">13-131</td>
-          <td class="s30" dir="ltr" colspan="2">13-203</td>
-          <td class="s28" colspan="2" rowspan="7">Ｆ走行部</td>
-          <td class="s29" colspan="8">ブレーキ</td>
-          <td class="s30" dir="ltr" colspan="2">13-167</td>
-          <td class="s30" dir="ltr" colspan="2">13-239</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(26) アース・オーガー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R32" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s35" colspan="2" rowspan="4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">クローラ</td>
-          <td class="s30" dir="ltr" colspan="2">13-132</td>
-          <td class="s30" dir="ltr" colspan="2">13-204</td>
-          <td class="s29" colspan="8">駐車ブレーキ</td>
-          <td class="s30" dir="ltr" colspan="2">13-168</td>
-          <td class="s30" dir="ltr" colspan="2">13-240</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(27) ペーパー・ドレーン・</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R33" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="6" rowspan="2">搬出予定年月日</td>
-          <td class="s38" dir="ltr" colspan="7" rowspan="2">「搬出予定年月日」13-018</td>
-          <td class="s23" colspan="7" rowspan="2">自社・リース</td>
-          <td class="s0" rowspan="2"></td>
-          <td class="s20"></td>
-          <td class="s28" rowspan="9">安全装置等</td>
-          <td class="s29" colspan="7">警報装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-133</td>
-          <td class="s30" dir="ltr" colspan="2">13-205</td>
-          <td class="s29" colspan="8">ブレーキロック</td>
-          <td class="s30" dir="ltr" colspan="2">13-169</td>
-          <td class="s30" dir="ltr" colspan="2">13-241</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">　　マシン</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R34" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">各種ミラー</td>
-          <td class="s30" dir="ltr" colspan="2">13-134</td>
-          <td class="s30" dir="ltr" colspan="2">13-206</td>
-          <td class="s29" colspan="8">クラッチ</td>
-          <td class="s30" dir="ltr" colspan="2">13-170</td>
-          <td class="s30" dir="ltr" colspan="2">13-242</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(28) 地下連続壁施工機械</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R35" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="6" rowspan="6">運　転　者<br> （取　扱　者）</td>
-          <td class="s8" colspan="12" rowspan="2">氏 名</td>
-          <td class="s8" colspan="19" rowspan="2">資 格 の 種 類</td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">方向指示器</td>
-          <td class="s30" dir="ltr" colspan="2">13-135</td>
-          <td class="s30" dir="ltr" colspan="2">13-207</td>
-          <td class="s29" colspan="8">操縦装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-171</td>
-          <td class="s30" dir="ltr" colspan="2">13-243</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(29) ローラー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R36" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">前後照灯</td>
-          <td class="s30" dir="ltr" colspan="2">13-136</td>
-          <td class="s30" dir="ltr" colspan="2">13-208</td>
-          <td class="s29" colspan="8">タイヤ・鉄輪</td>
-          <td class="s30" dir="ltr" colspan="2">13-172</td>
-          <td class="s30" dir="ltr" colspan="2">13-244</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(30) クローラドリル</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R37" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s23" dir="ltr" colspan="12" rowspan="2">「入場する作業員名」13-021</td>
-          <td class="s23" dir="ltr" colspan="19" rowspan="2">「資格の種類」13-022</td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">左折プロテクター</td>
-          <td class="s30" dir="ltr" colspan="2">13-137</td>
-          <td class="s30" dir="ltr" colspan="2">13-209</td>
-          <td class="s29" colspan="8">クローラ</td>
-          <td class="s30" dir="ltr" colspan="2">13-173</td>
-          <td class="s30" dir="ltr" colspan="2">13-245</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(31) ドリルジャンボ</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R38" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">アウトリガー</td>
-          <td class="s30" dir="ltr" colspan="2">13-138</td>
-          <td class="s30" dir="ltr" colspan="2">13-210</td>
-          <td class="s28" colspan="2" rowspan="5">Ｇ電気装置</td>
-          <td class="s29" colspan="8">配電盤</td>
-          <td class="s30" dir="ltr" colspan="2">13-174</td>
-          <td class="s30" dir="ltr" colspan="2">13-246</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(32) ロードヘッダー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R39" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s23" dir="ltr" colspan="12" rowspan="2">「入場する作業員名」13-023</td>
-          <td class="s23" dir="ltr" colspan="19" rowspan="2">「資格の種類」13-024</td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">昇降装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-139</td>
-          <td class="s30" dir="ltr" colspan="2">13-211</td>
-          <td class="s29" colspan="8">配線</td>
-          <td class="s30" dir="ltr" colspan="2">13-175</td>
-          <td class="s30" dir="ltr" colspan="2">13-247</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(33) アスファルトフイニッ</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R40" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">ベッセル</td>
-          <td class="s30" dir="ltr" colspan="2">13-140</td>
-          <td class="s30" dir="ltr" colspan="2">13-212</td>
-          <td class="s29" colspan="8">絶縁</td>
-          <td class="s30" dir="ltr" colspan="2">13-176</td>
-          <td class="s30" dir="ltr" colspan="2">13-248</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">　　シャー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R41" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s39"></td>
-          <td class="s40" colspan="2" rowspan="6">自主検査　有効期限<br></td>
-          <td class="s8" colspan="2" rowspan="4">定 期</td>
-          <td class="s8" colspan="2" rowspan="2">年次</td>
-          <td class="s24" dir="ltr" colspan="7" rowspan="2">「自主検査有効期限・定期・年次」13-025</td>
-          <td class="s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
-          <td class="s36" dir="ltr" colspan="7" rowspan="6">「移動式クレーン等の性能検査有効期限」13-028</td>
-          <td class="s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
-          <td class="s36" dir="ltr" colspan="7" rowspan="6">「自動車検査証有効期限」13-029</td>
-          <td class="s4"></td>
-          <td class="s35"></td>
-          <td class="s35"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">後方監視装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-141</td>
-          <td class="s30" dir="ltr" colspan="2">13-213</td>
-          <td class="s29" colspan="8">アース</td>
-          <td class="s30" dir="ltr" colspan="2">13-177</td>
-          <td class="s30" dir="ltr" colspan="2">13-249</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(34) スタビライザ</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R42" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s39"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s28" colspan="2" rowspan="5">Ｃゴンドラ</td>
-          <td class="s28" rowspan="5"></td>
-          <td class="s29" colspan="7">突りょう</td>
-          <td class="s30" dir="ltr" colspan="2">13-142</td>
-          <td class="s30" dir="ltr" colspan="2">13-214</td>
-          <td class="s41" dir="ltr" colspan="8">「追加項目④」13-106</td>
-          <td class="s30" dir="ltr" colspan="2">13-178</td>
-          <td class="s30" dir="ltr" colspan="2">13-250</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(35) ロードプレーナ</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R43" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s39"></td>
-          <td class="s8" colspan="2" rowspan="2">月次</td>
-          <td class="s24" dir="ltr" colspan="7" rowspan="2">「自主検査有効期限・定期・月次」13-026</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">作業床</td>
-          <td class="s30" dir="ltr" colspan="2">13-143</td>
-          <td class="s30" dir="ltr" colspan="2">13-215</td>
-          <td class="s28" colspan="2" rowspan="4">Ｈその他</td>
-          <td class="s41" dir="ltr" colspan="8">「追加項目⑤」13-107</td>
-          <td class="s30" dir="ltr" colspan="2">13-179</td>
-          <td class="s30" dir="ltr" colspan="2">13-251</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(36) ロードカッター</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R44" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s39"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">昇降装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-144</td>
-          <td class="s30" dir="ltr" colspan="2">13-216</td>
-          <td class="s41" dir="ltr" colspan="8">「追加項目⑥」13-108</td>
-          <td class="s30" dir="ltr" colspan="2">13-180</td>
-          <td class="s30" dir="ltr" colspan="2">13-252</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(37) コンクリート吹付機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R45" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s39"></td>
-          <td class="s8" colspan="4" rowspan="2">特 定</td>
-          <td class="s24" dir="ltr" colspan="7" rowspan="2">「自主検査有効期限・特定」13-027</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">電気装置</td>
-          <td class="s30" dir="ltr" colspan="2">13-145</td>
-          <td class="s30" dir="ltr" colspan="2">13-217</td>
-          <td class="s41" dir="ltr" colspan="8">「追加項目⑦」13-109</td>
-          <td class="s30" dir="ltr" colspan="2">13-181</td>
-          <td class="s30" dir="ltr" colspan="2">13-253</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(38) ボーリングマシーン</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R46" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s39"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s29" colspan="7">ワイヤ・ライフライン</td>
-          <td class="s30" dir="ltr" colspan="2">13-146</td>
-          <td class="s30" dir="ltr" colspan="2">13-218</td>
-          <td class="s41" dir="ltr" colspan="8">「追加項目⑧」13-110</td>
-          <td class="s30" dir="ltr" colspan="2">13-182</td>
-          <td class="s30" dir="ltr" colspan="2">13-254</td>
-          <td class="s5"></td>
-          <td class="s22" colspan="7">(39) ブレーカ</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R47" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="6" rowspan="4">任 意 保 険</td>
-          <td class="s8" colspan="4" rowspan="4">加入額</td>
-          <td class="s8" colspan="3" rowspan="2">対人</td>
-          <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対人」13-030</td>
-          <td class="s8" colspan="2" rowspan="2">千円</td>
-          <td class="s8" colspan="3" rowspan="2">搭乗者</td>
-          <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・搭乗者」13-032</td>
-          <td class="s8" colspan="2" rowspan="2">千円</td>
-          <td class="s8" colspan="7" rowspan="2">有 効 期 限</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s21" rowspan="3">(a)</td>
-          <td class="s28" rowspan="3">点検日</td>
-          <td class="s42" colspan="6">年 月 日</td>
-          <td class="s28" rowspan="3">点検者</td>
-          <td class="s24" dir="ltr" colspan="4" rowspan="3">「(a)点検年月日」13-256</td>
-          <td class="s43" dir="ltr" rowspan="3">印13-262</td>
-          <td class="s21" rowspan="3">(b)</td>
-          <td class="s28" rowspan="3">点検日</td>
-          <td class="s42" colspan="6">年 月 日</td>
-          <td class="s28" rowspan="3">点検者</td>
-          <td class="s24" dir="ltr" colspan="4" rowspan="3">「(b)点検者名」13-258</td>
-          <td class="s43" dir="ltr" rowspan="3">印13-263</td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(40) 鉄骨切断機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R48" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s38" dir="ltr" colspan="6" rowspan="2">「(a)点検年月日」13-255</td>
-          <td class="s38" dir="ltr" colspan="6" rowspan="2">「(b)点検年月日」13-257</td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(41) 解体用つかみ機</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R49" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="3" rowspan="2">対物</td>
-          <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対物」13-031</td>
-          <td class="s8" colspan="2" rowspan="2">千円</td>
-          <td class="s8" colspan="3" rowspan="2">その他</td>
-          <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・その他」13-033</td>
-          <td class="s8" colspan="2" rowspan="2">千円</td>
-          <td class="s36" dir="ltr" colspan="7" rowspan="2">「有効期限」13-034</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s20"></td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(42) 重ダンプトラック</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R50" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s5"></td>
-          <td class="s5"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s44"></td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(43) ダンプトラック</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R51" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="6" rowspan="2">接触防止措置等</td>
-          <td class="s23" dir="ltr" colspan="31" rowspan="2">「有効期限」13-035</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s45" colspan="2">（注）</td>
-          <td class="s45" colspan="2">１．</td>
-          <td class="s22" colspan="24">持込機械等の届け出は、当該機械を持ち込む会社（貸与を受けた会社が下請の場合</td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(44) トラックミキサー</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R52" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s22"></td>
-          <td class="s22"></td>
-          <td class="s22" colspan="2"></td>
-          <td class="s22" colspan="24">はその会社）の代表者が所長に届け出ること。</td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(45) 散水車</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R53" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="6" rowspan="8">機械等の特性<br> ・その他その<br> 使用上注意す<br> べき事項</td>
-          <td class="s23" dir="ltr" colspan="31" rowspan="8">「機械等の特性・その他その使用上注意すべき事項」13-036</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s22"></td>
-          <td class="s22"></td>
-          <td class="s45" colspan="2">２．</td>
-          <td class="s22" colspan="24">点検表の点検結果欄には、該当する箇所へ✔印を記入すること。</td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(46) 不整地運搬車</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R54" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s22"></td>
-          <td class="s22"></td>
-          <td class="s45" colspan="2">３．</td>
-          <td class="s22" colspan="24">自社の点検表にて点検したものは、その点検表を貼付する（転記の必要はなし）。</td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(47) コンクリートポンプ車</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R55" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s22"></td>
-          <td class="s22"></td>
-          <td class="s45" colspan="2">４．</td>
-          <td class="s22" colspan="24">機械名（１）から（６）まではＡ、Ｂ欄を、（７）はＣ欄を、（８）から（42）ま</td>
-          <td class="s4"></td>
-          <td class="s22" colspan="7">(48) その他</td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R56" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s22"></td>
-          <td class="s22"></td>
-          <td class="s22" colspan="2"></td>
-          <td class="s22" colspan="24">ではＤ、Ｅ、Ｆ、Ｇ欄を、（43）から（47）まではＢ欄を、（48）はＢ、Ｄ、Ｅ欄</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R57" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s22"></td>
-          <td class="s22"></td>
-          <td class="s22" colspan="2"></td>
-          <td class="s22" colspan="24">を使用して点検すること。</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R58" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s22"></td>
-          <td class="s22"></td>
-          <td class="s45" colspan="2">５．</td>
-          <td class="s22" colspan="24">点検結果の（ａ）は、機械所有会社の確認欄とし、（ｂ）は持込会社又は機械使用</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R59" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s22"></td>
-          <td class="s22"></td>
-          <td class="s22" colspan="2"></td>
-          <td class="s22" colspan="24">会社の確認欄とする。元請が確認するときは、（ｂ）欄を利用すること。</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R60" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s46"></td>
-          <td class="s46"></td>
-          <td class="s45" colspan="2">６．</td>
-          <td class="s22" colspan="24">場内搬入後、持込機械届済証を当該機械に貼付すること。</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R61" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="13" rowspan="2">元 請 確 認 欄</td>
-          <td class="s8" colspan="12" rowspan="2">受 付 番 号</td>
-          <td class="s8" colspan="12" rowspan="2">受 付 確 認 者</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s46"></td>
-          <td class="s46"></td>
-          <td class="s45" colspan="2">７．</td>
-          <td class="s22" colspan="24">直近に実施した特定（年次）及び月例の定期自主検査帳票の写し、任意保険（移動</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R62" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s46"></td>
-          <td class="s46"></td>
-          <td class="s45" colspan="2"></td>
-          <td class="s22" colspan="24">式クレーンの場合）の写しを必ず添付すること。</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R63" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s8" colspan="2" rowspan="3">担当者</td>
-          <td class="s23" dir="ltr" colspan="11" rowspan="3">「元請確認欄・担当者」13-037</td>
-          <td class="s23" dir="ltr" colspan="12" rowspan="3">「受付番号」13-038</td>
-          <td class="s36" dir="ltr" colspan="7" rowspan="3">「受付確認年月日」13-039</td>
-          <td class="s36" dir="ltr" colspan="5" rowspan="3">「受付確認者」13-040</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s44"></td>
-          <td class="s46"></td>
-          <td class="s45" colspan="2">８．</td>
-          <td class="s22" colspan="24">資格を必要とする建設機械運転者等には作業中、必ず運転免許等の資格証を携帯さ</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R64" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s44"></td>
-          <td class="s46"></td>
-          <td class="s45" colspan="2"></td>
-          <td class="s22" colspan="24">せること。</td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-        <tr style="height: 22px">
-          <th id="1612125903R65" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
-            <div class="row-header-wrapper" style="line-height: 22px"></div>
-          </th>
-          <td class="s7"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s44"></td>
-          <td class="s46"></td>
-          <td class="s46"></td>
-          <td class="s46"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s47"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-          <td class="s4"></td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <div class="doc_13th_image">
-    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAABkCAYAAAA8AQ3AAAAFFElEQVR4Xu3XPy+kexjH4Z9kQyIhJKYYU/AK6DRK7wWVQkQkiskUOtTiBWkVOg0SfxITIjQG8RyzOVtxCs99cmdn95Jstth83Y/rmXxih4ovAgQIDIjA0IA8p8ckQIBAESwfAgIEBkZAsAbmVXlQAgQEy2eAAIGBERCsgXlVHpQAAcHyGSBAYGAEBGtgXpUHJUBAsHwGCBAYGAHBGphX5UEJEKgdrL29ver6+rr0/zw9PZWLi4svNU9OTmrf8HoIEPi9BRYXF6vHx8cvH7LRaJRms1mmpqZKq9Uqm5ub4RZ8+xvMzc1Vp6enZXp6uszMzJTR0dGfDzM+Pl6qqvr04B9h+/aN3/sVeToCBH4JbG1tVb1e70uQbrdb7u/vS//f+7/QXF5elre3t7KwsFCOjo5qdaHOqNrY2Ci7u7t1tt40AQJ/sUCn06na7XZfoFY/6ox+Hvw4XGf7F78qPzoBAv8K9P8rVqsfdUaC5XNHgEAtgcPDw2p5edlvWLX0jAgQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIH/QaD6+B5Ddb5PnVHVbrdLp9Ops63zjDYECPwhAvv7+9X6+nr/p6nVjzqjant7u+zs7NTZ/iHsfgwCBH4JHBwc9H9j+vT1+vparq6uSq/XK91ut9ze3pbj4+Py/v5e7u7uavXj26NGo1GNjY2VpaWl0v97ZGSktFqtMjw8XKrq83OvrKx8+4aPAgECgyEwMTFRPTw8fPmwH60ozWaz/Pjxo8zOzpbJyckyPz9f1tbWajeh1nB1dbU6OzsrNzc35fn5uZyfn5eXl5f/Eq51YzBel6ckQCBTQEwytd0iQCAkIFghPmMCBDIFBCtT2y0CBEICghXiMyZAIFNAsDK13SJAICQgWCE+YwIEMgUEK1PbLQIEQgKCFeIzJkAgU0CwMrXdIkAgJCBYIT5jAgQyBQQrU9stAgRCAoIV4jMmQCBTQLAytd0iQCAk8A8IBa+DqEh0OQAAAABJRU5ErkJggg==">
-  </div>
-</body>
+<% document_info.field_special_vehicles.each do |field_special_vehicle| %>
+  <body style="font-family: Noto Sans JP, Hiragino Kaku Gothic ProN, Meiryo, sans-serif;">
+    <div class="ritz grid-container page-break" dir="ltr">
+      <table class="waffle no-grid" cellspacing="0" cellpadding="0">
+        <tbody>
+          <tr style="height: 22px">
+            <th id="1612125903R0" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px">&emsp;</div>
+            </th>
+            <td class="s0"></td>
+            <td class="s1"></td>
+            <td class="s1"></td>
+            <td class="s1"></td>
+            <td class="s1"></td>
+            <td class="s1"></td>
+            <td class="s1"></td>
+            <td class="s1"></td>
+            <td class="s1"></td>
+            <td class="s1"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s4">&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;</td> <!-- 中心調整 -->
+            <td class="s4"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R1" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="12">全建統一様式第９号</td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R2" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s6"></td>
+            <td class="s9" colspan="7" rowspan="2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s10" dir="ltr" colspan="8">「提出日（西暦）」13-001</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s11" colspan="5" rowspan="2">持込時の点検表</td>
+            <td class="s3"></td>
+            <td class="s12" colspan="6"></td>
+            <td class="s12" colspan="10"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s4"></td>
+            <td class="s13"></td>
+            <td class="s13"></td>
+            <td class="s13"></td>
+            <td class="s13"></td>
+            <td class="s13"></td>
+            <td class="s13"></td>
+            <td class="s13"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R3" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s14" colspan="9" rowspan="2">移動式クレーン</td>
+            <td class="s15" colspan="2" rowspan="4">　等</td>
+            <td class="s0"></td>
+            <td class="s15" colspan="4" rowspan="4">使用届</td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s16"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s16"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s4"></td>
+            <td class="s17" colspan="7">機 械 名</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R4" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s18" colspan="6" rowspan="2"></td>
+            <td class="s19"></td>
+            <td class="s6"></td>
+            <td class="s0"></td>
+            <td class="s3"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s21" colspan="14">所 有 会 社 名</td>
+            <td class="s21" colspan="14">代 表 者 名</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(１) クレーン</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R5" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s18"></td>
+            <td class="s18"></td>
+            <td class="s18"></td>
+            <td class="s19"></td>
+            <td class="s6"></td>
+            <td class="s14" colspan="9" rowspan="2">車両系建設機械</td>
+            <td class="s2"></td>
+            <td class="s3"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s23" dir="ltr" colspan="14" rowspan="3">「所有会社名」13-101</td>
+            <td class="s23" dir="ltr" colspan="12" rowspan="3">「代表者名」13-102</td>
+            <td class="s24" dir="ltr" colspan="2" rowspan="3">印13-261</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(２) 移動式クレーン</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R6" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s6"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s0"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(３) デリック</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R7" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(４) エレベーター</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R8" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s0"></td>
+            <td class="s0" colspan="5" rowspan="2">事業所の名称</td>
+            <td class="s25" dir="ltr" colspan="13" rowspan="2">
+              <%= document_site_info.site_name %> <!-- 13-003 事業所名(現場名) -->
+            </td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s0" colspan="5" rowspan="2">一次会社名</td>
+            <td class="s25" dir="ltr" colspan="12" rowspan="2">
+              <%= primary_subcon_name(document_info) %> <!-- 13-005 一次会社名 -->
+            </td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s21" colspan="14">移動式クレーン等</td>
+            <td class="s21" colspan="14">車両系建設機械等</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(５) 建設用リフト</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R9" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s0"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s21" colspan="10" rowspan="2">点検事項</td>
+            <td class="s21" colspan="4">点検結果</td>
+            <td class="s21" colspan="10" rowspan="2">点検事項</td>
+            <td class="s21" colspan="4">点検結果</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(６) 高所作業車</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R10" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s0"></td>
+            <td class="s0" colspan="5" rowspan="2">所 長 名</td>
+            <td class="s26" dir="ltr" colspan="11" rowspan="2">
+              <%= document_site_info.site_agent_name %> <!-- 13-004 元請会社の現場代理人名 -->
+            </td>
+            <td class="s1" colspan="2" rowspan="2">殿</td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s0" colspan="5">持込会社名</td>
+            <td class="s25" dir="ltr" colspan="12" rowspan="2">
+              <%= document_info.content&.[]('subcon_name') %> <!-- 13-007 持込会社名(自社名) -->
+            </td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s21" colspan="2">(a)</td>
+            <td class="s21" colspan="2">(b)</td>
+            <td class="s21" colspan="2">(a)</td>
+            <td class="s21" colspan="2">(b)</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(７) ゴンドラ</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R11" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s0"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s0">（</td>
+            <td class="s27" dir="ltr" colspan="3">
+              <%= sc_hierarchy(document_info) %> <!-- 13-006 次 -->
+              &emsp;&emsp;
+            </td>
+            <td class="s0">）</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s28" colspan="2" rowspan="17">Ａクレーン部（上部旋回体）</td>
+            <td class="s28" rowspan="5">安全装置</td>
+            <td class="s29" colspan="7">巻過防止装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-111</td>
+            <td class="s30" dir="ltr" colspan="2">13-183</td>
+            <td class="s28" colspan="2" rowspan="10">Ｄ安全装置</td>
+            <td class="s28" rowspan="6">各種ロック</td>
+            <td class="s29" colspan="7">旋回</td>
+            <td class="s30" dir="ltr" colspan="2">13-147</td>
+            <td class="s30" dir="ltr" colspan="2">13-219</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(８) ブル・ドーザー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R12" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s0" colspan="5" rowspan="2">代 表 者 名</td>
+            <td class="s25" dir="ltr" colspan="10" rowspan="2">
+              <%= document_info.content&.[]('subcon_representative_name') %> <!-- 13-008 持込会社の代表者名 -->
+            </td>
+            <td class="s31" dir="ltr" colspan="2" rowspan="2">
+              印 <!-- 13-259 印 -->
+            </td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">過負荷防止装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-112</td>
+            <td class="s30" dir="ltr" colspan="2">13-184</td>
+            <td class="s29" colspan="7">バケット</td>
+            <td class="s30" dir="ltr" colspan="2">13-148</td>
+            <td class="s30" dir="ltr" colspan="2">13-220</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(９) モーター・グレーダー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R13" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">フックのはずれ止め</td>
+            <td class="s30" dir="ltr" colspan="2">13-113</td>
+            <td class="s30" dir="ltr" colspan="2">13-185</td>
+            <td class="s29" colspan="7">ブーム・アーム</td>
+            <td class="s30" dir="ltr" colspan="2">13-149</td>
+            <td class="s30" dir="ltr" colspan="2">13-221</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(10) トラクターショベル</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R14" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s0" colspan="5" rowspan="2">電　　話</td>
+            <td class="s25" dir="ltr" colspan="12" rowspan="2">
+              <%= document_info.content&.[]('subcon_phone_number') %> <!-- 13-009 持込会社の電話番号 -->
+            </td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">起伏装置制御</td>
+            <td class="s30" dir="ltr" colspan="2">13-114</td>
+            <td class="s30" dir="ltr" colspan="2">13-186</td>
+            <td class="s32" dir="ltr" colspan="7">「追加項目内容①」13-103</td>
+            <td class="s30" dir="ltr" colspan="2">13-150</td>
+            <td class="s30" dir="ltr" colspan="2">13-222</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(11) ずり積機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R15" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">旋回警報装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-115</td>
+            <td class="s30" dir="ltr" colspan="2">13-187</td>
+            <td class="s32" dir="ltr" colspan="7">「追加項目内容②」13-104</td>
+            <td class="s30" dir="ltr" colspan="2">13-151</td>
+            <td class="s30" dir="ltr" colspan="2">13-223</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(12) スクレーパー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R16" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s2"></td>
+            <td class="s2"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s3"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s28" rowspan="9">制御装置・作業装置</td>
+            <td class="s29" colspan="7">主巻・補巻</td>
+            <td class="s30" dir="ltr" colspan="2">13-116</td>
+            <td class="s30" dir="ltr" colspan="2">13-188</td>
+            <td class="s32" dir="ltr" colspan="7">「追加項目内容③」13-105</td>
+            <td class="s30" dir="ltr" colspan="2">13-152</td>
+            <td class="s30" dir="ltr" colspan="2">13-224</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(13) スクレープ・ドーザー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R17" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3" colspan="37">このたび、下記機械等を裏面の点検表により、点検整備のうえ持込・使用しますので、お届けします。</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">起伏・旋回</td>
+            <td class="s30" dir="ltr" colspan="2">13-117</td>
+            <td class="s30" dir="ltr" colspan="2">13-189</td>
+            <td class="s29" colspan="8">警報装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-153</td>
+            <td class="s30" dir="ltr" colspan="2">13-225</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(14) パワー・ショベル</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R18" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s3" colspan="37">なお、使用に際しては関係法令に定められた事項を遵守します。</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">クラッチ</td>
+            <td class="s30" dir="ltr" colspan="2">13-118</td>
+            <td class="s30" dir="ltr" colspan="2">13-190</td>
+            <td class="s29" colspan="8">アウトリガー</td>
+            <td class="s30" dir="ltr" colspan="2">13-154</td>
+            <td class="s30" dir="ltr" colspan="2">13-226</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(15) ドラグ・ショベル</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R19" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s3"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s11"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">ブレーキ・ロック</td>
+            <td class="s30" dir="ltr" colspan="2">13-119</td>
+            <td class="s30" dir="ltr" colspan="2">13-191</td>
+            <td class="s29" colspan="8">ヘッドガード</td>
+            <td class="s30" dir="ltr" colspan="2">13-155</td>
+            <td class="s30" dir="ltr" colspan="2">13-227</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">　（油圧ショベル）</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R20" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="20" rowspan="2">使用会社名</td>
+            <td class="s8" colspan="17" rowspan="2">代表者名</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">ジブ</td>
+            <td class="s30" dir="ltr" colspan="2">13-120</td>
+            <td class="s30" dir="ltr" colspan="2">13-192</td>
+            <td class="s29" colspan="8">照明</td>
+            <td class="s30" dir="ltr" colspan="2">13-156</td>
+            <td class="s30" dir="ltr" colspan="2">13-228</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(16) ドラグライン</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R21" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">滑車</td>
+            <td class="s30" dir="ltr" colspan="2">13-121</td>
+            <td class="s30" dir="ltr" colspan="2">13-193</td>
+            <td class="s28" colspan="2" rowspan="10">Ｅ作業装置</td>
+            <td class="s29" colspan="8">操作装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-157</td>
+            <td class="s30" dir="ltr" colspan="2">13-229</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(17) クラムシェル</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R22" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s23" colspan="20" rowspan="3">
+              <%= field_special_vehicle.use_company_name %> <!-- 使用会社名 -->
+            </td>
+            <td class="s25" dir="ltr" colspan="15" rowspan="3">
+              <%= %> <!-- 13-011 使用会社の代表者名 -->
+            </td>
+            <td class="s24" dir="ltr" colspan="2" rowspan="3">
+              印 <!-- 印 13-260 -->
+            </td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">フック・バケット</td>
+            <td class="s30" dir="ltr" colspan="2">13-122</td>
+            <td class="s30" dir="ltr" colspan="2">13-194</td>
+            <td class="s29" colspan="8">バケット・ブレード</td>
+            <td class="s30" dir="ltr" colspan="2">13-158</td>
+            <td class="s30" dir="ltr" colspan="2">13-230</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(18) バケット掘削機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R23" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">ワイヤロープ・チェーン</td>
+            <td class="s30" dir="ltr" colspan="2">13-123</td>
+            <td class="s30" dir="ltr" colspan="2">13-195</td>
+            <td class="s29" colspan="8">ブーム・アーム</td>
+            <td class="s30" dir="ltr" colspan="2">13-159</td>
+            <td class="s30" dir="ltr" colspan="2">13-231</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(19) トレンチャー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R24" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">玉掛用具</td>
+            <td class="s30" dir="ltr" colspan="2">13-124</td>
+            <td class="s30" dir="ltr" colspan="2">13-196</td>
+            <td class="s29" colspan="8">ジブ</td>
+            <td class="s30" dir="ltr" colspan="2">13-160</td>
+            <td class="s30" dir="ltr" colspan="2">13-232</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(20) コンクリート圧砕機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R25" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s33"></td>
+            <td class="s34" colspan="6" rowspan="3"></td>
+            <td class="s8" colspan="5" rowspan="3">名　称</td>
+            <td class="s8" colspan="7" rowspan="3">メーカー</td>
+            <td class="s8" colspan="12" rowspan="3">規　格 ・ 性　能</td>
+            <td class="s8" colspan="3" rowspan="3">製造年</td>
+            <td class="s8" colspan="4" rowspan="3">管理番号<br> (整理番号)</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s28" rowspan="3">その他</td>
+            <td class="s29" colspan="7">操作装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-125</td>
+            <td class="s30" dir="ltr" colspan="2">13-197</td>
+            <td class="s29" colspan="8">リーダ</td>
+            <td class="s30" dir="ltr" colspan="2">13-161</td>
+            <td class="s30" dir="ltr" colspan="2">13-233</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(21) くい打機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R26" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s33"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">性能表示</td>
+            <td class="s30" dir="ltr" colspan="2">13-126</td>
+            <td class="s30" dir="ltr" colspan="2">13-198</td>
+            <td class="s29" colspan="8">ハンマ・オーガ・バイブロ</td>
+            <td class="s30" dir="ltr" colspan="2">13-162</td>
+            <td class="s30" dir="ltr" colspan="2">13-234</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(22) くい抜機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R27" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s33"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">照明</td>
+            <td class="s30" dir="ltr" colspan="2">13-127</td>
+            <td class="s30" dir="ltr" colspan="2">13-199</td>
+            <td class="s29" colspan="8">油圧駆動装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-163</td>
+            <td class="s30" dir="ltr" colspan="2">13-235</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(23) アース・ドリル</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R28" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="6" rowspan="3">機　　械</td>
+            <td class="s36" dir="ltr" colspan="5" rowspan="3">
+              <%= field_special_vehicle.vehicle_name %> <!-- 13-012 機械の名称 -->
+            </td>
+            <td class="s36" dir="ltr" colspan="7" rowspan="3">
+              <%= field_special_vehicle.content&.[]("maker") %> <!-- 13-013 機械のメーカー -->
+            </td>
+            <td class="s23" dir="ltr" colspan="12" rowspan="3">
+              <%= field_special_vehicle.content&.[]("standards_performance") %> <!-- 13-014 機械の規格・性能 -->
+            </td>
+            <td class="s37" dir="ltr" colspan="2" rowspan="3">
+              <%= field_special_vehicle.content&.[]("year_manufactured")[0..3] %> <!-- 13-015 機械の製造年 -->
+            </td>
+            <td class="s34" rowspan="3">年</td>
+            <td class="s24" dir="ltr" colspan="4" rowspan="3">
+              <%= field_special_vehicle.content&.[]("control_number") %> <!-- 13-016 機械の管理番号(整理番号) -->
+            </td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s28" colspan="2" rowspan="14">Ｂ車両部（下部走行体）</td>
+            <td class="s28" rowspan="5">走行部</td>
+            <td class="s29" colspan="7">ブレーキ</td>
+            <td class="s30" dir="ltr" colspan="2">13-128</td>
+            <td class="s30" dir="ltr" colspan="2">13-200</td>
+            <td class="s29" colspan="8">ワイヤロープ・チェーン</td>
+            <td class="s30" dir="ltr" colspan="2">13-164</td>
+            <td class="s30" dir="ltr" colspan="2">13-236</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(24) リバース・サーキュレー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R29" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">クラッチ</td>
+            <td class="s30" dir="ltr" colspan="2">13-129</td>
+            <td class="s30" dir="ltr" colspan="2">13-201</td>
+            <td class="s29" colspan="8">吊り具等</td>
+            <td class="s30" dir="ltr" colspan="2">13-165</td>
+            <td class="s30" dir="ltr" colspan="2">13-237</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">ション・ドリル</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R30" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">ハンドル</td>
+            <td class="s30" dir="ltr" colspan="2">13-130</td>
+            <td class="s30" dir="ltr" colspan="2">13-202</td>
+            <td class="s29" colspan="8">滑車</td>
+            <td class="s30" dir="ltr" colspan="2">13-166</td>
+            <td class="s30" dir="ltr" colspan="2">13-238</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(25) せん孔機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R31" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="6" rowspan="2">持 込 年 月 日</td>
+            <td class="s23" dir="ltr" colspan="7" rowspan="2">
+              <%= document_date(field_special_vehicle.carry_on_date) %> <!-- 13-017 持込年月日 -->
+            </td>
+            <td class="s8" colspan="5" rowspan="4">使用場所</td>
+            <td class="s23" dir="ltr" colspan="12" rowspan="4">
+              <%= field_special_vehicle.use_place %> <!-- 13-019 使用場所 -->
+            </td>
+            <td class="s8" colspan="7" rowspan="2">自社・リースの区別</td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">タイヤ</td>
+            <td class="s30" dir="ltr" colspan="2">13-131</td>
+            <td class="s30" dir="ltr" colspan="2">13-203</td>
+            <td class="s28" colspan="2" rowspan="7">Ｆ走行部</td>
+            <td class="s29" colspan="8">ブレーキ</td>
+            <td class="s30" dir="ltr" colspan="2">13-167</td>
+            <td class="s30" dir="ltr" colspan="2">13-239</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(26) アース・オーガー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R32" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s35" colspan="2" rowspan="4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">クローラ</td>
+            <td class="s30" dir="ltr" colspan="2">13-132</td>
+            <td class="s30" dir="ltr" colspan="2">13-204</td>
+            <td class="s29" colspan="8">駐車ブレーキ</td>
+            <td class="s30" dir="ltr" colspan="2">13-168</td>
+            <td class="s30" dir="ltr" colspan="2">13-240</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(27) ペーパー・ドレーン・</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R33" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="6" rowspan="2">搬出予定年月日</td>
+            <td class="s23" dir="ltr" colspan="7" rowspan="2">
+              <%= document_date(field_special_vehicle.carry_out_date) %> <!-- 13-018 搬出予定年月日 -->
+            </td>
+            <td class="s23" colspan="7" rowspan="2">自社・リース</td>
+            <td class="s0" rowspan="2"></td>
+            <td class="s20"></td>
+            <td class="s28" rowspan="9">安全装置等</td>
+            <td class="s29" colspan="7">警報装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-133</td>
+            <td class="s30" dir="ltr" colspan="2">13-205</td>
+            <td class="s29" colspan="8">ブレーキロック</td>
+            <td class="s30" dir="ltr" colspan="2">13-169</td>
+            <td class="s30" dir="ltr" colspan="2">13-241</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">　　マシン</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R34" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">各種ミラー</td>
+            <td class="s30" dir="ltr" colspan="2">13-134</td>
+            <td class="s30" dir="ltr" colspan="2">13-206</td>
+            <td class="s29" colspan="8">クラッチ</td>
+            <td class="s30" dir="ltr" colspan="2">13-170</td>
+            <td class="s30" dir="ltr" colspan="2">13-242</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(28) 地下連続壁施工機械</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R35" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="6" rowspan="6">運　転　者<br> （取　扱　者）</td>
+            <td class="s8" colspan="12" rowspan="2">氏 名</td>
+            <td class="s8" colspan="19" rowspan="2">資 格 の 種 類</td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">方向指示器</td>
+            <td class="s30" dir="ltr" colspan="2">13-135</td>
+            <td class="s30" dir="ltr" colspan="2">13-207</td>
+            <td class="s29" colspan="8">操縦装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-171</td>
+            <td class="s30" dir="ltr" colspan="2">13-243</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(29) ローラー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R36" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">前後照灯</td>
+            <td class="s30" dir="ltr" colspan="2">13-136</td>
+            <td class="s30" dir="ltr" colspan="2">13-208</td>
+            <td class="s29" colspan="8">タイヤ・鉄輪</td>
+            <td class="s30" dir="ltr" colspan="2">13-172</td>
+            <td class="s30" dir="ltr" colspan="2">13-244</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(30) クローラドリル</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R37" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s23" dir="ltr" colspan="12" rowspan="2">
+              <%= field_special_vehicle.driver_name %> <!-- 13-021 入場する作業員名(運転者名・正) -->
+            </td>
+            <td class="s23" dir="ltr" colspan="19" rowspan="2">
+              <%= field_special_vehicle.driver_license.split[0][0..20] %>　<!-- 13-022 資格の種類 --> 
+            </td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">左折プロテクター</td>
+            <td class="s30" dir="ltr" colspan="2">13-137</td>
+            <td class="s30" dir="ltr" colspan="2">13-209</td>
+            <td class="s29" colspan="8">クローラ</td>
+            <td class="s30" dir="ltr" colspan="2">13-173</td>
+            <td class="s30" dir="ltr" colspan="2">13-245</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(31) ドリルジャンボ</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R38" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">アウトリガー</td>
+            <td class="s30" dir="ltr" colspan="2">13-138</td>
+            <td class="s30" dir="ltr" colspan="2">13-210</td>
+            <td class="s28" colspan="2" rowspan="5">Ｇ電気装置</td>
+            <td class="s29" colspan="8">配電盤</td>
+            <td class="s30" dir="ltr" colspan="2">13-174</td>
+            <td class="s30" dir="ltr" colspan="2">13-246</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(32) ロードヘッダー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R39" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s23" dir="ltr" colspan="12" rowspan="2">
+              <!-- 13-023 入場する作業員名 ※未実装※ -->
+            </td>
+            <td class="s23" dir="ltr" colspan="19" rowspan="2">
+              <!--13-024 資格の種類 ※未実装※ -->
+            </td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">昇降装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-139</td>
+            <td class="s30" dir="ltr" colspan="2">13-211</td>
+            <td class="s29" colspan="8">配線</td>
+            <td class="s30" dir="ltr" colspan="2">13-175</td>
+            <td class="s30" dir="ltr" colspan="2">13-247</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(33) アスファルトフイニッ</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R40" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">ベッセル</td>
+            <td class="s30" dir="ltr" colspan="2">13-140</td>
+            <td class="s30" dir="ltr" colspan="2">13-212</td>
+            <td class="s29" colspan="8">絶縁</td>
+            <td class="s30" dir="ltr" colspan="2">13-176</td>
+            <td class="s30" dir="ltr" colspan="2">13-248</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">　　シャー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R41" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s39"></td>
+            <td class="s40" colspan="2" rowspan="6">自主検査　有効期限<br></td>
+            <td class="s8" colspan="2" rowspan="4">定 期</td>
+            <td class="s8" colspan="2" rowspan="2">年次</td>
+            <td class="s24" dir="ltr" colspan="7" rowspan="2">
+              <%= field_special_vehicle.content&.[]("check_exp_date_year").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-025 自主検査有効期限・定期・年次 -->
+            </td>
+            <td class="s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
+            <td class="s36" dir="ltr" colspan="7" rowspan="6">
+              <%= field_special_vehicle.content&.[]("check_exp_date_machine").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
+            </td>
+            <td class="s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
+            <td class="s36" dir="ltr" colspan="7" rowspan="6">
+              <%= field_special_vehicle.content&.[]("check_exp_date_car").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-029 自動車検査証有効期限 -->
+            </td>
+            <td class="s4"></td>
+            <td class="s35"></td>
+            <td class="s35"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">後方監視装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-141</td>
+            <td class="s30" dir="ltr" colspan="2">13-213</td>
+            <td class="s29" colspan="8">アース</td>
+            <td class="s30" dir="ltr" colspan="2">13-177</td>
+            <td class="s30" dir="ltr" colspan="2">13-249</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(34) スタビライザ</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R42" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s39"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s28" colspan="2" rowspan="5">Ｃゴンドラ</td>
+            <td class="s28" rowspan="5"></td>
+            <td class="s29" colspan="7">突りょう</td>
+            <td class="s30" dir="ltr" colspan="2">13-142</td>
+            <td class="s30" dir="ltr" colspan="2">13-214</td>
+            <td class="s41" dir="ltr" colspan="8">「追加項目④」13-106</td>
+            <td class="s30" dir="ltr" colspan="2">13-178</td>
+            <td class="s30" dir="ltr" colspan="2">13-250</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(35) ロードプレーナ</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R43" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s39"></td>
+            <td class="s8" colspan="2" rowspan="2">月次</td>
+            <td class="s24" dir="ltr" colspan="7" rowspan="2">
+              <%= field_special_vehicle.content&.[]("check_exp_date_month").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-026 自主検査有効期限・定期・月次 -->
+            </td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">作業床</td>
+            <td class="s30" dir="ltr" colspan="2">13-143</td>
+            <td class="s30" dir="ltr" colspan="2">13-215</td>
+            <td class="s28" colspan="2" rowspan="4">Ｈその他</td>
+            <td class="s41" dir="ltr" colspan="8">「追加項目⑤」13-107</td>
+            <td class="s30" dir="ltr" colspan="2">13-179</td>
+            <td class="s30" dir="ltr" colspan="2">13-251</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(36) ロードカッター</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R44" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s39"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">昇降装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-144</td>
+            <td class="s30" dir="ltr" colspan="2">13-216</td>
+            <td class="s41" dir="ltr" colspan="8">「追加項目⑥」13-108</td>
+            <td class="s30" dir="ltr" colspan="2">13-180</td>
+            <td class="s30" dir="ltr" colspan="2">13-252</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(37) コンクリート吹付機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R45" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s39"></td>
+            <td class="s8" colspan="4" rowspan="2">特 定</td>
+            <td class="s24" dir="ltr" colspan="7" rowspan="2">
+              <%= field_special_vehicle.content&.[]("check_exp_date_specific").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-027 自主検査有効期限・特定 -->
+            </td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">電気装置</td>
+            <td class="s30" dir="ltr" colspan="2">13-145</td>
+            <td class="s30" dir="ltr" colspan="2">13-217</td>
+            <td class="s41" dir="ltr" colspan="8">「追加項目⑦」13-109</td>
+            <td class="s30" dir="ltr" colspan="2">13-181</td>
+            <td class="s30" dir="ltr" colspan="2">13-253</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(38) ボーリングマシーン</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R46" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s39"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s29" colspan="7">ワイヤ・ライフライン</td>
+            <td class="s30" dir="ltr" colspan="2">13-146</td>
+            <td class="s30" dir="ltr" colspan="2">13-218</td>
+            <td class="s41" dir="ltr" colspan="8">「追加項目⑧」13-110</td>
+            <td class="s30" dir="ltr" colspan="2">13-182</td>
+            <td class="s30" dir="ltr" colspan="2">13-254</td>
+            <td class="s5"></td>
+            <td class="s22" colspan="7">(39) ブレーカ</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R47" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="6" rowspan="4">任 意 保 険</td>
+            <td class="s8" colspan="4" rowspan="4">加入額</td>
+            <td class="s8" colspan="3" rowspan="2">対人</td>
+            <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対人」13-030</td>
+            <td class="s8" colspan="2" rowspan="2">千円</td>
+            <td class="s8" colspan="3" rowspan="2">搭乗者</td>
+            <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・搭乗者」13-032</td>
+            <td class="s8" colspan="2" rowspan="2">千円</td>
+            <td class="s8" colspan="7" rowspan="2">有 効 期 限</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s21" rowspan="3">(a)</td>
+            <td class="s28" rowspan="3">点検日</td>
+            <td class="s42" colspan="6">年 月 日</td>
+            <td class="s28" rowspan="3">点検者</td>
+            <td class="s24" dir="ltr" colspan="4" rowspan="3">「(a)点検年月日」13-256</td>
+            <td class="s43" dir="ltr" rowspan="3">印13-262</td>
+            <td class="s21" rowspan="3">(b)</td>
+            <td class="s28" rowspan="3">点検日</td>
+            <td class="s42" colspan="6">年 月 日</td>
+            <td class="s28" rowspan="3">点検者</td>
+            <td class="s24" dir="ltr" colspan="4" rowspan="3">「(b)点検者名」13-258</td>
+            <td class="s43" dir="ltr" rowspan="3">印13-263</td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(40) 鉄骨切断機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R48" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s38" dir="ltr" colspan="6" rowspan="2">「(a)点検年月日」13-255</td>
+            <td class="s38" dir="ltr" colspan="6" rowspan="2">「(b)点検年月日」13-257</td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(41) 解体用つかみ機</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R49" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="3" rowspan="2">対物</td>
+            <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・対物」13-031</td>
+            <td class="s8" colspan="2" rowspan="2">千円</td>
+            <td class="s8" colspan="3" rowspan="2">その他</td>
+            <td class="s31" dir="ltr" colspan="5" rowspan="2">「任意保険加入額・その他」13-033</td>
+            <td class="s8" colspan="2" rowspan="2">千円</td>
+            <td class="s36" dir="ltr" colspan="7" rowspan="2">「有効期限」13-034</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s20"></td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(42) 重ダンプトラック</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R50" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s5"></td>
+            <td class="s5"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s44"></td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(43) ダンプトラック</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R51" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="6" rowspan="2">接触防止措置等</td>
+            <td class="s23" dir="ltr" colspan="31" rowspan="2">
+              <%= field_special_vehicle.contact_prevention %> <!-- 13-035 接触防止措置等 -->
+            </td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s45" colspan="2">（注）</td>
+            <td class="s45" colspan="2">１．</td>
+            <td class="s22" colspan="24">持込機械等の届け出は、当該機械を持ち込む会社（貸与を受けた会社が下請の場合</td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(44) トラックミキサー</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R52" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s22"></td>
+            <td class="s22"></td>
+            <td class="s22" colspan="2"></td>
+            <td class="s22" colspan="24">はその会社）の代表者が所長に届け出ること。</td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(45) 散水車</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R53" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="6" rowspan="8">機械等の特性<br> ・その他その<br> 使用上注意す<br> べき事項</td>
+            <td class="s23" dir="ltr" colspan="31" rowspan="8">「機械等の特性・その他その使用上注意すべき事項」13-036</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s22"></td>
+            <td class="s22"></td>
+            <td class="s45" colspan="2">２．</td>
+            <td class="s22" colspan="24">点検表の点検結果欄には、該当する箇所へ✔印を記入すること。</td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(46) 不整地運搬車</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R54" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s22"></td>
+            <td class="s22"></td>
+            <td class="s45" colspan="2">３．</td>
+            <td class="s22" colspan="24">自社の点検表にて点検したものは、その点検表を貼付する（転記の必要はなし）。</td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(47) コンクリートポンプ車</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R55" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s22"></td>
+            <td class="s22"></td>
+            <td class="s45" colspan="2">４．</td>
+            <td class="s22" colspan="24">機械名（１）から（６）まではＡ、Ｂ欄を、（７）はＣ欄を、（８）から（42）ま</td>
+            <td class="s4"></td>
+            <td class="s22" colspan="7">(48) その他</td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R56" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s22"></td>
+            <td class="s22"></td>
+            <td class="s22" colspan="2"></td>
+            <td class="s22" colspan="24">ではＤ、Ｅ、Ｆ、Ｇ欄を、（43）から（47）まではＢ欄を、（48）はＢ、Ｄ、Ｅ欄</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R57" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s22"></td>
+            <td class="s22"></td>
+            <td class="s22" colspan="2"></td>
+            <td class="s22" colspan="24">を使用して点検すること。</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R58" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s22"></td>
+            <td class="s22"></td>
+            <td class="s45" colspan="2">５．</td>
+            <td class="s22" colspan="24">点検結果の（ａ）は、機械所有会社の確認欄とし、（ｂ）は持込会社又は機械使用</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R59" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s22"></td>
+            <td class="s22"></td>
+            <td class="s22" colspan="2"></td>
+            <td class="s22" colspan="24">会社の確認欄とする。元請が確認するときは、（ｂ）欄を利用すること。</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R60" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s46"></td>
+            <td class="s46"></td>
+            <td class="s45" colspan="2">６．</td>
+            <td class="s22" colspan="24">場内搬入後、持込機械届済証を当該機械に貼付すること。</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R61" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="13" rowspan="2">元 請 確 認 欄</td>
+            <td class="s8" colspan="12" rowspan="2">受 付 番 号</td>
+            <td class="s8" colspan="12" rowspan="2">受 付 確 認 者</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s46"></td>
+            <td class="s46"></td>
+            <td class="s45" colspan="2">７．</td>
+            <td class="s22" colspan="24">直近に実施した特定（年次）及び月例の定期自主検査帳票の写し、任意保険（移動</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R62" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s46"></td>
+            <td class="s46"></td>
+            <td class="s45" colspan="2"></td>
+            <td class="s22" colspan="24">式クレーンの場合）の写しを必ず添付すること。</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R63" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s8" colspan="2" rowspan="3">担当者</td>
+            <td class="s23" dir="ltr" colspan="11" rowspan="3">「元請確認欄・担当者」13-037</td>
+            <td class="s23" dir="ltr" colspan="12" rowspan="3">「受付番号」13-038</td>
+            <td class="s36" dir="ltr" colspan="7" rowspan="3">「受付確認年月日」13-039</td>
+            <td class="s36" dir="ltr" colspan="5" rowspan="3">「受付確認者」13-040</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s44"></td>
+            <td class="s46"></td>
+            <td class="s45" colspan="2">８．</td>
+            <td class="s22" colspan="24">資格を必要とする建設機械運転者等には作業中、必ず運転免許等の資格証を携帯さ</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R64" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s44"></td>
+            <td class="s46"></td>
+            <td class="s45" colspan="2"></td>
+            <td class="s22" colspan="24">せること。</td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+          <tr style="height: 22px">
+            <th id="1612125903R65" style="height: 22px; border: 1px SOLID #ffffff;" class="row-headers-background">
+              <div class="row-header-wrapper" style="line-height: 22px"></div>
+            </th>
+            <td class="s7"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s44"></td>
+            <td class="s46"></td>
+            <td class="s46"></td>
+            <td class="s46"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s47"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+            <td class="s4"></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="doc_13th_image">
+      <!-- <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAABkCAYAAAA8AQ3AAAAFFElEQVR4Xu3XPy+kexjH4Z9kQyIhJKYYU/AK6DRK7wWVQkQkiskUOtTiBWkVOg0SfxITIjQG8RyzOVtxCs99cmdn95Jstth83Y/rmXxih4ovAgQIDIjA0IA8p8ckQIBAESwfAgIEBkZAsAbmVXlQAgQEy2eAAIGBERCsgXlVHpQAAcHyGSBAYGAEBGtgXpUHJUBAsHwGCBAYGAHBGphX5UEJEKgdrL29ver6+rr0/zw9PZWLi4svNU9OTmrf8HoIEPi9BRYXF6vHx8cvH7LRaJRms1mmpqZKq9Uqm5ub4RZ8+xvMzc1Vp6enZXp6uszMzJTR0dGfDzM+Pl6qqvr04B9h+/aN3/sVeToCBH4JbG1tVb1e70uQbrdb7u/vS//f+7/QXF5elre3t7KwsFCOjo5qdaHOqNrY2Ci7u7t1tt40AQJ/sUCn06na7XZfoFY/6ox+Hvw4XGf7F78qPzoBAv8K9P8rVqsfdUaC5XNHgEAtgcPDw2p5edlvWLX0jAgQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIGIgGBF9GwJEEgVEKxUbscIEIgICFZEz5YAgVQBwUrldowAgYiAYEX0bAkQSBUQrFRuxwgQiAgIVkTPlgCBVAHBSuV2jACBiIBgRfRsCRBIFRCsVG7HCBCICAhWRM+WAIFUAcFK5XaMAIH/QaD6+B5Ddb5PnVHVbrdLp9Ops63zjDYECPwhAvv7+9X6+nr/p6nVjzqjant7u+zs7NTZ/iHsfgwCBH4JHBwc9H9j+vT1+vparq6uSq/XK91ut9ze3pbj4+Py/v5e7u7uavXj26NGo1GNjY2VpaWl0v97ZGSktFqtMjw8XKrq83OvrKx8+4aPAgECgyEwMTFRPTw8fPmwH60ozWaz/Pjxo8zOzpbJyckyPz9f1tbWajeh1nB1dbU6OzsrNzc35fn5uZyfn5eXl5f/Eq51YzBel6ckQCBTQEwytd0iQCAkIFghPmMCBDIFBCtT2y0CBEICghXiMyZAIFNAsDK13SJAICQgWCE+YwIEMgUEK1PbLQIEQgKCFeIzJkAgU0CwMrXdIkAgJCBYIT5jAgQyBQQrU9stAgRCAoIV4jMmQCBTQLAytd0iQCAk8A8IBa+DqEh0OQAAAABJRU5ErkJggg=="> -->
+    </div>
+  </body>
+<% end %>
 
 <style>
   .ritz .waffle a {
@@ -2497,4 +2545,8 @@
     bottom: 1490px;
     left: 375px;
   }
+
+  .page-break {
+		page-break-after: always;
+	}
 </style>

--- a/app/views/users/documents/doc_13th/_show.pdf.erb
+++ b/app/views/users/documents/doc_13th/_show.pdf.erb
@@ -3,8 +3,8 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 
 <% document_info.field_special_vehicles.each do |field_special_vehicle| %>
-  <body style="font-family: Noto Sans JP, Hiragino Kaku Gothic ProN, Meiryo, sans-serif;">
-    <div class="ritz grid-container page-break" dir="ltr">
+  <body class="page-break" style="font-family: Noto Sans JP, Hiragino Kaku Gothic ProN, Meiryo, sans-serif;">
+    <div class="ritz grid-container" dir="ltr">
       <table class="waffle no-grid" cellspacing="0" cellpadding="0">
         <tbody>
           <tr style="height: 22px">
@@ -49,9 +49,7 @@
             <td class="s3"></td>
             <td class="s3"></td>
             <td class="s3"></td>
-            <td class="s4">
-              &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-            </td> <!-- 中心調整 -->
+            <td class="s4" style="letter-spacing: 250px;">&emsp;</td> <!-- 中心調整 -->
             <td class="s4"></td>
             <td class="s5"></td>
             <td class="s5"></td>
@@ -1199,7 +1197,7 @@
               <%= field_special_vehicle.driver_name %> <!-- 13-021 入場する作業員名(運転者名・正) -->
             </td>
             <td class="s23" dir="ltr" colspan="19" rowspan="2">
-              <%= field_special_vehicle.driver_license.split[0][0..20] %>　<!-- 13-022 資格の種類 --> 
+              <%= field_special_vehicle.driver_license.split[0][0..20] if field_special_vehicle.driver_license %>　<!-- 13-022 資格の種類 --> 
             </td>
             <td class="s4"></td>
             <td class="s35"></td>

--- a/app/views/users/documents/doc_13th/_show.pdf.erb
+++ b/app/views/users/documents/doc_13th/_show.pdf.erb
@@ -421,11 +421,15 @@
           </th>
           <td class="s0"></td>
           <td class="s0" colspan="5" rowspan="2">事業所の名称</td>
-          <td class="s25" dir="ltr" colspan="13" rowspan="2">「事業所名（現場名）」13-003</td>
+          <td class="s25" dir="ltr" colspan="13" rowspan="2">
+            <%= document_site_info.site_name %> <!-- 13-003 事業所名(現場名) -->
+          </td>
           <td class="s2"></td>
           <td class="s2"></td>
           <td class="s0" colspan="5" rowspan="2">一次会社名</td>
-          <td class="s25" dir="ltr" colspan="12" rowspan="2">「一次会社名」13-005</td>
+          <td class="s25" dir="ltr" colspan="12" rowspan="2">
+            <%= primary_subcon_name(document_info) %> <!-- 13-005 一次会社名 -->
+          </td>
           <td class="s4"></td>
           <td class="s4"></td>
           <td class="s4"></td>
@@ -459,12 +463,16 @@
           </th>
           <td class="s0"></td>
           <td class="s0" colspan="5" rowspan="2">所 長 名</td>
-          <td class="s26" dir="ltr" colspan="11" rowspan="2">元請会社の「各会社の現場代理人名」13-004</td>
+          <td class="s26" dir="ltr" colspan="11" rowspan="2">
+            <%= document_site_info.site_agent_name %> <!-- 13-004 元請会社の現場代理人名 -->
+          </td>
           <td class="s1" colspan="2" rowspan="2">殿</td>
           <td class="s2"></td>
           <td class="s2"></td>
           <td class="s0" colspan="5">持込会社名</td>
-          <td class="s25" dir="ltr" colspan="12" rowspan="2">「持込会社名」13-007</td>
+          <td class="s25" dir="ltr" colspan="12" rowspan="2">
+            <%= document_info.content&.[]('subcon_name') %> <!-- 13-007 持込会社名(自社名) -->
+          </td>
           <td class="s4"></td>
           <td class="s4"></td>
           <td class="s4"></td>
@@ -484,8 +492,10 @@
           <td class="s2"></td>
           <td class="s2"></td>
           <td class="s0">（</td>
-          <td class="s27" dir="ltr" colspan="2">13-006</td>
-          <td class="s0">次</td>
+          <td class="s27" dir="ltr" colspan="3">
+            <%= sc_hierarchy(document_info) %> <!-- 13-006 次 -->
+            &emsp;&emsp;
+          </td>
           <td class="s0">）</td>
           <td class="s4"></td>
           <td class="s4"></td>
@@ -530,7 +540,9 @@
           <td class="s2"></td>
           <td class="s2"></td>
           <td class="s0" colspan="5" rowspan="2">代 表 者 名</td>
-          <td class="s25" dir="ltr" colspan="10" rowspan="2">持込会社の「代表者名」13-008</td>
+          <td class="s25" dir="ltr" colspan="10" rowspan="2">
+            <%= document_info.content&.[]('subcon_representative_name') %> <!-- 13-008 持込会社の代表者名 -->
+          </td>
           <td class="s31" dir="ltr" colspan="2" rowspan="2">印13-259</td>
           <td class="s4"></td>
           <td class="s4"></td>


### PR DESCRIPTION
### 概要
- order、request_order側の各データを移動式クレーン/車両系建設機械等使用届に反映させる。

### タスク
- [ ] なし
- [x] あり https://trello.com/c/jJp0ksHQ

### 実装内容・手法
- 移動式クレーン/車両系建設機械等使用届詳細画面、PDF画面に各情報の反映
- 未反映部分は「※未実装※」コメントアウトで表記としています。

### 実装画像などあれば添付する


