### PR TITLE
書類画面HTML修正【(15)有機溶剤・特定化学物質等持込使用届】(池田) Re fix/doc 15th edit

### DIFF
--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -105,6 +105,19 @@ module Users
           flash[:danger] = @error_msg_for_doc_14th.first
           render action: :edit
         end
+      when 'doc_15th'
+        @error_msg_for_doc_15th = @document.error_msg_for_doc_15th(document_params(@document))
+        if @error_msg_for_doc_15th.blank?
+          if @document.update(document_params(@document))
+            redirect_to users_request_order_document_url, success: "保存に成功しました"
+          else
+            flash[:danger] = '保存に失敗しました'
+            render action: :edit
+          end
+        else
+          flash[:danger] = @error_msg_for_doc_15th.first
+          render action: :edit
+        end
       when 'doc_19th'
         @error_msg_for_doc_19th = @document.error_msg_for_doc_19th(document_params(@document))
         if @error_msg_for_doc_19th.blank?
@@ -590,6 +603,12 @@ module Users
             prime_contractor_confirmation
             reception_confirmation_date
             inspection_date
+          ]
+        )
+      when 'doc_15th'
+        params.require(:document).permit(
+          content: [
+            :date_submitted
           ]
         )
       when 'doc_19th'

--- a/app/controllers/users/orders/field_solvents_controller.rb
+++ b/app/controllers/users/orders/field_solvents_controller.rb
@@ -126,7 +126,7 @@ module Users::Orders
 
     def field_solvent_params
       params.require(:field_solvent).permit(
-        :date_submitted, :solvent_name_one, :solvent_name_two, :solvent_name_three, :solvent_name_four, :solvent_name_five,
+        :solvent_name_one, :solvent_name_two, :solvent_name_three, :solvent_name_four, :solvent_name_five,
         :carried_quantity_one, :carried_quantity_two, :carried_quantity_three, :carried_quantity_four, :carried_quantity_five,
         :solvent_classification_one, :solvent_classification_two, :solvent_classification_three, :solvent_classification_four,
         :solvent_classification_five,

--- a/app/controllers/users/request_orders/field_solvents_controller.rb
+++ b/app/controllers/users/request_orders/field_solvents_controller.rb
@@ -126,7 +126,7 @@ module Users::RequestOrders
 
     def field_solvent_params
       params.require(:field_solvent).permit(
-        :date_submitted, :solvent_name_one, :solvent_name_two, :solvent_name_three, :solvent_name_four, :solvent_name_five,
+        :solvent_name_one, :solvent_name_two, :solvent_name_three, :solvent_name_four, :solvent_name_five,
         :carried_quantity_one, :carried_quantity_two, :carried_quantity_three, :carried_quantity_four, :carried_quantity_five,
         :solvent_classification_one, :solvent_classification_two, :solvent_classification_three, :solvent_classification_four,
         :solvent_classification_five,

--- a/app/javascript/stylesheets/users/doc_15th.scss
+++ b/app/javascript/stylesheets/users/doc_15th.scss
@@ -33,6 +33,18 @@
   height: 14px;
 }
 
+.s_15_01_r {
+  border:0px SOLID #ffffff;
+  background-color:#ffffff;
+  text-align:left;
+  font-size:12pt;
+  color:red;
+  vertical-align:middle;
+  direction:ltr;
+  width: 25.25px;
+  height: 14px;
+}
+
 // 様式・元請確認欄
 .s_15_1 {
   border:1px SOLID #000000;
@@ -45,9 +57,20 @@
   height: 19.5px;
 }
 
+.s_15_1_1 {
+  border:1px SOLID #000000;
+  background-color: #e9ecef;
+  text-align:center;
+  font-size:11pt;
+  vertical-align:middle;
+  direction:ltr;
+  width: 25.25px;
+  height: 19.5px;
+}
+
 .s_15_2 {
   border:0px SOLID #ffffff;
-  background-color:#ffffff;
+  background-color: #ccffcc;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -87,7 +110,7 @@
   border-right:0px SOLID #ffffff;
   border-bottom:1px SOLID #000000;
   border-left:0px SOLID #ffffff;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -113,7 +136,7 @@
   border-right:0px SOLID #ffffff;
   border-bottom:1px SOLID #000000;
   border-left:0px SOLID #ffffff;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:9pt;
   vertical-align:middle;
@@ -140,7 +163,7 @@
   border-right:0px SOLID #ffffff;
   border-bottom:1px SOLID #000000;
   border-left:0px SOLID #ffffff;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -186,9 +209,31 @@
   height: 37px;
 }
 
+.s_15_12_1 {
+  border:1px SOLID #000000;
+  background-color: #e9ecef;
+  text-align:center;
+  font-size:11pt;
+  vertical-align:middle;
+  direction:ltr;
+  width: 25.25px;
+  height: 37px;
+}
+
 .s_15_13 {
   border:1px SOLID #000000;
   background-color:#ffffff;
+  text-align:center;
+  font-size:11pt;
+  vertical-align:middle;
+  direction:ltr;
+  width: 25.25px;
+  height: 37px;
+}
+
+.s_15_13_1 {
+  border:1px SOLID #000000;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -224,7 +269,7 @@
 
 .s_15_21 {
   border:1px SOLID #000000;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -256,6 +301,17 @@
   height: 74px;
 }
 
+.s_15_31_1 {
+  border:1px SOLID #000000;
+  background-color: #e9ecef;
+  text-align:center;
+  font-size:11pt;
+  vertical-align:middle;
+  direction:ltr;
+  width: 25.25px;
+  height: 74px;
+}
+
 // 使用期間
 .s_15_40 {
   border:1px SOLID #000000;
@@ -273,7 +329,7 @@
   border-right:0px SOLID #ffffff;
   border-bottom:1px SOLID #000000;
   border-left:1px SOLID #000000;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -301,7 +357,7 @@
   border-right:0px SOLID #ffffff;
   border-bottom:1px SOLID #000000;
   border-left:0px SOLID #ffffff;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -355,7 +411,7 @@
   border-right:1px SOLID #000000;
   border-bottom:0px SOLID #ffffff;
   border-left:0px SOLID #ffffff;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -397,7 +453,7 @@
   border-right:0px SOLID #ffffff;
   border-bottom:1px SOLID #000000;
   border-left:0px SOLID #ffffff;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -479,7 +535,7 @@
   border-right:0px SOLID #ffffff;
   border-bottom:1px SOLID #000000;
   border-left:0px SOLID #ffffff;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;
@@ -516,7 +572,7 @@
 
 .s_15_71 {
   border:1px SOLID #000000;
-  background-color:#ffffff;
+  background-color: #e9ecef;
   text-align:center;
   font-size:11pt;
   vertical-align:middle;

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -95,6 +95,18 @@ class Document < ApplicationRecord
     end
   end
 
+  # エラーメッセージ(有機溶剤・特定化学物質等持込使用届)
+  def error_msg_for_doc_15th(document_params)
+    if document_type == 'doc_15th'
+      error_msg_for_doc_15th = []
+      # 提出日
+      if document_params[:content][:date_submitted].blank?
+        error_msg_for_doc_15th.push('提出日を入力してください')
+      end
+      error_msg_for_doc_15th
+    end
+  end
+
   # エラーメッセージ(工事安全衛生計画書用)
   def error_msg_for_doc_19th(document_params)
     error_msg_for_doc_19th = []

--- a/app/models/field_solvent.rb
+++ b/app/models/field_solvent.rb
@@ -10,7 +10,6 @@ class FieldSolvent < ApplicationRecord
   enum working_process: { y: 0, n: 1 }, _prefix: true
   enum sds: { y: 0, n: 1 }, _prefix: true
 
-  validates :date_submitted, presence: true
   validates :solvent_name_one, presence: true
   validates :carried_quantity_one, presence: true
   validates :using_location, length: { maximum: 100 }

--- a/app/views/users/documents/doc_15th/_edit.html.erb
+++ b/app/views/users/documents/doc_15th/_edit.html.erb
@@ -1,0 +1,884 @@
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
+  integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+
+<!-- (1５)全建統一様式第１１号(有機溶剤・特定化学物質等持込使用届) -->
+<% document_info.field_solvents.each do |field_solvent| %>
+  <%= form_with(model: @document, url: users_request_order_document_path, local: true, method: :patch) do |f| %>
+    <div class="document-outer">
+      <div class="card">  
+        <div class="card-body">
+          <%= f.submit '登録', class: 'btn btn-block btn-primary' %>
+          <%= link_to '詳細画面へ', users_request_order_document_url, class: "btn btn-md btn-block btn-default" %>
+        </div>
+      </div>
+
+      <div id="s_15" class="document-inner">
+        <div class="s_15_text-container">
+          <table class="no-grid" cellspacing="0" cellpadding="0">
+            <thead></thead>
+            <tbody>
+              <tr><!-- 1行目 -->
+                <td class="s_15_1" colspan="6">参考様式第11号</td><!-- 1列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 10列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 20列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_1" colspan="3" rowspan="2">
+                    元 請<br />
+                    確認欄</td>
+                <td class="s_15_1_1" dir="ltr" colspan="8" rowspan="2">
+                  <%= '※15-001未実装※' %><!-- 「元請会社の確認欄」15-001 -->
+                </td>
+              </tr>
+              <tr><!-- 2行目 -->
+                <td class="s_15_00"></td><!-- 1列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 10列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 20列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+              </tr>
+              <tr><!-- 3行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 4行目 -->
+                <td class="s_15_00"></td><!-- 1列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 10列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 20列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_2" dir="ltr" colspan="8" rowspan="2"><span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+                  <%= f.date_field name = 'content[date_submitted]',
+                                include_blank: true,
+                                value: @document.content&.[]('date_submitted') %><!-- 15-002 「提出日(西暦)」 -->
+                </td>
+              </tr>
+              <tr><!-- 5行目 -->
+                <td class="s_15_00"></td><!-- 1列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 10列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 20列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+              </tr>
+              <tr><!-- 6行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 7行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 8行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_3" dir="ltr" colspan="22" rowspan="2">有機溶剤・特定化学物質等持込使用届</td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+              </tr>
+              <tr><!-- 9行目 -->
+                <td class="s_15_00"></td><!-- 1列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+              </tr>
+              <tr><!-- 10行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 11行目 -->
+                <td class="s_15_4" dir="ltr" colspan="5" rowspan="2">事業所の名称</td><!-- 1列目 -->
+                <td class="s_15_5" dir="ltr" colspan="12" rowspan="2">
+                  <%= document_site_info.site_name %> <!-- 15-003 「事業所名(現場名)」 -->
+                </td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 20列目 -->
+                <td class="s_15_4" dir="ltr" colspan="5" rowspan="2">一次会社名</td>
+                <td class="s_15_5" dir="ltr" colspan="12" rowspan="2">
+                  <%= '※15-005未実装※' %> <!-- 15-005 「一次会社名」 -->
+                </td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 12行目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 20列目 -->
+              </tr>
+              <tr><!-- 13行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 14行目 -->
+                <td class="s_15_4" dir="ltr" colspan="5" rowspan="2">所長名</td><!-- 1列目 -->
+                <td class="s_15_9" dir="ltr" colspan="10" rowspan="2">
+                  <%= document_site_info.site_agent_name %> <!-- 15-004 元請会社の「各会社の現場代理人名」 -->
+                </td>
+                <td class="s_15_9" dir="ltr" colspan="2" rowspan="2">殿</td>
+                <td class="s_15_00"></td><!-- 20列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_6" dir="ltr" colspan="5">使用会社名</td>
+                <td class="s_15_9" dir="ltr" colspan="12" rowspan="2">
+                  <%= Business.find(document_info.business_id).name %> <!-- 15-007 「会社名」 -->
+                </td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 15行目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_6">(</td>
+                <td class="s_15_8" dir="ltr" colspan="2">
+                  <%= sc_hierarchy(document_info) %> <!-- 15-006 次 -->
+                </td>
+                <td class="s_15_6">
+                  次
+                </td>
+                <td class="s_15_6">)</td>
+              </tr>
+              <tr><!-- 16行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 17行目 -->
+                <td class="s_15_00"></td><!-- 1列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 10列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_6" dir="ltr" colspan="5">現場代理人</td>
+                <td class="s_15_5" dir="ltr" colspan="10" rowspan="2">
+                  <%= document_site_info.site_agent_name %> <!-- 15-008 「各会社の現場代理人名」 -->
+                </td><!-- 36列目 -->
+                <td class="s_15_7" dir="ltr" colspan="2" rowspan="2">
+                  ㊞<%= '※15-009未実装※' %> <!-- 15-009 ㊞ -->
+                </td>
+              </tr>
+              <tr><!-- 18行目 -->
+                <td class="s_15_00"></td><!-- 1列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td><!-- 10列目 -->
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_00"></td>
+                <td class="s_15_6" dir="ltr" colspan="5">(現場責任者)</td><!-- 20列目 -->
+              </tr>
+              <tr><!-- 19行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 20行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 21行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 22行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_10" dir="ltr" colspan="29">このたび、下記の有機物質・特定化学物質等を持込・使用するのでお届けします。なお、</td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 23行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_10" dir="ltr" colspan="29">使用に際しては、ＳＤＳ(安全データシート)内容を掲示し、作業員に対して周知を行うと</td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 24行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_10" dir="ltr" colspan="29">ともに関係法規を遵守します。</td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 25行目 -->
+                <td class="s_15_11" dir="ltr" colspan="5" rowspan="12">使用材料</td><!-- 1列目 -->
+                <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">商品名</td>
+                <td class="s_15_13" dir="ltr" colspan="4" rowspan="2">搬入量</td>
+                <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">種別</td>
+                <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">含有成分</td>
+              </tr>
+              <tr><!-- 26行目 -->
+              </tr>
+              <tr><!-- 27行目 -->
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_name_one %> <!-- 15-010 「商品名1」 -->
+                </td>
+                <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
+                  <%= field_solvent.carried_quantity_one %> <!-- 15-012 「搬入量1(書類作成時に記載)」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_classification_one %> <!-- 15-013 「種別1」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_ingredients_one %> <!-- 15-014 「含有成分1」 -->
+                </td>
+              </tr>
+              <tr><!-- 28行目 -->
+              </tr>
+              <tr><!-- 29行目 -->
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_name_two %> <!-- 15-010 「商品名2」 -->
+                </td>
+                <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
+                  <%= field_solvent.carried_quantity_two %> <!-- 15-012 「搬入量2(書類作成時に記載)」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_classification_two %> <!-- 15-013 「種別2」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_ingredients_two %> <!-- 15-014 「含有成分2」 -->
+                </td>
+              </tr>
+              <tr><!-- 30行目 -->
+              </tr>
+              <tr><!-- 31行目 -->
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_name_three %> <!-- 15-010 「商品名3」 -->
+                </td>
+                <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
+                  <%= field_solvent.carried_quantity_three %> <!-- 15-012 「搬入量3(書類作成時に記載)」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_classification_three %> <!-- 15-013 「種別3」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_ingredients_three %> <!-- 15-014 「含有成分3」 -->
+                </td>
+              </tr>
+              <tr><!-- 32行目 -->
+              </tr>
+              <tr><!-- 33行目 -->
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_name_four %> <!-- 15-010 「商品名4」 -->
+                </td>
+                <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
+                  <%= field_solvent.carried_quantity_four %> <!-- 15-012 「搬入量4(書類作成時に記載)」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_classification_four %> <!-- 15-013 「種別4」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_ingredients_four %> <!-- 15-014 「含有成分4」 -->
+                </td>
+              </tr>
+              <tr><!-- 34行目 -->
+              </tr>
+              <tr><!-- 35行目 -->
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_name_five %> <!-- 15-010 「商品名5」 -->
+                </td>
+                <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
+                  <%= field_solvent.carried_quantity_five %> <!-- 15-012 「搬入量5(書類作成時に記載)」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_classification_five %> <!-- 15-013 「種別5」 -->
+                </td>
+                <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
+                  <%= field_solvent.solvent_ingredients_five %> <!-- 15-014 「含有成分5」 -->
+                </td>
+              </tr>
+              <tr><!-- 36行目 -->
+              </tr>
+              <tr><!-- 37行目 -->
+                <td class="s_15_20" dir="ltr" colspan="5" rowspan="4">使用場所</td><!-- 1列目 -->
+                <td class="s_15_21" dir="ltr" colspan="31" rowspan="4">
+                  <%= document_info.field_solvents.first.using_location %> <!-- 15-015 「使用場所」 -->
+                </td>
+              </tr>
+              <tr><!-- 38行目 -->
+              </tr>
+              <tr><!-- 39行目 -->
+              </tr>
+              <tr><!-- 40行目 -->
+              </tr>
+              <tr><!-- 41行目 -->
+                <td class="s_15_30" dir="ltr" colspan="5" rowspan="4">保管場所</td><!-- 1列目 -->
+                <td class="s_15_31_1" dir="ltr" colspan="12" rowspan="4">
+                  <%= field_solvent.storing_place %> <!-- 15-016 「保管場所」 -->
+                </td>
+                <td class="s_15_31" dir="ltr" colspan="7" rowspan="4">使用機械<br>又は工具</td>
+                <td class="s_15_31_1" dir="ltr" colspan="12" rowspan="4">
+                  <%= field_solvent.using_tool %> <!-- 15-017 「使用機械または工具」 -->
+                </td>
+              </tr>
+              <tr><!-- 42行目 -->
+              </tr>
+              <tr><!-- 43行目 -->
+              </tr>
+              <tr><!-- 44行目 -->
+              </tr>
+              <tr><!-- 45行目 -->
+                <td class="s_15_40" dir="ltr" colspan="5" rowspan="4">使用期間</td><!-- 1列目 -->
+                <td class="s_15_41" dir="ltr" colspan="13" rowspan="4">
+                  <%= wareki(field_solvent.usage_period_start) %><!-- 15-018 「使用期間(始期)」 -->
+                </td>
+                <td class="s_15_42" dir="ltr" colspan="2" rowspan="4">〜</td>
+                <td class="s_15_43" dir="ltr" colspan="13" rowspan="4">
+                  <%= wareki(field_solvent.usage_period_end) %><!-- 15-019 「使用期間(終期)」 -->
+                </td>
+                <td class="s_15_44" dir="ltr" colspan="3" rowspan="4">(予定)</td>
+              </tr>
+              <tr><!-- 46行目 -->
+              </tr>
+              <tr><!-- 47行目 -->
+              </tr>
+              <tr><!-- 48行目 -->
+              </tr>
+              <tr><!-- 49行目 -->
+                <td class="s_15_50" dir="ltr" colspan="5" rowspan="4">作業主任者等</td><!-- 1列目 -->
+                <td class="s_15_51" dir="ltr" colspan="6" rowspan="2">氏名</td>
+                <td class="s_15_52" dir="ltr" colspan="25" rowspan="2">
+                  <%= '※15-020未実装※' %> <!-- 15-020 「各会社の作業主任者」 -->
+                </td>
+              </tr>
+              <tr><!-- 50行目 -->
+              </tr>
+              <tr><!-- 51行目 -->
+                <td class="s_15_53" dir="ltr" colspan="6" rowspan="2">作業手順書</td>
+                <td class="s_15_54" dir="ltr" colspan="4" rowspan="2">添付</td>
+                <td class="s_15_54" dir="ltr" colspan="2" rowspan="2">(</td>
+                <td class="s_15_55" dir="ltr" colspan="5" rowspan="2">
+                  <%= field_solvent_working_process_y(field_solvent.working_process) %> <!-- 15-021 ⇦「作業手順書の添付の有無」 -->
+                  ・<%= field_solvent_working_process_n(field_solvent.working_process) %>
+                </td>
+                <td class="s_15_54" dir="ltr" colspan="2" rowspan="2">)</td>
+                <td class="s_15_56" dir="ltr" colspan="12" rowspan="2"></td><!-- 10列目 -->
+              </tr>
+              <tr><!-- 52行目 -->
+              </tr>
+              <tr><!-- 53行目 -->
+                <td class="s_15_60" dir="ltr" colspan="5" rowspan="4">SDS</td><!-- 1列目 -->
+                <td class="s_15_61" dir="ltr" colspan="6" rowspan="4">SDS</td>
+                <td class="s_15_62" dir="ltr" colspan="4" rowspan="4">添付</td>
+                <td class="s_15_63" dir="ltr" colspan="2" rowspan="4">(</td>
+                <td class="s_15_64" dir="ltr" colspan="5" rowspan="4">
+                  <%= field_solvent_sds_y(field_solvent.sds) %> <!-- 15-022 ⇦「SDS(安全データシート)の添付の有無」 -->
+                  ・<%= field_solvent_sds_n(field_solvent.sds) %>
+                </td>
+                <td class="s_15_63" dir="ltr" colspan="2" rowspan="4">)</td>
+                <td class="s_15_65" dir="ltr" colspan="12" rowspan="4"></td>
+              </tr>
+              <tr><!-- 54行目 -->
+              </tr>
+              <tr><!-- 55行目 -->
+              </tr>
+              <tr><!-- 56行目 -->
+              </tr>
+              <tr><!-- 57行目 -->
+                <td class="s_15_70" dir="ltr" colspan="5" rowspan="4">換気等対策</td><!-- 1列目 -->
+                <td class="s_15_71" dir="ltr" colspan="31" rowspan="4">
+                  <%= field_solvent.ventilation_control %> <!-- 15-023 「換気等対策」 -->
+                </td>
+              </tr>
+              <tr><!-- 58行目 -->
+              </tr>
+              <tr><!-- 59行目 -->
+              </tr>
+              <tr><!-- 60行目 -->
+              </tr>
+              <tr><!-- 61行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 10列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 20列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 30列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td><!-- 36列目 -->
+              </tr>
+              <tr><!-- 62行目 -->
+                <td class="s_15_80" dir="ltr" colspan="3">(注)</td><!-- 1列目 -->
+                <td class="s_15_81" dir="ltr" colspan="33">１．商品名、種別、含有成分等は材料に添付されているラベル成分表等から写しを記入して下さい。</td>
+              </tr>
+              <tr><!-- 63行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_81" dir="ltr" colspan="33">２．危険物とは、ガソリン、灯油、プロパン、アセチレンガス等をいいます。</td>
+              </tr>
+              <tr><!-- 64行目 -->
+                <td class="s_15_01"></td><!-- 1列目 -->
+                <td class="s_15_01"></td>
+                <td class="s_15_01"></td>
+                <td class="s_15_81" dir="ltr" colspan="33">３．有害物とは、塗装、防水などに使用する有機溶剤、特定化学物質などをいいます。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/users/documents/doc_15th/_show.html.erb
+++ b/app/views/users/documents/doc_15th/_show.html.erb
@@ -30,7 +30,7 @@
               <td class="s_15_1" colspan="3" rowspan="2">
                   元 請<br />
                   確認欄</td>
-              <td class="s_15_1" dir="ltr" colspan="8" rowspan="2">
+              <td class="s_15_1_1" dir="ltr" colspan="8" rowspan="2">
                 <%= '※15-001未実装※' %><!-- 「元請会社の確認欄」15-001 -->
               </td>
             </tr>
@@ -129,7 +129,7 @@
               <td class="s_15_00"></td>
               <td class="s_15_00"></td>
               <td class="s_15_2" dir="ltr" colspan="8" rowspan="2">
-                <%= document_date(field_solvent.date_submitted) %><!-- 15-002 「提出日(西暦)」 -->
+                <%= doc_content_date(@document.content&.[]("date_submitted")) %><!-- 15-002 「提出日(西暦)」 -->
               </td>
             </tr>
             <tr><!-- 5行目 -->
@@ -272,22 +272,7 @@
               <td class="s_15_00"></td>
             </tr>
             <tr><!-- 10行目 -->
-              <td class="s_15_01"></td><!-- 1列目 -->
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td><!-- 10列目 -->
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
-              <td class="s_15_01"></td>
+              <td class="s_15_01_r" dir="ltr" colspan="16">※ 緑枠は入力項目です。必要あれば入力してください。</td><!-- 1列目 -->
               <td class="s_15_01"></td>
               <td class="s_15_01"></td>
               <td class="s_15_01"></td>
@@ -630,80 +615,80 @@
             <tr><!-- 26行目 -->
             </tr>
             <tr><!-- 27行目 -->
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_name_one %> <!-- 15-010 「商品名1」 -->
               </td>
-              <td class="s_15_13" dir="ltr" colspan="4" rowspan="2">
+              <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
                 <%= field_solvent.carried_quantity_one %> <!-- 15-012 「搬入量1(書類作成時に記載)」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_classification_one %> <!-- 15-013 「種別1」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_ingredients_one %> <!-- 15-014 「含有成分1」 -->
               </td>
             </tr>
             <tr><!-- 28行目 -->
             </tr>
             <tr><!-- 29行目 -->
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_name_two %> <!-- 15-010 「商品名2」 -->
               </td>
-              <td class="s_15_13" dir="ltr" colspan="4" rowspan="2">
+              <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
                 <%= field_solvent.carried_quantity_two %> <!-- 15-012 「搬入量2(書類作成時に記載)」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_classification_two %> <!-- 15-013 「種別2」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_ingredients_two %> <!-- 15-014 「含有成分2」 -->
               </td>
             </tr>
             <tr><!-- 30行目 -->
             </tr>
             <tr><!-- 31行目 -->
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_name_three %> <!-- 15-010 「商品名3」 -->
               </td>
-              <td class="s_15_13" dir="ltr" colspan="4" rowspan="2">
+              <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
                 <%= field_solvent.carried_quantity_three %> <!-- 15-012 「搬入量3(書類作成時に記載)」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_classification_three %> <!-- 15-013 「種別3」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_ingredients_three %> <!-- 15-014 「含有成分3」 -->
               </td>
             </tr>
             <tr><!-- 32行目 -->
             </tr>
             <tr><!-- 33行目 -->
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_name_four %> <!-- 15-010 「商品名4」 -->
               </td>
-              <td class="s_15_13" dir="ltr" colspan="4" rowspan="2">
+              <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
                 <%= field_solvent.carried_quantity_four %> <!-- 15-012 「搬入量4(書類作成時に記載)」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_classification_four %> <!-- 15-013 「種別4」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_ingredients_four %> <!-- 15-014 「含有成分4」 -->
               </td>
             </tr>
             <tr><!-- 34行目 -->
             </tr>
             <tr><!-- 35行目 -->
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_name_five %> <!-- 15-010 「商品名5」 -->
               </td>
-              <td class="s_15_13" dir="ltr" colspan="4" rowspan="2">
+              <td class="s_15_13_1" dir="ltr" colspan="4" rowspan="2">
                 <%= field_solvent.carried_quantity_five %> <!-- 15-012 「搬入量5(書類作成時に記載)」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_classification_five %> <!-- 15-013 「種別5」 -->
               </td>
-              <td class="s_15_12" dir="ltr" colspan="9" rowspan="2">
+              <td class="s_15_12_1" dir="ltr" colspan="9" rowspan="2">
                 <%= field_solvent.solvent_ingredients_five %> <!-- 15-014 「含有成分5」 -->
               </td>
             </tr>

--- a/app/views/users/documents/doc_15th/_show.pdf.erb
+++ b/app/views/users/documents/doc_15th/_show.pdf.erb
@@ -132,7 +132,7 @@
               <td class="s_15_00"></td>
               <td class="s_15_00"></td>
               <td class="s_15_2" dir="ltr" colspan="8" rowspan="2">
-                <%= document_date(field_solvent.date_submitted) %><!-- 15-002 「提出日(西暦)」 -->
+                <%= doc_content_date(@document.content&.[]("date_submitted")) %><!-- 15-002 「提出日(西暦)」 -->
               </td>
             </tr>
             <tr><!-- 5行目 -->

--- a/app/views/users/orders/field_solvents/edit.html.erb
+++ b/app/views/users/orders/field_solvents/edit.html.erb
@@ -9,13 +9,6 @@
 
       <div class="row">
         <div class="col-md-3">
-          <%= f.label :date_submitted %>
-          <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-          <%= f.date_field :date_submitted, class: "form-control" %>
-        </div>
-      </div><br>
-      <div class="row">
-        <div class="col-md-3">
           <%= f.label :solvent_name_one %>
           <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
           <%= f.collection_select :solvent_name_one, Solvent.where(business_id: @order.business_id), :name, :name, { include_blank: '商品名1を選択してください' }, { class: 'form-control', :onchange => "catchSolventName1($(this).val())" } %>

--- a/app/views/users/orders/field_solvents/new.html.erb
+++ b/app/views/users/orders/field_solvents/new.html.erb
@@ -9,13 +9,6 @@
 
       <div class="row">
         <div class="col-md-3">
-          <%= f.label :date_submitted %>
-          <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-          <%= f.date_field :date_submitted, class: "form-control" %>
-        </div>
-      </div><br>
-      <div class="row">
-        <div class="col-md-3">
           <%= f.label :solvent_name_one %>
           <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
           <%= f.collection_select :solvent_name_one, Solvent.where(business_id: @order.business_id), :name, :name, { include_blank: '商品名1を選択してください' }, { class: 'form-control', :onchange => "getSolventName1($(this).val())" } %>
@@ -151,9 +144,6 @@
           });
           $(".field_solvent-form-validation").validate({
             rules:{
-              "field_solvent[date_submitted]": {
-                required: true
-              },
               "field_solvent[solvent_name_one]": {
                 required: true
               },
@@ -192,9 +182,6 @@
               },
             },
             messages:{
-              "field_solvent[date_submitted]": {
-                required: "提出日を入力してください。"
-              },
               "field_solvent[solvent_name_one]": {
                 required: "商品名1を入力してください。"
               },

--- a/app/views/users/orders/field_solvents/show.html.erb
+++ b/app/views/users/orders/field_solvents/show.html.erb
@@ -4,12 +4,6 @@
   <div class="card-body table-responsive p-0">
     <table class="table table-hover text-nowrap">
       <tbody>
-        <tr>
-          <th><%= FieldSolvent.human_attribute_name(:date_submitted) %></th>
-          <td><%= @field_solvent.date_submitted %></td>
-          <td></td>
-          <td></td>
-        </tr>
         <tr bgcolor="#dee2e6">
           <th><%= FieldSolvent.human_attribute_name(:solvent_name_one) %></th>
           <th><%= FieldSolvent.human_attribute_name(:carried_quantity_one) %></th>

--- a/db/migrate/20230226124854_remove_date_submitted_from_field_solvents.rb
+++ b/db/migrate/20230226124854_remove_date_submitted_from_field_solvents.rb
@@ -1,0 +1,5 @@
+class RemoveDateSubmittedFromFieldSolvents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :field_solvents, :date_submitted, :date, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,6 @@ ActiveRecord::Schema.define(version: 2023_01_31_030912) do
 
   create_table "businesses", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "uuid", null: false
-    t.integer "business_type", null: false
     t.string "name", null: false
     t.string "name_kana", null: false
     t.string "branch_name", null: false
@@ -92,17 +91,9 @@ ActiveRecord::Schema.define(version: 2023_01_31_030912) do
     t.string "address", null: false
     t.string "post_code", null: false
     t.string "phone_number", null: false
-    t.string "fax_number"
-    t.string "career_up_id"
-    t.json "career_up_card_copy"
+    t.string "carrier_up_id"
     t.json "stamp_images"
-    t.json "occupation_ids"
-    t.json "industry_ids"
-    t.integer "specific_skilled_foreigners_exist"
-    t.integer "foreign_construction_workers_exist"
-    t.integer "foreign_technical_intern_trainees_exist"
-    t.string "employment_manager_name"
-    t.string "employment_manager_post"
+    t.integer "business_type", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -648,8 +639,6 @@ ActiveRecord::Schema.define(version: 2023_01_31_030912) do
     t.string "name"
     t.integer "age"
     t.integer "gender"
-    t.json "invited_user_ids"
-    t.json "invitation_sent_user_ids"
     t.integer "role", default: 1
     t.bigint "admin_user_id"
     t.string "invitation_token"
@@ -762,28 +751,13 @@ ActiveRecord::Schema.define(version: 2023_01_31_030912) do
     t.date "hiring_on", null: false
     t.integer "experience_term_before_hiring", null: false
     t.integer "blank_term", null: false
-    t.string "career_up_id"
+    t.string "carrier_up_id"
     t.json "images"
     t.bigint "business_id", null: false
-    t.string "uuid", null: false
-    t.string "job_title", null: false
-    t.integer "employment_contract", default: 0, null: false
-    t.string "family_name", null: false
-    t.string "relationship", null: false
-    t.string "email"
-    t.integer "sex", default: 0, null: false
-    t.integer "status_of_residence", default: 0, null: false
-    t.date "maturity_date"
-    t.integer "confirmed_check", default: 0, null: false
-    t.date "confirmed_check_date"
-    t.json "responsible_director"
-    t.string "responsible_name"
-    t.integer "responsible_contact_address"
-    t.json "passport"
-    t.json "residence_card"
-    t.json "employment_conditions"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "uuid", null: false
+    t.string "job_title", null: false
     t.index ["business_id"], name: "index_workers_on_business_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_31_030912) do
+ActiveRecord::Schema.define(version: 2023_02_26_124854) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "namespace"
@@ -288,7 +288,6 @@ ActiveRecord::Schema.define(version: 2023_01_31_030912) do
     t.string "carried_quantity_three"
     t.string "carried_quantity_four"
     t.string "carried_quantity_five"
-    t.date "date_submitted", null: false
     t.index ["field_solventable_type", "field_solventable_id"], name: "index_field_solvents_on_field_solventable"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2023_02_26_124854) do
 
   create_table "businesses", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "uuid", null: false
+    t.integer "business_type", null: false
     t.string "name", null: false
     t.string "name_kana", null: false
     t.string "branch_name", null: false
@@ -91,9 +92,17 @@ ActiveRecord::Schema.define(version: 2023_02_26_124854) do
     t.string "address", null: false
     t.string "post_code", null: false
     t.string "phone_number", null: false
-    t.string "carrier_up_id"
+    t.string "fax_number"
+    t.string "career_up_id"
+    t.json "career_up_card_copy"
     t.json "stamp_images"
-    t.integer "business_type", null: false
+    t.json "occupation_ids"
+    t.json "industry_ids"
+    t.integer "specific_skilled_foreigners_exist"
+    t.integer "foreign_construction_workers_exist"
+    t.integer "foreign_technical_intern_trainees_exist"
+    t.string "employment_manager_name"
+    t.string "employment_manager_post"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -638,6 +647,8 @@ ActiveRecord::Schema.define(version: 2023_02_26_124854) do
     t.string "name"
     t.integer "age"
     t.integer "gender"
+    t.json "invited_user_ids"
+    t.json "invitation_sent_user_ids"
     t.integer "role", default: 1
     t.bigint "admin_user_id"
     t.string "invitation_token"
@@ -750,7 +761,7 @@ ActiveRecord::Schema.define(version: 2023_02_26_124854) do
     t.date "hiring_on", null: false
     t.integer "experience_term_before_hiring", null: false
     t.integer "blank_term", null: false
-    t.string "carrier_up_id"
+    t.string "career_up_id"
     t.json "images"
     t.bigint "business_id", null: false
     t.string "uuid", null: false

--- a/spec/factories/businesses.rb
+++ b/spec/factories/businesses.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     address { 'TEST' }
     post_code { '0120123' }
     phone_number { '09001230123' }
-    carrier_up_id { '1' }
+    career_up_id { '1' }
     business_type { 0 }
     business_health_insurance_status { 0 } # 健康保険(加入状況)
     business_health_insurance_association { 'TEST健康保険組合' } # 健康保険(組合名)

--- a/spec/factories/businesses.rb
+++ b/spec/factories/businesses.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     address { 'TEST' }
     post_code { '0120123' }
     phone_number { '09001230123' }
-    career_up_id { '1' }
+    carrier_up_id { '1' }
     business_type { 0 }
     business_health_insurance_status { 0 } # 健康保険(加入状況)
     business_health_insurance_association { 'TEST健康保険組合' } # 健康保険(組合名)

--- a/spec/factories/field_solvents.rb
+++ b/spec/factories/field_solvents.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     field_solventable_type { 'Order' }
     association :field_solventable, factory: :order
     uuid { SecureRandom.uuid }
-    date_submitted { '2022-01-01' }
     sequence(:solvent_name_one) { |n| "solvent_name_one#{n}" }
     sequence(:solvent_name_two) { |n| "solvent_name_two#{n}" }
     sequence(:solvent_name_three) { |n| "solvent_name_three#{n}" }
@@ -38,7 +37,6 @@ FactoryBot.define do
     field_solventable_type { 'RequestOrder' }
     association :field_solventable, factory: :request_order
     uuid { SecureRandom.uuid }
-    date_submitted { '2022-01-01' }
     sequence(:solvent_name_one) { |n| "solvent_name_one#{n}" }
     sequence(:solvent_name_two) { |n| "solvent_name_two#{n}" }
     sequence(:solvent_name_three) { |n| "solvent_name_three#{n}" }

--- a/spec/models/field_solvent_spec.rb
+++ b/spec/models/field_solvent_spec.rb
@@ -11,16 +11,6 @@ RSpec.describe FieldSolvent, type: :model do
       expect(subject).to be_valid
     end
 
-    describe '#date_submitted' do
-      context '存在しない場合' do
-        before(:each) { subject.date_submitted = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
-    end
-
     describe '#solvent_name_one' do
       context '存在しない場合' do
         before(:each) { subject.solvent_name_one = nil }
@@ -121,16 +111,6 @@ RSpec.describe FieldSolvent, type: :model do
 
     it 'バリデーションが通ること' do
       expect(subject).to be_valid
-    end
-
-    describe '#date_submitted' do
-      context '存在しない場合' do
-        before(:each) { subject.date_submitted = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-      end
     end
 
     describe '#solvent_name_one' do


### PR DESCRIPTION
### 概要
(15)有機溶剤・特定化学物質等持込使用届の編集ページ及び機能実装

### タスク
- [] なし
- [x] あり _([書類画面HTML作成【(15)有機溶剤・特定化学物質等持込使用届】](https://trello.com/c/3ezGNaBi))_

### 実装内容・手法
 - 編集ページ実装
 - 編集ページにおいて提出日を編集できるように機能追加

### 実装画像などあれば添付する
 - 書類編集画面
<img width="1792" alt="2023-02-26 doc_15th_edit" src="https://user-images.githubusercontent.com/57995349/221413685-daee7af1-5290-41bb-bedc-041ea8528286.png">
