### PR TITLE
承認取り消し機能追加

### DIFF
--- a/app/javascript/stylesheets/users.scss
+++ b/app/javascript/stylesheets/users.scss
@@ -20,3 +20,32 @@ form.cmxform label.error, label.error {
 .line_through {
   text-decoration: line-through;
 }
+
+.step {
+  font-size: 120%;
+  margin : 20px ;
+}
+
+.step_first {
+  text-indent: 20px;
+  font-size: 120%;
+  margin : 20px ;
+}
+
+.step_second {
+  text-indent: 40px;
+  font-size: 120%;
+  margin : 20px ;
+}
+
+.step_third {
+  text-indent: 60px;
+  font-size: 120%;
+  margin : 20px ;
+}
+
+.step_forth {
+  text-indent: 80px;
+  font-size: 120%;
+  margin : 20px ;
+}

--- a/app/views/users/request_orders/edit_approval_status.html.erb
+++ b/app/views/users/request_orders/edit_approval_status.html.erb
@@ -1,6 +1,6 @@
-<% provide(:title, "発注依頼承認取り消し") %>
+<% provide(:title, "書類作成依頼承認取り消し") %>
 <% provide(:btn_text, "取り消し") %>
-<font color="red">※ 取り消す依頼を選んでください。</br>&emsp;元請を含め、選んだ下請けの依頼から上の階層の承認が取り消されます。</font>
+<font color="red">&emsp;※ 承認を取り消す依頼を選んでください。</br>&emsp;&emsp;元請(自身)を含め、選んだ下請けの依頼から上の階層の承認が取り消されます。</font>
 <div class="card">
   <div class="card-body">
     <%= form_with url: users_request_order_update_approval_status_path(@request_order), method: :post, local: true do |f| %>

--- a/app/views/users/request_orders/edit_approval_status.html.erb
+++ b/app/views/users/request_orders/edit_approval_status.html.erb
@@ -1,0 +1,59 @@
+<% provide(:title, "発注依頼承認取り消し") %>
+<% provide(:btn_text, "取り消し") %>
+<font color="red">※ 取り消す依頼を選んでください。</br>&emsp;元請を含め、選んだ下請けの依頼から上の階層の承認が取り消されます。</font>
+<div class="card">
+  <div class="card-body">
+    <%= form_with url: users_request_order_update_approval_status_path(@request_order), method: :post, local: true do |f| %>
+      <div class = 'step'>
+        <% if @request_order.status == 'approved'%>
+          <%= f.radio_button :resecission_uuid, @request_order.uuid %>
+        <% end %>
+        <b>元請(自身)</b>&emsp;
+        <%= @request_order.business.name %>
+        (ステータス：<%= I18n.t("enums.request_order.status.#{@request_order.status}") %>)
+      </div>
+      <% @request_order.children.each do |first_request_order| %>
+        <div class = 'step_first'>
+          <% if first_request_order.status == 'approved'%>
+            <%= f.radio_button :resecission_uuid, first_request_order.uuid %>
+          <% end %>
+          <b>一次下請け</b>&emsp;
+          <%= first_request_order.content&.[]('subcon_name') %>
+          (ステータス：<%= I18n.t("enums.request_order.status.#{first_request_order.status}") %>)
+        </div>
+        <% first_request_order.children.each do |second_request_order| %>
+          <div class = 'step_second'>
+            <% if second_request_order.status == 'approved'%>
+              <%= f.radio_button :resecission_uuid, second_request_order.uuid %>
+            <% end %>
+            <b>二次下請け</b>&emsp;
+            <%= second_request_order.content&.[]('subcon_name') %>
+            (ステータス：<%= I18n.t("enums.request_order.status.#{second_request_order.status}") %>)
+          </div>
+          <% second_request_order.children.each do |third_request_order| %>
+            <div class = 'step_third'>
+              <% if third_request_order.status == 'approved'%>
+                <%= f.radio_button :resecission_uuid, third_request_order.uuid %>
+              <% end %>
+              <b>三次下請け</b>&emsp;
+              <%= third_request_order.content&.[]('subcon_name') %>
+              (ステータス：<%= I18n.t("enums.request_order.status.#{third_request_order.status}") %>)
+            </div>
+            <% third_request_order.children.each do |forth_request_order| %>
+              <div class = 'step_forth'>
+                <% if forth_request_order.status == 'approved'%>
+                  <%= f.radio_button :resecission_uuid, forth_request_order.uuid %>
+                <%end%>
+                <b>四次下請け</b>&emsp;
+                <%= forth_request_order.content&.[]('subcon_name') %>
+                (ステータス：<%= I18n.t("enums.request_order.status.#{forth_request_order.status}") %>)
+              </div>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %></br>
+      <%= f.submit yield(:btn_text), class: "btn btn-md btn-block btn-primary", data: { confirm: "承認を取り消して宜しいですか？" } %>
+      <%= link_to "戻る", users_request_order_path(@request_order), class: "btn btn-md btn-block btn-default" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/request_orders/show.html.erb
+++ b/app/views/users/request_orders/show.html.erb
@@ -35,11 +35,18 @@
                 <div class="col-md-4 mb-2">
                 <%= link_to "下請発注情報一覧", users_request_orders_path, class: "btn btn-block btn-default" %>
               </div>
-            </div>
-            <div class="row">
-              <div class="col-md-12 mb-2">
-                <%= link_to "一覧画面へ", users_request_orders_path, class: "btn btn-md btn-block btn-default" %>
+              <div class="row">
+                <div class="col-md-12 mb-2">
+                  <%= link_to "一覧画面へ", users_request_orders_path, class: "btn btn-md btn-block btn-default" %>
+                </div>
               </div>
+              <% if @request_order.parent.nil? %>
+                <div class="row">
+                  <div class="col-md-12 mb-2">
+                    <%= link_to "承認取り消し画面へ", users_request_order_edit_approval_status_path(@request_order), class: "btn btn-md btn-block btn-default" %>
+                  </div>
+                </div>
+              <% end %>
             </div>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     post 'request_orders/:uuid/submit', to: 'request_orders#submit', as: :request_order_submit
     post 'request_orders/:uuid/sub_request_orders/:sub_request_uuid/fix_request', to: 'request_orders#fix_request', as: :request_order_fix_request
     post 'request_orders/:uuid/sub_request_orders/:sub_request_uuid/approve', to: 'request_orders#approve', as: :request_order_approve
+    get 'request_orders/:uuid/edit_approval_status', to: 'request_orders#edit_approval_status', as: :request_order_edit_approval_status
+    post 'request_orders/:uuid/update_approval_status', to: 'request_orders#update_approval_status', as: :request_order_update_approval_status
   end
   # =================================================================
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -123,4 +123,6 @@ RSpec.configure do |config|
     Capybara.server_port = 3000
     Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
   end
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/request_orders_spec.rb
+++ b/spec/requests/request_orders_spec.rb
@@ -1,7 +1,87 @@
 require 'rails_helper'
 
 RSpec.describe 'RequestOrders', type: :request do
+  let!(:user) { create(:user) }
+  let!(:user_first_sub) { create(:user, name: '1次下請けユーザー', email: 'first_sub-user@example.com', password: '123456', password_confirmation: '123456', role: 'admin') }
+  let!(:business) { create(:business, user: user) }
+  let!(:business_first_sub) { create(:business, user: user_first_sub) }
+  let!(:order) { create(:order, business: business) }
+
   describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
+  end
+
+  describe 'GET/edit_approval_status' do
+    let!(:request_order) { create(:request_order, business: business, order: order) }
+    let!(:request_order_first_sub) { create(:request_order, parent_id: request_order.id, business: business_first_sub, order: order) }
+
+    context '元請の場合' do
+      before(:each) do
+        sign_in user
+        get users_request_order_edit_approval_status_path(request_order)
+      end
+
+      it '正常レスポンスが返ってくる' do
+        expect(response).to have_http_status '200'
+      end
+    end
+
+    context '下請けの場合' do
+      before(:each) do
+        sign_in user_first_sub
+        get users_request_order_edit_approval_status_path(request_order_first_sub)
+      end
+
+      it '指定のURLにリダイレクトされる' do
+        expect(response).to redirect_to(users_request_order_url)
+      end
+    end
+  end
+
+  describe 'Post/update_approval_status' do
+    let!(:request_order) { create(:request_order, business: business, order: order, status: 'approved') }
+    let!(:request_order_first_sub) { create(:request_order, parent_id: request_order.id, business: business_first_sub, order: order, status: 'approved') }
+
+    context '元請が自分自身の承認をキャンセルした場合' do
+      before(:each) do
+        sign_in user
+        post users_request_order_update_approval_status_path(uuid: request_order.uuid, resecission_uuid: request_order.uuid)
+      end
+
+      it '元請のステータスがrequestedに変更される' do
+        expect(request_order.reload.status).to eq 'requested'
+      end
+
+      it '下請けのステータスがrequestedに変更されない' do
+        expect(request_order_first_sub.reload.status).to eq 'approved'
+      end
+    end
+
+    context '元請が一次下請けの承認をキャンセルした場合' do
+      before(:each) do
+        sign_in user
+        post users_request_order_update_approval_status_path(uuid: request_order.uuid, resecission_uuid: request_order_first_sub.uuid)
+      end
+
+      it '元請のステータスがrequestedに変更される' do
+        expect(request_order.reload.status).to eq 'requested'
+      end
+
+      it '下請けのステータスがrequestedに変更される' do
+        expect(request_order_first_sub.reload.status).to eq 'requested'
+      end
+    end
+
+    context '下請けが一次下請けの承認をキャンセルした場合' do
+      before(:each) do
+        sign_in user_first_sub
+        post users_request_order_update_approval_status_path(uuid: request_order_first_sub.uuid,
+          resecission_uuid: request_order_first_sub.uuid)
+      end
+
+      it '指定のURLにリダイレクトされる' do
+        expect(response).to redirect_to(users_request_order_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
### 概要
承認取り消し機能追加

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
新たに画面を作成
元請のリクエストオーダにぶら下がっているリクエストオーダを表示
ラジオボタンにて承認済みのリクエストオーダを選べるようになっている。

### 実装画像などあれば添付する
![image](https://user-images.githubusercontent.com/80724165/215273072-fba1f09a-b72f-4159-8137-032057322b68.png)


