### PR TITLE
現場,下請現場情報の建設許可関連データ追加(平野)

### DIFF
--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -165,7 +165,13 @@ module Users
           genecon_welfare_pension_insurance_join_status:   current_business.business_welfare_pension_insurance_join_status,   # 厚生年金加入状況
           genecon_welfare_pension_insurance_office_number: current_business.business_welfare_pension_insurance_office_number, # 厚生年金番号
           genecon_employment_insurance_join_status:        current_business.business_employment_insurance_join_status,        # 雇用保険加入状況
-          genecon_employment_insurance_number:             current_business.business_employment_insurance_number              # 雇用保険番号
+          genecon_employment_insurance_number:             current_business.business_employment_insurance_number,             # 雇用保険番号
+          genecon_occupation:                              Occupation.find(current_business.business_occupations.first.occupation_id).name,                       # 業種
+          genecon_construction_license_permission_type_minister_governor:      current_business.construction_license_permission_type_minister_governor_i18n,      # 建設業許可種別(大臣,知事)
+          genecon_construction_license_permission_type_identification_general: current_business.construction_license_permission_type_identification_general_i18n, # 建設業許可種別(特定,一般)
+          genecon_construction_construction_license_number_double_digit:       current_business.construction_license_number_double_digit,                         # 建設業許可番号(2桁)
+          genecon_construction_license_number_six_digits:                      current_business.construction_license_number_six_digits,                           # 建設業許可番号(5桁)
+          genecon_construction_license_updated_at:                             current_business.construction_license_updated_at                                   # 建設許可証(更新日)
         }
       )
     end

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -156,17 +156,17 @@ module Users
         :subcontractor_name
       ).merge(
         content: {
-          genecon_name:                                    current_business.name,                                             # 会社名
-          genecon_address:                                 current_business.address,                                          # 会社住所
-          genecon_carrier_up_id:                           current_business.carrier_up_id,                                    # 事業所ID(キャリアアップ)
-          genecon_health_insurance_status:                 current_business.business_health_insurance_status,                 # 健康保険加入状況
-          genecon_health_insurance_association:            current_business.business_health_insurance_association,            # 健康保険会社
-          genecon_health_insurance_office_number:          current_business.business_health_insurance_office_number,          # 健康保険番号
-          genecon_welfare_pension_insurance_join_status:   current_business.business_welfare_pension_insurance_join_status,   # 厚生年金加入状況
-          genecon_welfare_pension_insurance_office_number: current_business.business_welfare_pension_insurance_office_number, # 厚生年金番号
-          genecon_employment_insurance_join_status:        current_business.business_employment_insurance_join_status,        # 雇用保険加入状況
-          genecon_employment_insurance_number:             current_business.business_employment_insurance_number,             # 雇用保険番号
-          genecon_occupation:                              Occupation.find(current_business.business_occupations.first.occupation_id).name,                       # 業種
+          genecon_name:                                                        current_business.name,                                             # 会社名
+          genecon_address:                                                     current_business.address,                                          # 会社住所
+          genecon_carrier_up_id:                                               current_business.carrier_up_id,                                    # 事業所ID(キャリアアップ)
+          genecon_health_insurance_status:                                     current_business.business_health_insurance_status,                 # 健康保険加入状況
+          genecon_health_insurance_association:                                current_business.business_health_insurance_association,            # 健康保険会社
+          genecon_health_insurance_office_number:                              current_business.business_health_insurance_office_number,          # 健康保険番号
+          genecon_welfare_pension_insurance_join_status:                       current_business.business_welfare_pension_insurance_join_status,   # 厚生年金加入状況
+          genecon_welfare_pension_insurance_office_number:                     current_business.business_welfare_pension_insurance_office_number, # 厚生年金番号
+          genecon_employment_insurance_join_status:                            current_business.business_employment_insurance_join_status,        # 雇用保険加入状況
+          genecon_employment_insurance_number:                                 current_business.business_employment_insurance_number,             # 雇用保険番号
+          genecon_occupation:                                                  Occupation.find(current_business.business_occupations.first.occupation_id).name, # 業種
           genecon_construction_license_permission_type_minister_governor:      current_business.construction_license_permission_type_minister_governor_i18n,      # 建設業許可種別(大臣,知事)
           genecon_construction_license_permission_type_identification_general: current_business.construction_license_permission_type_identification_general_i18n, # 建設業許可種別(特定,一般)
           genecon_construction_construction_license_number_double_digit:       current_business.construction_license_number_double_digit,                         # 建設業許可番号(2桁)

--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -123,21 +123,21 @@ module Users
         :registered_core_engineer_name
       ).merge(
         content: {
-          subcon_name:                                    current_business.name,                                             # 会社名
-          subcon_branch_name:                             current_business.branch_name,                                      # 支店･営業所名
-          subcon_address:                                 current_business.address,                                          # 会社住所
-          subcon_post_code:                               current_business.post_code,                                        # 会社郵便番号
-          subcon_phone_number:                            current_business.phone_number,                                     # 会社電話番号
-          subcon_carrier_up_id:                           current_business.carrier_up_id,                                    # 事業所ID(キャリアアップ)
-          subcon_representative_name:                     current_business.representative_name,                              # 代表者名
-          subcon_health_insurance_status:                 current_business.business_health_insurance_status,                 # 健康保険加入状況
-          subcon_health_insurance_association:            current_business.business_health_insurance_association,            # 健康保険会社
-          subcon_health_insurance_office_number:          current_business.business_health_insurance_office_number,          # 健康保険番号
-          subcon_welfare_pension_insurance_join_status:   current_business.business_welfare_pension_insurance_join_status,   # 厚生年金加入状況
-          subcon_welfare_pension_insurance_office_number: current_business.business_welfare_pension_insurance_office_number, # 厚生年金番号
-          subcon_employment_insurance_join_status:        current_business.business_employment_insurance_join_status,        # 雇用保険加入状況
-          subcon_employment_insurance_number:             current_business.business_employment_insurance_number,             # 雇用保険番号
-          subcon_occupation:                              Occupation.find(current_business.business_occupations.first.occupation_id).name,                       # 業種
+          subcon_name:                                                        current_business.name,                                             # 会社名
+          subcon_branch_name:                                                 current_business.branch_name,                                      # 支店･営業所名
+          subcon_address:                                                     current_business.address,                                          # 会社住所
+          subcon_post_code:                                                   current_business.post_code,                                        # 会社郵便番号
+          subcon_phone_number:                                                current_business.phone_number,                                     # 会社電話番号
+          subcon_carrier_up_id:                                               current_business.carrier_up_id,                                    # 事業所ID(キャリアアップ)
+          subcon_representative_name:                                         current_business.representative_name,                              # 代表者名
+          subcon_health_insurance_status:                                     current_business.business_health_insurance_status,                 # 健康保険加入状況
+          subcon_health_insurance_association:                                current_business.business_health_insurance_association,            # 健康保険会社
+          subcon_health_insurance_office_number:                              current_business.business_health_insurance_office_number,          # 健康保険番号
+          subcon_welfare_pension_insurance_join_status:                       current_business.business_welfare_pension_insurance_join_status,   # 厚生年金加入状況
+          subcon_welfare_pension_insurance_office_number:                     current_business.business_welfare_pension_insurance_office_number, # 厚生年金番号
+          subcon_employment_insurance_join_status:                            current_business.business_employment_insurance_join_status,        # 雇用保険加入状況
+          subcon_employment_insurance_number:                                 current_business.business_employment_insurance_number,             # 雇用保険番号
+          subcon_occupation:                                                  Occupation.find(current_business.business_occupations.first.occupation_id).name, # 業種
           subcon_construction_license_permission_type_minister_governor:      current_business.construction_license_permission_type_minister_governor_i18n,      # 建設業許可種別(大臣,知事)
           subcon_construction_license_permission_type_identification_general: current_business.construction_license_permission_type_identification_general_i18n, # 建設業許可種別(特定,一般)
           subcon_construction_construction_license_number_double_digit:       current_business.construction_license_number_double_digit,                         # 建設業許可番号(2桁)

--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -136,7 +136,13 @@ module Users
           subcon_welfare_pension_insurance_join_status:   current_business.business_welfare_pension_insurance_join_status,   # 厚生年金加入状況
           subcon_welfare_pension_insurance_office_number: current_business.business_welfare_pension_insurance_office_number, # 厚生年金番号
           subcon_employment_insurance_join_status:        current_business.business_employment_insurance_join_status,        # 雇用保険加入状況
-          subcon_employment_insurance_number:             current_business.business_employment_insurance_number              # 雇用保険番号
+          subcon_employment_insurance_number:             current_business.business_employment_insurance_number,             # 雇用保険番号
+          subcon_occupation:                              Occupation.find(current_business.business_occupations.first.occupation_id).name,                       # 業種
+          subcon_construction_license_permission_type_minister_governor:      current_business.construction_license_permission_type_minister_governor_i18n,      # 建設業許可種別(大臣,知事)
+          subcon_construction_license_permission_type_identification_general: current_business.construction_license_permission_type_identification_general_i18n, # 建設業許可種別(特定,一般)
+          subcon_construction_construction_license_number_double_digit:       current_business.construction_license_number_double_digit,                         # 建設業許可番号(2桁)
+          subcon_construction_license_number_six_digits:                      current_business.construction_license_number_six_digits,                           # 建設業許可番号(5桁)
+          subcon_construction_license_updated_at:                             current_business.construction_license_updated_at                                   # 建設許可証(更新日)
         }
       )
     end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -18,16 +18,16 @@ module DocumentsHelper
   # 一次下請の情報
   def subcon_info
     request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
-    request_order if request_order.parent_id == 1
+    request_order if request_order.depth == 1
   end
 
   def subcons_info
     request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
-    request_order.children if request_order.parent_id.nil?
+    request_order.children if request_order.depth == 0
   end
 
   def document_subcon_info
-    if RequestOrder.find_by(uuid: params[:request_order_uuid]).parent_id == 1
+    if RequestOrder.find_by(uuid: params[:request_order_uuid]).depth == 1
       subcon_info
     else
       @subcon

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -23,7 +23,7 @@ module DocumentsHelper
 
   def subcons_info
     request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
-    request_order.children if request_order.depth == 0
+    request_order.children if request_order.depth.zero?
   end
 
   def document_subcon_info

--- a/app/views/users/documents/doc_4th/_form.html.erb
+++ b/app/views/users/documents/doc_4th/_form.html.erb
@@ -52,7 +52,7 @@
         <table class="table table-sm table-bordered" width="100%">
           <tbody>
             <tr>
-              <td rowspan="5" width=10%">建設業の<br />許可</td>
+              <td rowspan="5" width="10%">建設業の<br />許可</td>
               <td colspan="2" width="25%">許 可 業 種</td>
               <td colspan="6" width="35%">許 可 番 号</td>
               <td width="30%">許可 （更新） 年月日</td>

--- a/app/views/users/documents/doc_4th/_show.html.erb
+++ b/app/views/users/documents/doc_4th/_show.html.erb
@@ -1,5 +1,5 @@
 <!-- (4)全建統一様式第3号(施工体制台帳) -->
-<% if RequestOrder.find_by(uuid: params[:request_order_uuid]).parent_id == 1 %>
+<% if RequestOrder.find_by(uuid: params[:request_order_uuid]).depth == 1 %>
   <%= render "users/documents/doc_4th/form" %>
 <% else %>
   <% subcons_info.each do |subcon| @subcon = subcon %>


### PR DESCRIPTION
### 概要
- order、request_orderのconten内に会社情報の建設許可関連のデータを追加

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- (4)施工体制台帳、(5)再下請負通知書(変更届)で使用する建設許可関連データを、orderとrequest_orderのcontentカラムに保存させる。

### 実装画像などあれば添付する
- 例；(元請)order.contentの中身
![FireShot Capture 030 - JSONきれい ～JSON整形ツール～ - instant tools - tools m-bsys com](https://user-images.githubusercontent.com/52871417/212538067-54be4886-ed53-435b-b26d-ad38f247f255.png)

