### PR TITLE
承認時の編集と下請けへの依頼禁止

### DIFF
--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -5,6 +5,8 @@ module Users
     before_action :set_documents # サイドバーに常時表示させるために必要
     before_action :set_document, except: :index # オブジェクトが1つも無い場合、indexで呼び出さないようにする
     before_action :set_workers, only: %i[show edit update] # 2次下請以下の作業員を定義する
+    before_action :set_workers, only: %i[show edit update]
+    before_action :edit_restriction_after_approved, only: %i[edit update]
 
     def index; end
 
@@ -160,6 +162,14 @@ module Users
         end
         merge_workers = workers&.map { |sub_worker| { sub_worker&.name => sub_worker&.uuid } }
         @workers_name_uuid = {}.merge(*merge_workers)
+      end
+    end
+
+    def edit_restriction_after_approved
+      request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
+      if request_order.status == 'approved'
+        flash[:danger] = '承認されているため編集できません'
+        redirect_to users_request_order_document_url
       end
     end
 

--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -5,7 +5,6 @@ module Users
     before_action :set_documents # サイドバーに常時表示させるために必要
     before_action :set_document, except: :index # オブジェクトが1つも無い場合、indexで呼び出さないようにする
     before_action :set_workers, only: %i[show edit update] # 2次下請以下の作業員を定義する
-    before_action :set_workers, only: %i[show edit update]
     before_action :edit_restriction_after_approved, only: %i[edit update]
 
     def index; end

--- a/app/controllers/users/sub_request_orders_controller.rb
+++ b/app/controllers/users/sub_request_orders_controller.rb
@@ -1,6 +1,7 @@
 module Users
   class SubRequestOrdersController < Users::Base
     before_action :set_request_order
+    before_action :order_restriction_after_approved, only: %i[new create]
 
     def index; end
 
@@ -33,6 +34,14 @@ module Users
     def create_documents!(request_order)
       Document::OPERATABLE_DOC_TYPE.each do |document_type|
         request_order.documents.create!(document_type: document_type, business_id: request_order.business_id)
+      end
+    end
+
+    def order_restriction_after_approved
+      request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
+      if request_order.status == 'approved'
+        flash[:danger] = '承認されているため依頼できません'
+        redirect_to users_request_order_url(uuid: params[:request_order_uuid])
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -123,4 +123,6 @@ RSpec.configure do |config|
     Capybara.server_port = 3000
     Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
   end
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -1,7 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe 'Documents', type: :request do
+  let!(:user) { create(:user) }
+  let!(:business) { create(:business, user: user) }
+  let!(:order) { create(:order, business: business) }
+  let!(:worker) { create(:worker, business: business) }
+  let!(:document) { create(:document, business: business, request_order: request_order) }
+  let(:doc_19th) { create(:document, :doc_19th, business: business, request_order: request_order) }
+
   describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
+  end
+
+  describe 'GET/edit' do
+    subject { doc_19th }
+    let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
+
+    before do
+      sign_in user
+      get edit_users_request_order_document_path(request_order, subject)
+    end
+
+    it '指定のURLにリダイレクトされる' do
+      expect(response).to redirect_to(users_request_order_document_url)
+    end
+  end
+
+  describe 'PATCH/update' do
+    subject { doc_19th }
+    let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
+
+    before do
+      sign_in user
+      patch users_request_order_document_path(request_order, subject)
+    end
+
+    it '指定のURLにリダイレクトされる' do
+      expect(response).to redirect_to(users_request_order_document_url)
+    end
   end
 end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe 'Documents', type: :request do
 
   describe 'GET/edit' do
     subject { doc_19th }
+
     let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
 
-    before do
+    before(:each) do
       sign_in user
       get edit_users_request_order_document_path(request_order, subject)
     end
@@ -28,9 +29,10 @@ RSpec.describe 'Documents', type: :request do
 
   describe 'PATCH/update' do
     subject { doc_19th }
+
     let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
 
-    before do
+    before(:each) do
       sign_in user
       patch users_request_order_document_path(request_order, subject)
     end

--- a/spec/requests/sub_request_orders_spec.rb
+++ b/spec/requests/sub_request_orders_spec.rb
@@ -1,7 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe 'SubRequestOrders', type: :request do
+  let!(:user) { create(:user) }
+  let!(:business) { create(:business, user: user) }
+  let!(:order) { create(:order, business: business) }
+  let!(:worker) { create(:worker, business: business) }
+  let!(:document) { create(:document, business: business, request_order: request_order) }
+
   describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
+  end
+
+  describe 'GET/new' do
+    let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
+
+    before do
+      sign_in user
+      get new_users_request_order_sub_request_order_path(request_order)
+    end
+
+    it '指定のURLにリダイレクトされる' do
+      expect(response).to redirect_to(users_request_order_url(request_order))
+    end
+  end
+
+  describe 'Post/create' do
+    let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
+
+    before do
+      sign_in user
+      post users_request_order_sub_request_orders_path(request_order)
+    end
+
+    it '指定のURLにリダイレクトされる' do
+      expect(response).to redirect_to(users_request_order_url(request_order))
+    end
   end
 end

--- a/spec/requests/sub_request_orders_spec.rb
+++ b/spec/requests/sub_request_orders_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'SubRequestOrders', type: :request do
   describe 'GET/new' do
     let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
 
-    before do
+    before(:each) do
       sign_in user
       get new_users_request_order_sub_request_order_path(request_order)
     end
@@ -27,7 +27,7 @@ RSpec.describe 'SubRequestOrders', type: :request do
   describe 'Post/create' do
     let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
 
-    before do
+    before(:each) do
       sign_in user
       post users_request_order_sub_request_orders_path(request_order)
     end


### PR DESCRIPTION
### 概要
承認時の編集と下請けへの依頼禁止する設定を追加

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
承認時の編集と下請けへの依頼禁止するbefore_actionを設定

![image](https://user-images.githubusercontent.com/80724165/215113465-1b3e79c9-c8ef-4d88-919c-71fe52dcf99d.png)

![image](https://user-images.githubusercontent.com/80724165/215113954-f12b1792-be6a-452c-ab6b-38ababcadf32.png)


