### PR TITLE
作業員外国人責任者役職のデータ型をstringからjsonに変更

### DIFF
--- a/db/migrate/20220128032655_create_workers.rb
+++ b/db/migrate/20220128032655_create_workers.rb
@@ -29,7 +29,7 @@ class CreateWorkers < ActiveRecord::Migration[6.1]
       t.date :maturity_date
       t.integer :confirmed_check, null: false, default: 0
       t.date :confirmed_check_date
-      t.string :responsible_director
+      t.json :responsible_director
       t.string :responsible_name
       t.integer :responsible_contact_address
       t.json :passport

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -774,7 +774,7 @@ ActiveRecord::Schema.define(version: 2023_01_31_030912) do
     t.date "maturity_date"
     t.integer "confirmed_check", default: 0, null: false
     t.date "confirmed_check_date"
-    t.string "responsible_director"
+    t.json "responsible_director"
     t.string "responsible_name"
     t.integer "responsible_contact_address"
     t.json "passport"


### PR DESCRIPTION
### 概要
作業員情報の外国人責任者の役職を複数持たせるための変更

ーrails db:migrate検証済みー

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
wokerマイグレーションファイルのresponsible_directorカラムのデータ型をstringからjsonに変更

### 実装画像などあれば添付する


