### PR TITLE
workerテーブルのデータ型変更、および不要カラムの削除(奥野)

### DIFF
--- a/db/migrate/20220128032655_create_workers.rb
+++ b/db/migrate/20220128032655_create_workers.rb
@@ -25,16 +25,15 @@ class CreateWorkers < ActiveRecord::Migration[6.1]
       t.string :relationship,null: false                        # 緊急連絡先-続柄
       t.string :email
       t.integer :sex, null: false, default: 0
-      t.integer :status_of_residence, null: false, default: 0
+      t.integer :status_of_residence
       t.date :maturity_date
-      t.integer :confirmed_check, null: false, default: 0
+      t.integer :confirmed_check
       t.date :confirmed_check_date
-      t.json :responsible_director
-      t.string :responsible_name
-      t.integer :responsible_contact_address
-      t.json :passport
-      t.json :residence_card
-      t.json :employment_conditions
+      t.string :passport_front
+      t.string :passport_back
+      t.string :residence_card_front
+      t.string :residence_card_back
+      t.string :employment_condition
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -772,16 +772,15 @@ ActiveRecord::Schema.define(version: 2023_01_31_030912) do
     t.string "relationship", null: false
     t.string "email"
     t.integer "sex", default: 0, null: false
-    t.integer "status_of_residence", default: 0, null: false
+    t.integer "status_of_residence"
     t.date "maturity_date"
-    t.integer "confirmed_check", default: 0, null: false
+    t.integer "confirmed_check"
     t.date "confirmed_check_date"
-    t.json "responsible_director"
-    t.string "responsible_name"
-    t.integer "responsible_contact_address"
-    t.json "passport"
-    t.json "residence_card"
-    t.json "employment_conditions"
+    t.string "passport_front"
+    t.string "passport_back"
+    t.string "residence_card_front"
+    t.string "residence_card_back"
+    t.string "employment_condition"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["business_id"], name: "index_workers_on_business_id"


### PR DESCRIPTION
### 概要
外国人労働者の責任者の参照元が変更されたため、不要カラムの削除を実装
各写しのデータ型変更

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
〇create_workerマイグレーションファイルを編集
　・パスポートの表と裏、在留カードの表と裏のカラム追加
　・雇用条件書のデータ型変更
　・外国人労働者の責任者にかかわる、カラムの削除

### 実装画像などあれば添付する
作業員マスタ仕様書
https://docs.google.com/spreadsheets/d/17efxKqin51KXy65poeR457DknImWY9Lf5DtJ4i3qnek/edit#gid=142516760

