### PR TITLE
元請の書類承認時のバリデーション回避

### DIFF
--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -60,7 +60,7 @@ module Users
 
     def submit
       if @request_order.parent_id.nil? && @request_order.children.all? { |r| r.status == 'approved' }
-        @request_order.approved!
+        @request_order.update_column(:status, 'approved')
         flash[:success] = '下請発注情報を承認しました'
       elsif @request_order.children.all? { |r| r.status == 'approved' }
         @request_order.submitted!


### PR DESCRIPTION
### 概要
元請の書類承認時のバリデーション回避をしました。

原因
承認(submitアクション)でrequest_orderのstatusカラムをアップデートするときにrequest_order.rbに記載されているバリデーションがかかりエラーが発生している

作成時にバリデーションがかからない理由：
orderにrequest_orderをbuildしてorderをsaveしているため、order.rbに記載されているバリデーションしかかからない(request_order.rbのバリデーションはかからない)

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
stautsのみ更新し、他カラムのバリデーションは無視するような実装とした。
参考：http://railman.net/railsguides/5.1/active_record_validations.html
　　　https://qiita.com/lemtosh469/items/371544fa4fd3c333adf1

### 実装画像などあれば添付する
<img width="850" alt="image" src="https://user-images.githubusercontent.com/80724165/213897132-bf7f9cb1-ccb0-4097-9c96-d2bcb54ed0ce.png">
<img width="653" alt="image" src="https://user-images.githubusercontent.com/80724165/213897193-3fad57ce-c021-495a-b22b-189efd456219.png">


