### PR TITLE
Businessのuuidバリデーション修正(平野)

### DIFF
--- a/app/controllers/users/businesses_controller.rb
+++ b/app/controllers/users/businesses_controller.rb
@@ -89,7 +89,7 @@ module Users
 
     def business_params
       params.require(:business).permit(
-        :uuid, :name, :name_kana, :branch_name, :representative_name, :email, :address, :post_code,
+        :name, :name_kana, :branch_name, :representative_name, :email, :address, :post_code,
         :phone_number, :fax_number, :career_up_id, :business_type, { stamp_images: [] }, :user_id,
         :business_health_insurance_status, :business_health_insurance_association,
         :business_health_insurance_office_number, :business_welfare_pension_insurance_join_status,

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -15,6 +15,8 @@ class Business < ApplicationRecord
   accepts_nested_attributes_for :business_occupations, allow_destroy: true
   accepts_nested_attributes_for :business_industries, allow_destroy: true
 
+  before_create -> { self.uuid = SecureRandom.uuid }
+
   enum business_type: { corporation: 0, freelance: 1, Individual_five_over: 2, Individual_five_less: 3 }
   enum business_health_insurance_status: { join: 0, not_join: 1, not_coverd: 2 }, _prefix: true               # 健康保険(加入状況)
   enum business_welfare_pension_insurance_join_status: { join: 0, not_join: 1, not_coverd: 2 }, _prefix: true # 厚生年金保険(加入状況)
@@ -30,7 +32,6 @@ class Business < ApplicationRecord
   enum foreign_technical_intern_trainees_exist: { available: 0, not_available: 1 }, _prefix: true             # 人技能実習生の従事の状況
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  validates :uuid, presence: true
   validates :name, presence: true
   validates :name_kana, presence: true, format: { with: /\A[ァ-ヴー]+\z/u, message: 'はカタカナで入力して下さい。' }
   validates :branch_name, presence: true
@@ -57,8 +58,6 @@ class Business < ApplicationRecord
   validates :construction_license_number_six_digits, format: { with: /\A\d{1,6}\z/, message: 'は数字6桁以下で入力してください' }, presence: true
   validates :construction_license_number, presence: true
   validates :construction_license_updated_at, presence: true
-
-  before_create -> { self.uuid = SecureRandom.uuid }
 
   mount_uploaders :stamp_images, StampImagesUploader
 end

--- a/spec/models/business_spec.rb
+++ b/spec/models/business_spec.rb
@@ -10,21 +10,6 @@ RSpec.describe Business, type: :model do
       expect(subject).to be_valid
     end
 
-    describe '#uuid' do
-      context '存在しない場合' do
-        before(:each) { subject.uuid = nil }
-
-        it 'バリデーションに落ちること' do
-          expect(subject).to be_invalid
-        end
-
-        it 'バリデーションのエラーが正しいこと' do
-          subject.valid?
-          expect(subject.errors.full_messages).to include('会社IDを入力してください')
-        end
-      end
-    end
-
     describe '#name' do
       context '存在しない場合' do
         before(:each) { subject.name = nil }


### PR DESCRIPTION
### 概要
- 会社情報を登録する時、会社IDが未入力の為エラーになって会社登録できない不具合修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- ストロングパラメータのuuid、businessモデルのバリデーション削除
- uuidのモデルspec修正

### 実装画像などあれば添付する


