### PR TITLE
⑰下請負業者編成表の値反映 & ⑱工事作業所災害防止協議会兼施工体系図の一部修正 & サイドメニューの修正

### DIFF
--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -538,9 +538,9 @@ module Users
 
     # doc_17thの配置を決定させるためのロジック
     def get_subcon_info_17th
-      edge_position = 1
+      edge_position = 1 #端の配置となる番号を変数として取得
       current_order_id = RequestOrder.find_by(uuid: params[:request_order_uuid]).order_id #現場IDの取得
-      @primary_subcon_id_17th = RequestOrder.find_by(business_id: Business.find_by(representative_name: current_user.name).id).id
+      @primary_subcon_id_17th = RequestOrder.find_by(uuid: params[:request_order_uuid]).id #一次下請けのidの取得
       if RequestOrder.where(order_id: current_order_id, parent_id: @primary_subcon_id_17th).present? #二次下請けが存在するか確認(開始)
         secondary_element = 0
         secondary_subcon_list_base = RequestOrder.where(order_id: current_order_id, parent_id: @primary_subcon_id_17th).order(id: "ASC") #二次下請けの配列作成(開始)
@@ -710,10 +710,10 @@ module Users
             date_created:   field_worker_keys  # 13-004 作成日(西暦)
           ]
         )
-      when 'doc_12th' 
+      when 'doc_12th'
         field_car_ids = @document.request_order.field_cars.ids
         field_car_keys = field_car_ids.map{|field_car_id|"field_car_#{field_car_id}"}
-        params.require(:document).permit(content: 
+        params.require(:document).permit(content:
           [
             date_submitted: field_car_keys, # 12-002 提出日(西暦)
           ]

--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -7,7 +7,8 @@ module Users
     before_action :set_document, except: :index # オブジェクトが1つも無い場合、indexで呼び出さないようにする
     before_action :set_workers, only: %i[show edit update] # 2次下請以下の作業員を定義する
     before_action :edit_restriction_after_approved, only: %i[edit update]
-    before_action :get_subcon_info_18th, only: :show # doc_18thの配置を決定させるためのロジック
+    before_action :get_subcon_info_17th, only: %i[show edit] #doc_17thの配置を決定させるためのロジック
+    before_action :get_subcon_info_18th, only: :show #doc_18thの配置を決定させるためのロジック
 
     def index; end
 
@@ -530,6 +531,75 @@ module Users
       end
     end
 
+    # doc_17thの配置を決定させるためのロジック
+    def get_subcon_info_17th
+      edge_position = 1
+      current_order_id = RequestOrder.find_by(uuid: params[:request_order_uuid]).order_id #現場IDの取得
+      @primary_subcon_id_17th = RequestOrder.find_by(business_id: Business.find_by(representative_name: current_user.name).id).id
+      if RequestOrder.where(order_id: current_order_id, parent_id: @primary_subcon_id_17th).present? #二次下請けが存在するか確認(開始)
+        secondary_element = 0
+        secondary_subcon_list_base = RequestOrder.where(order_id: current_order_id, parent_id: @primary_subcon_id_17th).order(id: "ASC") #二次下請けの配列作成(開始)
+        secondary_subcon_list = []
+        secondary_subcon_list_base.each do |record|
+          secondary_subcon_list << record.id
+        end #二次下請けの配列作成(終了)
+        secondary_subcon_list_size = secondary_subcon_list.size
+        while instance_variable_set("@secondary_subcon_id_17th_#{edge_position}", secondary_subcon_list.slice(secondary_element)).present? #二次下請けの繰り返し処理(開始)
+          instance_variable_set("@secondary_subcon_id_17th_#{edge_position}", secondary_subcon_list.slice(secondary_element))
+          if RequestOrder.where(order_id: current_order_id, parent_id: instance_variable_get("@secondary_subcon_id_17th_#{edge_position}")).present? #三次下請けが存在するか確認(開始)
+            tertiary_subcon_list_base = RequestOrder.where(order_id: current_order_id, parent_id: instance_variable_get("@secondary_subcon_id_17th_#{edge_position}")).order(id: "ASC") #三次下請けの配列作成(開始)
+            tertiary_subcon_list = []
+            tertiary_subcon_list_base.each do |record|
+              tertiary_subcon_list << record.id
+            end #三次下請けの配列作成(終了)
+            tertiary_subcon_list_size = tertiary_subcon_list.size
+            tertiary_element = 0
+            while instance_variable_set("@tertiary_subcon_id_17th_#{edge_position}", tertiary_subcon_list.slice(tertiary_element)).present? #三次下請けの繰り返し処理(開始)
+              instance_variable_set("@tertiary_subcon_id_17th_#{edge_position}", tertiary_subcon_list.slice(tertiary_element))
+              if RequestOrder.where(order_id: current_order_id, parent_id: instance_variable_get("@tertiary_subcon_id_17th_#{edge_position}")).present? #四次下請けが存在するか確認(開始)
+                quaternary_subcon_list_base = RequestOrder.where(order_id: current_order_id, parent_id: instance_variable_get("@tertiary_subcon_id_17th_#{edge_position}")).order(id: "ASC") #四次下請けの配列作成(開始)
+                quaternary_subcon_list = []
+                quaternary_subcon_list_base.each do |record|
+                  quaternary_subcon_list << record.id
+                end #四次下請けの配列作成(終了)
+                quaternary_subcon_list_size = quaternary_subcon_list.size
+                quaternary_element = 0
+                while quaternary_element < quaternary_subcon_list_size #四次下請けの要素の数だけ処理(開始)
+                  instance_variable_set("@quaternary_subcon_id_17th_#{edge_position}", quaternary_subcon_list.slice(quaternary_element))
+                  if (quaternary_element + 1) == quaternary_subcon_list_size #四次下請けの数が到達したらブレイク
+                    break
+                  end
+                  edge_position += 1
+                  quaternary_element += 1
+                end #四次下請けの要素の数だけ処理(終了)
+              end #四次下請けが存在するか確認(開始)
+              if (tertiary_element + 1) == tertiary_subcon_list_size #三次下請けの数が到達したらブレイク
+                if not (edge_position%3 == 0) #三次下請けブレイク時にedge_positionが3の倍数でない場合は強制的に次の3の倍数にする
+                  if not (secondary_element + 1) == secondary_subcon_list_size
+                    edge_position = (edge_position.div(3)+1)*3
+                  end
+                end
+                break
+              end
+              edge_position += 1
+              tertiary_element += 1
+            end #三次下請けの繰り返し処理(終了)
+          else #三次下請けが存在しない場合
+            if not (secondary_element + 1) == secondary_subcon_list_size #最後に配置した一次下請けに二次下請けが存在しない場合は倍数計算しないようにする
+              edge_position = (edge_position.div(3)+1)*3
+            end
+          end #三次下請けが存在するか確認(終了)
+          if (secondary_element + 1) == secondary_subcon_list_size #二次下請けの数が到達したらブレイク
+            break
+          end
+          edge_position += 1
+          secondary_element += 1
+        end #二次下請けの繰り返し処理(終了)
+      end #二次下請けが存在するか確認(終了)
+      @total_pages_17th = (edge_position-1).div(3)
+      #binding.pry
+    end
+
     # doc_18thの配置を決定させるためのロジック
     def get_subcon_info_18th
       edge_position = 1
@@ -591,29 +661,30 @@ module Users
                   tertiary_element += 1
                 end #三次下請けの繰り返し処理(終了)
               end #三次下請けが存在するか確認(終了)
-              #binding.pry
               if (secondary_element + 1) == secondary_subcon_list_size
                 if not (edge_position%4 == 0)
-                  edge_position = (edge_position.div(4)+1)*4
+                  if not (primary_element + 1) == primary_subcon_list_size
+                    edge_position = (edge_position.div(4)+1)*4
+                  end
                 end
-                #binding.pry
                 break
               end
               edge_position += 1
               secondary_element += 1
             end #二次下請けの繰り返し処理(終了)
-          else
-            edge_position = (edge_position.div(4)+1)*4
+          else #二次下請けが存在しない場合
+            if not (primary_element + 1) == primary_subcon_list_size
+              edge_position = (edge_position.div(4)+1)*4
+            end
           end #二次下請けが存在するか確認(終了)
           if (primary_element + 1) == primary_subcon_list_size
             break
           end
           edge_position += 1
           primary_element += 1
-          #binding.pry
         end #一次下請けの繰り返し処理(終了)
       end #一次下請けが存在するか確認(終了)
-      @total_pages = (edge_position-1).div(4)
+      @total_pages_18th = (edge_position-1).div(4)
     end
 
     def document_params(document)

--- a/app/javascript/stylesheets/users/doc_17th.scss
+++ b/app/javascript/stylesheets/users/doc_17th.scss
@@ -8,12 +8,14 @@
   border-left: none;
   border-right: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: bottom;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -28,7 +30,9 @@
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -37,12 +41,14 @@
   border-top: none;
   border-bottom: none;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -52,12 +58,14 @@
   border-left: none;
   border-right: 1px SOLID #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -71,9 +79,11 @@
   text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -84,9 +94,27 @@
   text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_17_s51 {
+  border-top: 1px SOLID #000000;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -97,12 +125,14 @@
   border-left: none;
   border-bottom: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: bottom;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -110,11 +140,24 @@
 .ritz .waffle .doc_17_s3 {
   border: none;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_17_s50 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #e60033;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: top;
   white-space: nowrap;
   direction: ltr;
   padding: 0px 3px 0px 3px;
@@ -128,7 +171,9 @@
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -136,11 +181,11 @@
 .ritz .waffle .doc_17_s24 {
   border-top: none;
   border-bottom: 1px SOLID #000000;
-  background-color: #ccffcc;
+  background-color: #e9ecef;
   text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
   white-space: normal;
   overflow: hidden;
@@ -155,12 +200,14 @@
   border-left: none;
   border-bottom: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: bottom;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -170,26 +217,30 @@
   border-bottom: 1px SOLID #000000;
   border-right: 1px SOLID #000000;
   border-left: 1px SOLID #000000;
-  background-color: #ccffcc;
-  text-align: left;
+  background-color: #e9ecef;
+  text-align: center;
   color: #000000;
   font-family: 'docs-Calibri', Arial;
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
 
 .ritz .waffle .doc_17_s11 {
   border: 1px SOLID #000000;
-  background-color: #ccffcc;
-  text-align: left;
+  background-color: #e9ecef;
+  text-align: center;
   color: #000000;
   font-family: 'docs-Calibri', Arial;
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -212,13 +263,15 @@
 .ritz .waffle .doc_17_s22 {
   border-right: 1px SOLID #000000;
   border-bottom: none;
-  background-color: #ccffcc;
+  background-color: #e9ecef;
   text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -229,22 +282,29 @@
   text-align: left;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
 
 .ritz .waffle .doc_17_s20 {
-  border: 1px SOLID #000000;
-  background-color: #ccffcc;
+  border-top: 1px SOLID #000000;
+  border-right: none;
+  border-left: 1px SOLID #000000;
+  border-bottom: 1px SOLID #000000;
+  background-color: #e9ecef;
   text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -255,7 +315,7 @@
   text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
   white-space: normal;
   overflow: hidden;
@@ -273,18 +333,20 @@
   font-family: 'Arial';
   font-size: 24pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
 
 .ritz .waffle .doc_17_s13 {
   border: 1px SOLID #000000;
-  background-color: #ccffcc;
-  text-align: left;
+  background-color: #e9ecef;
+  text-align: center;
   color: #000000;
   font-family: 'docs-Calibri', Arial;
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
   white-space: normal;
   overflow: hidden;
@@ -295,13 +357,15 @@
 
 .ritz .waffle .doc_17_s34 {
   border: 1px SOLID #000000;
-  background-color: #ccffcc;
+  background-color: #e9ecef;
   text-align: center;
   color: #0000ff;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -324,12 +388,14 @@
 .ritz .waffle .doc_17_s1 {
   border: none;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: bottom;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -340,12 +406,14 @@
   border-left: none;
   border-bottom: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -356,12 +424,14 @@
   border-bottom: 1px DOTTED #000000;
   border-right: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -369,12 +439,14 @@
 .ritz .waffle .doc_17_s43 {
   border: none;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: bottom;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -385,12 +457,14 @@
   border-bottom: 1px DOTTED #000000;
   border-right: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -398,12 +472,14 @@
 .ritz .waffle .doc_17_s10 {
   border: 1px SOLID #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -413,24 +489,28 @@
   border-left: none;
   border-bottom: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
 
 .ritz .waffle .doc_17_s36 {
   border-bottom: 1px SOLID #000000;
-  background-color: #ccffcc;
+  background-color: #e9ecef;
   text-align: center;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -446,7 +526,9 @@
   font-family: 'Arial';
   font-size: 14pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -460,9 +542,11 @@
   text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -473,12 +557,14 @@
   border-left: none;
   border-bottom: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 14pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -489,23 +575,10 @@
   border-bottom: none;
   border-right: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
-  color: #000000;
-  font-family: 'Arial';
-  font-size: 10pt;
-  vertical-align: middle;
-  white-space: nowrap;
-  direction: ltr;
-  padding: 0px 3px 0px 3px;
-}
-
-.ritz .waffle .doc_17_s9 {
-  border: 1px SOLID #000000;
-  background-color: #ccffcc;
   text-align: center;
   color: #000000;
-  font-family: 'docs-Calibri', Arial;
-  font-size: 10pt;
+  font-family: 'Arial';
+  font-size: 9pt;
   vertical-align: middle;
   white-space: normal;
   overflow: hidden;
@@ -514,15 +587,34 @@
   padding: 0px 3px 0px 3px;
 }
 
+.ritz .waffle .doc_17_s9 {
+  border: 1px SOLID #000000;
+  border-bottom: 1px SOLID #ffffff;
+  background-color: #e9ecef;
+  text-align: center;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  writing-mode: vertical-lr;
+  padding: 0px 3px 0px 3px;
+}
+
 .ritz .waffle .doc_17_s12 {
   border: none;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'docs-Calibri', Arial;
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -537,7 +629,9 @@
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -548,12 +642,14 @@
   border-bottom: 1px DOTTED #000000;
   border-right: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: bottom;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -569,7 +665,9 @@
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -580,12 +678,14 @@
   border-left: none;
   border-right: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -598,7 +698,9 @@
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -607,11 +709,11 @@
   border-top: 1px SOLID #000000;
   border-bottom: 1px SOLID #000000;
   border-right: 1px SOLID #000000;
-  background-color: #ccffcc;
+  background-color: #e9ecef;
   text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
   white-space: normal;
   overflow: hidden;
@@ -624,12 +726,14 @@
   border-top: 1px SOLID #000000;
   border-bottom: 1px SOLID #000000;
   border-right: 1px SOLID #000000;
-  background-color: #ccffcc;
+  background-color: #e9ecef;
   text-align: center;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -644,7 +748,9 @@
   font-family: 'Arial';
   font-size: 14pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -655,12 +761,14 @@
   border-bottom: none;
   border-right: 1px DOTTED #000000;
   background-color: #ffffff;
-  text-align: left;
+  text-align: center;
   color: #000000;
   font-family: 'Arial';
-  font-size: 10pt;
+  font-size: 9pt;
   vertical-align: bottom;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -685,7 +793,9 @@
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }

--- a/app/javascript/stylesheets/users/doc_18th.scss
+++ b/app/javascript/stylesheets/users/doc_18th.scss
@@ -6,7 +6,27 @@
   font-family: 'Arial';
   font-size: 11pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_18_s53 {
+  border-top: 1px SOLID #000000;
+  border-right: none;
+  border-bottom: 1px SOLID #000000;
+  border-left: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -19,7 +39,9 @@
   font-family: 'Arial';
   font-size: 14pt;
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }
@@ -178,6 +200,21 @@
 .ritz .waffle .doc_18_s17 {
   border-bottom: 1px SOLID #000000;
   border-right: 1px SOLID #000000;
+  background-color: #e9ecef;
+  text-align: center;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 14pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_18_s54 {
+  border-bottom: 1px SOLID #000000;
   background-color: #e9ecef;
   text-align: center;
   color: #000000;

--- a/app/views/layouts/users/_side.html.erb
+++ b/app/views/layouts/users/_side.html.erb
@@ -108,17 +108,17 @@
               <p>安全書類の記入依頼</p>
             <% end %>
           </li>
+          <li class="nav-item">
+            <%= link_to users_subcon_users_path, class:"nav-link" do %>
+              <i class="nav-icon fas fa-building"></i>
+              <p>協力会社情報</p>
+            <% end %>
+          </li>
           <p class="non-slide-link-menu text-danger">↓ 初回ログイン時入力必須</p>
           <li class="nav-item">
             <%= link_to users_business_path, class:"nav-link" do %>
               <i class="nav-icon fas fa-building"></i>
               <p>会社情報</p>
-            <% end %>
-          </li>
-          <li class="nav-item">
-            <%= link_to users_subcon_users_path, class:"nav-link" do %>
-              <i class="nav-icon fas fa-building"></i>
-              <p>協力会社情報</p>
             <% end %>
           </li>
           <li class="nav-item">
@@ -140,6 +140,12 @@
             <% end %>
           </li>
           <li class="nav-item">
+            <%= link_to users_special_vehicles_path, class:"nav-link" do %>
+              <i class="nav-icon fas fa-truck"></i>
+              <p>特殊車両情報</p>
+            <% end %>
+          </li>
+          <li class="nav-item">
             <%= link_to users_machines_path, class:"nav-link" do %>
               <i class="nav-icon fas fa-cogs"></i>
               <p>持込機械情報</p>
@@ -149,12 +155,6 @@
             <%= link_to users_solvents_path, class:"nav-link" do %>
               <i class="nav-icon fas fa-flask"></i>
               <p>有機溶剤情報</p>
-            <% end %>
-          </li>
-          <li class="nav-item">
-            <%= link_to users_special_vehicles_path, class:"nav-link" do %>
-              <i class="nav-icon fas fa-truck"></i>
-              <p>特殊車両情報</p>
             <% end %>
           </li>
           <p></p>

--- a/app/views/users/documents/doc_17th/_edit.html.erb
+++ b/app/views/users/documents/doc_17th/_edit.html.erb
@@ -1,1781 +1,1817 @@
 <!-- (17)全建統一様式第1号－乙(下請負業者編成表) -->
 <%= form_with model: @document, url: users_request_order_document_path, method: :patch, local: true do |f| %>
   <div id="doc_17" class="document-outer" style="overflow: auto;">
-    <div class="card">  
+    <div class="card">
       <div class="card-body">
         <%= f.submit '登録', class: 'btn btn-block btn-primary' %>
         <%= link_to '詳細画面へ', users_request_order_document_url, class: "btn btn-md btn-block btn-default" %>
       </div>
     </div>
-
-    <div class="document-inner">
-      <section class="doc_17_sheet">
-        <div class="ritz grid-container" dir="ltr">
-          <table class="waffle" cellspacing="0" cellpadding="0" style="width: 100%; zoom: 90%;">
-            <thead>
-              <tr class="doc_17_s45">
-                <th style="width:30px;">&nbsp;</th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:30px;"></th>
-                <th style="width:20px;"></th>
-                <th style="width:20px;"></th>
-                <th style="width:20px;"></th>
-                <th style="width:40px;"></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="doc_17_s45" style="height: 4px;">
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s0"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 14px;">
-                <td class="doc_17_s47" colspan="9" rowspan="2">全建統一様式第１号-乙</td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 14px;">
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s4" dir="ltr" colspan="8">
-                  <%= f.date_field :content, name: "document[content][date_submitted][]",
-                                      value: doc_content_date(@document.content&.[]("date_submitted")),
-                                      class: 'form-control form-control-sm'
-                  %><!-- 17-001 提出日(西暦) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45">
-                <td class="doc_17_s48" colspan="9"></td>
-                <td colspan="29" style="border: none;"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 19px;">
-                <td class="doc_17_s5" colspan="38" rowspan="2">下請負業者編成表</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 19px">
-              </tr>
-              <tr class="doc_17_s45" style="height: 9px">
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 14px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s7" colspan="16" rowspan="2">（一次下請負業者＝作成下請負業者）</td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 14px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s9" dir="ltr" colspan="2" rowspan="13" style="writing-mode: tb-rl;">
-                  <%= primary_subcon_info(document_info)&.construction_name %> <!-- 17-002 工事名(一次) -->
-                </td>
-                <td class="doc_17_s10" colspan="7" rowspan="2">会社名</td>
-                <td class="doc_17_s11" dir="ltr" colspan="7" rowspan="2">
-                  <%= primary_subcon_info(document_info)&.content&.[]("subcon_name") %> <!-- 17-003 会社名(一次) -->
-                </td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s10" colspan="7" rowspan="2">代表者名</td>
-                <td class="doc_17_s11" dir="ltr" colspan="7" rowspan="2">
-                  <%= primary_subcon_info(document_info)&.content&.[]("subcon_representative_name") %> <!-- 17-004 代表者名(一次) -->
-                </td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s10" colspan="7" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                  <!-- 17-005 建設業許可番号(短縮)(一次) ※未実装※ -->
-                </td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s15" rowspan="3"></td>
-                <td class="doc_17_s10" colspan="7" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                  <%= primary_subcon_info(document_info)&.safety_manager_name %> <!-- 17-006 安全衛生責任者名(一次) -->
-                </td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s14"></td>
-                <td class="doc_17_s10" colspan="7" rowspan="2">主任技術者</td>
-                <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                  <%= primary_subcon_info(document_info)&.lead_engineer_name %> <!-- 17-007 主任技術者名(一次) -->
-                </td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s16" colspan="7" rowspan="2">専門技術者</td>
-                <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                  <%= primary_subcon_info(document_info)&.professional_engineer_name %> <!-- 17-008 専門技術者名(一次) -->
-                </td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s10" colspan="6" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                  <%= primary_subcon_info(document_info)&.professional_engineer_details %> <!-- 17-009 担当工事内容(一次) -->
-                </td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s18" colspan="2" rowspan="2">工</td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s19"></td>
-                <td class="doc_17_s17" colspan="7" rowspan="2">特定専門工事の有無</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(primary_subcon_info(document_info)&.professional_construction) %> <!-- 17-010 特定専門工事の有無(一次) -->
-                </td>
-                <td class="doc_17_s21" dir="ltr" colspan="3" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(primary_subcon_info(document_info)&.professional_construction) %> <!-- 17-010 特定専門工事の有無(一次) -->
-                </td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s23"></td>
-                <td class="doc_17_s23"></td>
-                <td class="doc_17_s23"></td>
-                <td class="doc_17_s23"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s19"></td>
-                <td class="doc_17_s18" colspan="2" rowspan="2">事</td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s23"></td>
-                <td class="doc_17_s23"></td>
-                <td class="doc_17_s23"></td>
-                <td class="doc_17_s23"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s19"></td>
-                <td class="doc_17_s10" colspan="7" rowspan="2">登録基幹技能者</td>
-                <td class="doc_17_s11" dir="ltr" colspan="7" rowspan="2">
-                  <%= primary_subcon_info(document_info)&.professional_engineer_details %> <!-- 17-011 登録基幹技能者(一次) -->
-                </td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s14" colspan="4" rowspan="3"></td>
-                <td class="doc_17_s19"></td>
-                <td class="doc_17_s7" style="border-top: none; border-right: none;"></td> <!-- s7 -->
-                <td class="doc_17_s17" style="border-top: none; border-left: none;"></td> <!-- s17 -->
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s6"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s12"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s17" colspan="3" rowspan="2">工期</td>
-                <td class="doc_17_s24" dir="ltr" colspan="6" rowspan="2">
-                  <%= document_date(primary_subcon_info(document_info)&.start_date) %> <!-- 17-012 各会社の工期(自)(一次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" rowspan="2">~</td>
-                <td class="doc_17_s25" dir="ltr" colspan="6" rowspan="2">
-                  <%= document_date(primary_subcon_info(document_info)&.end_date) %> <!-- 17-013 各会社の工期(至)(一次) -->
-                </td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s8"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s26"></td>
-                <td class="doc_17_s27" colspan="2"></td>
-                <td class="doc_17_s26"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s29"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s28"></td>
-                <td class="doc_17_s30"></td>
-                <td class="doc_17_s30"></td>
-                <td class="doc_17_s30"></td>
-                <td class="doc_17_s30"></td>
-                <td class="doc_17_s30"></td>
-                <td class="doc_17_s30"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s31"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s31"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s3"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s32"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-                <td class="doc_17_s1"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s9" dir="ltr" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s34" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s34" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(二次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 2)&.content&.[]("subcon_representative_name") %> <!-- 17-016-3 代表者名(二次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                  <!-- 17-017-1 建設業許可番号(短縮)(二次) ※未実装※ -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <!-- 17-017-2 建設業許可番号(短縮)(二次) ※未実装※ -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <!-- 17-017-3 建設業許可番号(短縮)(二次) ※未実装※ -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(二次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 2)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(二次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 2)&.professional_engineer_name %> <!-- 17-020-3 専門技術者名(二次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= secondary_subcon_info(document_info, 2)&.professional_engineer_details %> <!-- 17-021-3 担当工事内容(二次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18">工</td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">工</td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">工</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(secondary_subcon_info(document_info, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(二次) -->
-                </td>
-                <td class="doc_17_s21" dir="ltr" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(secondary_subcon_info(document_info, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(secondary_subcon_info(document_info, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(二次) -->
-                </td>
-                <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(secondary_subcon_info(document_info, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(secondary_subcon_info(document_info, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(二次) -->
-                </td>
-                <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(secondary_subcon_info(document_info, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(二次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s17" style="border-top: none;"></td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" style="border-top: none;"></td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" style="border-top: none;"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s24" dir="ltr" colspan="4" rowspan="2">
-                  <%= document_date(secondary_subcon_info(document_info, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(二次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s25" dir="ltr" colspan="4" rowspan="2">
-                  <%= document_date(secondary_subcon_info(document_info, 0)&.end_date) %> <!-- 17-024-1 各会社の工期(自)(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s36" colspan="4" rowspan="2">
-                  <%= document_date(secondary_subcon_info(document_info, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(二次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s37" colspan="4" rowspan="2">
-                  <%= document_date(secondary_subcon_info(document_info, 1)&.end_date) %> <!-- 17-024-2 各会社の工期(自)(二次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s36" colspan="4" rowspan="2">
-                  <%= document_date(secondary_subcon_info(document_info, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(二次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s37" colspan="4" rowspan="2">
-                  <%= document_date(secondary_subcon_info(document_info, 2)&.end_date) %> <!-- 17-024-3 各会社の工期(自)(二次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s38"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s40"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s42"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s38"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s38"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s44"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s34" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s34" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s34" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 3)&.content&.[]("subcon_representative_name") %> <!-- 17-016-3 代表者名(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <!-- 17-017-1 建設業許可番号(短縮)(三次) ※未実装※ -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <!-- 17-017-2 建設業許可番号(短縮)(三次) ※未実装※ -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <!-- 17-017-3 建設業許可番号(短縮)(三次) ※未実装※ -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 2)&.lead_engineer_name %> <!-- 17-019-3 主任技術者名(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 2)&.professional_engineer_name %> <!-- 17-020-3 専門技術者名(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 2, 2)&.professional_engineer_details %> <!-- 17-021-3 担当工事内容(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18">工</td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">工</td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">工</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(三次) -->
-                </td>
-                <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(三次) -->
-                </td>
-                <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(三次) -->
-                </td>
-                <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s17" style="border-top: none;"></td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" style="border-top: none;"></td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" style="border-top: none;"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s36" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 2, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(三次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s37" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 2, 0)&.end_date) %> <!-- 17-023-1 各会社の工期(自)(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s36" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 2, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(三次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s37" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 2, 1)&.end_date) %> <!-- 17-023-2 各会社の工期(自)(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s36" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 2, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(三次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s37" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 2, 2)&.end_date) %> <!-- 17-023-3 各会社の工期(自)(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s38"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s40"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s39"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s41"></td>
-                <td class="doc_17_s42"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s38"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s38"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s44"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s34" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s34" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s34" rowspan="12"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(四次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 2)&.content&.[]("subcon_representative_name") %> <!-- 17-016-3 代表者名(四次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <!-- 17-017-1 建設業許可番号(短縮)(四次) ※未実装※ -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <!-- 17-017-2 建設業許可番号(短縮)(四次) ※未実装※ -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <!-- 17-017-3 建設業許可番号(短縮)(四次) ※未実装※ -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(四次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 2)&.lead_engineer_name %> <!-- 17-019-3 主任技術者名(四次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(三次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 2)&.professional_engineer_name %> <!-- 17-020-3 専門技術者名(三次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18"></td>
-                <td class="doc_17_s49" rowspan="2"></td>
-                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-                <td class="doc_17_s35" colspan="6" rowspan="2">
-                  <%= hierarchy_subcon_info(document_info, 3, 2)&.professional_engineer_details %> <!-- 17-021-3 担当工事内容(四次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18">工</td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">工</td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">工</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(四次) -->
-                </td>
-                <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(四次) -->
-                </td>
-                <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s18">事</td>
-                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-                <td class="doc_17_s20" colspan="2" rowspan="2">
-                  <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(四次) -->
-                </td>
-                <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-                <td class="doc_17_s22" colspan="2" rowspan="2">
-                  <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(四次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s17" style="border-top: none;"></td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" style="border-top: none;"></td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" style="border-top: none;"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s36" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 3, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(四次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s37" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 3, 0)&.end_date) %> <!-- 17-023-1 各会社の工期(自)(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s36" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 3, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(四次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s37" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 3, 1)&.end_date) %> <!-- 17-023-2 各会社の工期(自)(四次) -->
-                </td>
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-                <td class="doc_17_s36" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 3, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(四次) -->
-                </td>
-                <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-                <td class="doc_17_s37" colspan="4" rowspan="2">
-                  <%= document_date(hierarchy_subcon_info(document_info, 3, 2)&.end_date) %> <!-- 17-023-3 各会社の工期(自)(四次) -->
-                </td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 12px">
-                <td class="doc_17_s16"></td>
-                <td class="doc_17_s16"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 9px">
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-                <td class="doc_17_s43"></td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 19px">
-                <td class="doc_17_s33" colspan="4">（記入要領）</td>
-                <td class="doc_17_s33">1</td>
-                <td class="doc_17_s33" colspan="33">一次下請負業者は、二次下請負業者以下の業者から提出された「届出書」(様式第１号－甲) に基づいて本表を作成</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 19px">
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33" colspan="33">の上、元請に届け出ること。</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 19px">
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33">2</td>
-                <td class="doc_17_s33" colspan="33">この下請負業者編成表でまとめきれない場合には、本様式をコピーするなどして適宜使用すること。</td>
-              </tr>
-              <tr class="doc_17_s45" style="height: 19px">
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33"></td>
-                <td class="doc_17_s33">3</td>
-                <td class="doc_17_s33" colspan="33">二次下請負業者を使用しない場合は、この書類は提出不要。</td>
-              </tr>
-            </tbody>
-          </table>
+    <% 25.times do |i| %>
+      <% if (instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}").present?) ||
+            (instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}").present?) ||
+            (instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}").present?) %>
+        <div class="document-inner">
+          <section class="doc_17_sheet">
+            <div class="ritz grid-container" dir="ltr">
+              <table class="waffle" cellspacing="0" cellpadding="0" style="width: 100%; zoom: 90%;">
+                <thead>
+                  <tr class="doc_17_s45">
+                    <th style="width:30px;">&nbsp;</th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:30px;"></th>
+                    <th style="width:20px;"></th>
+                    <th style="width:20px;"></th>
+                    <th style="width:20px;"></th>
+                    <th style="width:40px;"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="doc_17_s45" style="height: 4px;">
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s0"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 14px;">
+                    <td class="doc_17_s47" colspan="9" rowspan="2">全建統一様式第１号-乙</td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 14px;">
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <% if i == 0 %>
+                      <td class="doc_17_s4" dir="ltr" colspan="8" style="size: 20%">
+                        <%= f.date_field name = 'content[date_submitted]',
+                                          value: doc_content_date(@document.content&.[]("date_submitted")),
+                                          class: 'form-control form-control-sm',
+                                          style: 'width: 70%; margin: 0 auto'
+                        %><!-- 17-001 提出日(西暦) -->
+                      </td>
+                    <% else %>
+                      <td class="doc_17_s1" dir="ltr" colspan="8"></td>
+                    <% end %>
+                  </tr>
+                  <tr class="doc_17_s45">
+                    <td class="doc_17_s48" colspan="9"></td>
+                    <td colspan="29" style="border: none;"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 19px;">
+                    <% if i == 0 %>
+                      <td class="doc_17_s50" colspan="10" rowspan="2">※緑枠は入力項目です。必要あれば入力してください。</td>
+                    <% else %>
+                      <td class="doc_17_s50" colspan="10" rowspan="2"></td>
+                    <% end %>
+                    <td class="doc_17_s5" colspan="18" rowspan="2">下請負業者編成表</td>
+                    <td class="doc_17_s50" colspan="10" rowspan="2"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 19px">
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 9px">
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 14px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s7" colspan="16" rowspan="2">（一次下請負業者＝作成下請負業者）</td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 14px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s9" dir="ltr" colspan="1" rowspan="12">
+                      <%= request_order_info(@primary_subcon_id_17th)&.construction_name %>
+                    </td><!--17-002 工事名(一次)-->
+                    <td class="doc_17_s10" colspan="7" rowspan="2">会社名</td>
+                    <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                      <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_name") %>
+                    </td><!--17-003 会社名(一次)-->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s10" colspan="7" rowspan="2">代表者名</td>
+                    <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                      <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-004 代表者名(一次)-->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s10" colspan="7" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                      <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-005 建設業許可番号(短縮)(一次) -->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s15" rowspan="3"></td>
+                    <td class="doc_17_s10" colspan="7" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                      <%= request_order_info(@primary_subcon_id_17th)&.safety_manager_name %>
+                    </td><!--17-006 安全衛生責任者名(一次) -->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s14"></td>
+                    <td class="doc_17_s10" colspan="7" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                      <%= request_order_info(@primary_subcon_id_17th)&.lead_engineer_name %>
+                    </td><!--17-007 主任技術者名(一次) -->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s16" colspan="7" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                      <%= request_order_info(@primary_subcon_id_17th)&.professional_engineer_name %>
+                    </td><!--17-008 専門技術者名(一次)-->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s10" colspan="6" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                      <%= request_order_info(@primary_subcon_id_17th)&.professional_engineer_details %>
+                    </td><!--17-009 担当工事内容(一次)-->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s18" colspan="1" rowspan="2">工</td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s19"></td>
+                    <td class="doc_17_s17" colspan="7" rowspan="2">特定専門工事の有無</td>
+                    <td class="doc_17_s20" colspan="3" rowspan="2">
+                      <%= professional_construction_yes(request_order_info(@primary_subcon_id_17th)&.professional_construction) %>
+                    </td><!--17-010 特定専門工事の有無(一次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="3" rowspan="2">
+                      <%= professional_construction_no(request_order_info(@primary_subcon_id_17th)&.professional_construction) %>
+                    </td><!--17-010 特定専門工事の有無(一次)-->
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s23"></td>
+                    <td class="doc_17_s23"></td>
+                    <td class="doc_17_s23"></td>
+                    <td class="doc_17_s23"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s19"></td>
+                    <td class="doc_17_s18" colspan="1" rowspan="2">事</td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s23"></td>
+                    <td class="doc_17_s23"></td>
+                    <td class="doc_17_s23"></td>
+                    <td class="doc_17_s23"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s19"></td>
+                    <td class="doc_17_s10" colspan="7" rowspan="2">登録基幹技能者</td>
+                    <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                      <%= request_order_info(@primary_subcon_id_17th)&.registered_core_engineer_name %>
+                    </td><!--17-011 登録基幹技能者(一次)-->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s14" colspan="4" rowspan="3"></td>
+                    <td class="doc_17_s19"></td>
+                    <td class="doc_17_s7" style="border-top: none; border-right: none;"></td> <!-- s7 -->
+                    <!--<td class="doc_17_s17" style="border-top: none; border-left: none;"></td>--> <!-- s17 -->
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s6"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s12"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s17" colspan="3" rowspan="2">工期</td>
+                    <td class="doc_17_s24" dir="ltr" colspan="5" rowspan="2">
+                      <%= document_date(request_order_info(@primary_subcon_id_17th)&.start_date) %>
+                    </td><!--17-012 各会社の工期(自)(一次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="3" rowspan="2">~</td>
+                    <td class="doc_17_s25" dir="ltr" colspan="5" rowspan="2">
+                      <%= document_date(request_order_info(@primary_subcon_id_17th)&.end_date) %>
+                    </td><!--17-013 各会社の工期(至)(一次)-->
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s8"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s26"></td>
+                    <td class="doc_17_s27" colspan="2"></td>
+                    <td class="doc_17_s26"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s29"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s28"></td>
+                    <td class="doc_17_s30"></td>
+                    <td class="doc_17_s30"></td>
+                    <td class="doc_17_s30"></td>
+                    <td class="doc_17_s30"></td>
+                    <td class="doc_17_s30"></td>
+                    <td class="doc_17_s30"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s31"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s31"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s3"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s32"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                    <td class="doc_17_s1"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s9" dir="ltr" rowspan="12">
+                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
+                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-1 会社名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s9" rowspan="12">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-2 会社名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s9" rowspan="12">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-3 会社名(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
+                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-1 代表者名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-2 代表者名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-3 代表者名(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-1 建設業許可番号(短縮)(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-2 建設業許可番号(短縮)(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-3 建設業許可番号(短縮)(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-1 安全衛生責任者名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-2 安全衛生責任者名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-3 安全衛生責任者名(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-1 主任技術者名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-2 主任技術者名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-2 主任技術者名(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-1 専門技術者名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-2 専門技術者名(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-3 専門技術者名(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-1 担当工事内容(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-2 担当工事内容(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-3 担当工事内容(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18">工</td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">工</td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">工</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-1 特定専門工事の有無(二次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-1 特定専門工事の有無(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-2 特定専門工事の有無(二次)-->
+                    <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-2 特定専門工事の有無(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-3 特定専門工事の有無(二次)-->
+                    <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-3 特定専門工事の有無(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s24" dir="ltr" colspan="4" rowspan="2">
+                      <%= document_date(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-1 各会社の工期(自)(二次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s25" dir="ltr" colspan="4" rowspan="2">
+                      <%= document_date(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                    </td><!--17-024-1 各会社の工期(自)(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s36" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-2 各会社の工期(自)(二次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s37" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                    </td><!--17-024-2 各会社の工期(自)(二次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s36" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-3 各会社の工期(自)(二次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s37" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                    </td><!--17-024-3 各会社の工期(自)(二次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s38"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s40"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s42"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s38"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s38"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s44"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s9" rowspan="12">
+                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-1 会社名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s9" rowspan="12">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-2 会社名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s9" rowspan="12">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-3 会社名(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-1 代表者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-2 代表者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-3 代表者名(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-1 建設業許可番号(短縮)(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-2 建設業許可番号(短縮)(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-3 建設業許可番号(短縮)(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-1 安全衛生責任者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-2 安全衛生責任者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-3 安全衛生責任者名(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-1 主任技術者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-2 主任技術者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-3 主任技術者名(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-1 専門技術者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-2 専門技術者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-3 専門技術者名(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-1 担当工事内容(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-2 担当工事内容(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-3 担当工事内容(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18">工</td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">工</td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">工</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-1 特定専門工事の有無(三次)-->
+                    <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-1 特定専門工事の有無(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-2 特定専門工事の有無(三次)-->
+                    <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-2 特定専門工事の有無(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-3 特定専門工事の有無(三次)-->
+                    <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-3 特定専門工事の有無(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s36" colspan="4" rowspan="2">
+                      <%= document_date(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-1 各会社の工期(自)(三次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s37" colspan="4" rowspan="2">
+                      <%= document_date(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                    </td><!--17-023-1 各会社の工期(自)(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s36" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-2 各会社の工期(自)(三次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s37" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                    </td><!--17-023-2 各会社の工期(自)(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s36" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-3 各会社の工期(自)(三次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s37" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                    </td><!--17-023-3 各会社の工期(自)(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s38"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s40"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s39"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s41"></td>
+                    <td class="doc_17_s42"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s38"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s38"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s44"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s9" rowspan="12">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-1 会社名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s9" rowspan="12">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-2 会社名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s9" rowspan="12">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                    </td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                    </td><!--17-015-3 会社名(四次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-1 代表者名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-2 代表者名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                    </td><!--17-016-3 代表者名(四次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-1 建設業許可番号(短縮)(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-2 建設業許可番号(短縮)(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                    </td><!--17-017-3 建設業許可番号(短縮)(四次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-1 安全衛生責任者名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-2 安全衛生責任者名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                    </td><!--17-018-3 安全衛生責任者名(四次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-1 主任技術者名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-2 主任技術者名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                    </td><!--17-019-3 主任技術者名(四次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-1 専門技術者名(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-2 専門技術者名(三次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                    </td><!--17-020-3 専門技術者名(三次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-1 担当工事内容(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-2 担当工事内容(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18"></td>
+                    <td class="doc_17_s49" rowspan="2"></td>
+                    <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                    <td class="doc_17_s35" colspan="6" rowspan="2">
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                    </td><!--17-021-3 担当工事内容(四次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18">工</td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">工</td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">工</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-1 特定専門工事の有無(四次)-->
+                    <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-1 特定専門工事の有無(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-2 特定専門工事の有無(四次)-->
+                    <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-2 特定専門工事の有無(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s18">事</td>
+                    <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                    <td class="doc_17_s20" colspan="2" rowspan="2">
+                      <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-3 特定専門工事の有無(四次)-->
+                    <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                    <td class="doc_17_s22" colspan="2" rowspan="2">
+                      <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                    </td><!--17-022-3 特定専門工事の有無(四次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" style="border-top: none;"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s36" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-1 各会社の工期(自)(四次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s37" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                    </td><!--17-023-1 各会社の工期(自)(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s36" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-2 各会社の工期(自)(四次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s37" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                    </td><!--17-023-2 各会社の工期(自)(四次)-->
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                    <td class="doc_17_s36" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                    </td><!--17-023-3 各会社の工期(自)(四次)-->
+                    <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                    <td class="doc_17_s37" colspan="4" rowspan="2">
+                      <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                    </td><!--17-023-3 各会社の工期(自)(四次)-->
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 12px">
+                    <td class="doc_17_s16"></td>
+                    <td class="doc_17_s16"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 9px">
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                    <td class="doc_17_s43"></td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 19px">
+                    <td class="doc_17_s33" colspan="4">（記入要領）</td>
+                    <td class="doc_17_s33">1</td>
+                    <td class="doc_17_s33" colspan="33">一次下請負業者は、二次下請負業者以下の業者から提出された「届出書」(様式第１号－甲) に基づいて本表を作成</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 19px">
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33" colspan="33">の上、元請に届け出ること。</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 19px">
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33">2</td>
+                    <td class="doc_17_s33" colspan="33">この下請負業者編成表でまとめきれない場合には、本様式をコピーするなどして適宜使用すること。</td>
+                  </tr>
+                  <tr class="doc_17_s45" style="height: 19px">
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33"></td>
+                    <td class="doc_17_s33">3</td>
+                    <td class="doc_17_s33" colspan="33">二次下請負業者を使用しない場合は、この書類は提出不要。</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
         </div>
-      </section>
-    </div>
+      <% end %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/users/documents/doc_17th/_show.html.erb
+++ b/app/views/users/documents/doc_17th/_show.html.erb
@@ -1,1769 +1,1842 @@
 <!-- (17)全建統一様式第1号－乙(下請負業者編成表) -->
-<div id="doc_17" class="document-outer" style="overflow: auto;">
-  <div class="document-inner">
-    <section class="doc_17_sheet">
-      <div class="ritz grid-container" dir="ltr">
-        <table class="waffle" cellspacing="0" cellpadding="0" style="width: 100%; zoom: 90%;">
-          <thead>
-            <tr class="doc_17_s45">
-              <th style="width:30px;">&nbsp;</th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:30px;"></th>
-              <th style="width:20px;"></th>
-              <th style="width:20px;"></th>
-              <th style="width:20px;"></th>
-              <th style="width:40px;"></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="doc_17_s45" style="height: 4px;">
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s0"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 14px;">
-              <td class="doc_17_s47" colspan="9" rowspan="2">全建統一様式第１号-乙</td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 14px;">
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s4" dir="ltr" colspan="8">
-                <%= doc_content_date(@document.content&.[]("date_submitted")) %> <!-- 17-001 提出日(西暦) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45">
-              <td class="doc_17_s48" colspan="9"></td>
-              <td colspan="29" style="border: none;"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 19px;">
-              <td class="doc_17_s5" colspan="38" rowspan="2">下請負業者編成表</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 19px">
-            </tr>
-            <tr class="doc_17_s45" style="height: 9px">
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 14px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s7" colspan="16" rowspan="2">（一次下請負業者＝作成下請負業者）</td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 14px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s9" dir="ltr" colspan="2" rowspan="13" style="writing-mode: tb-rl;">
-                <%= primary_subcon_info(document_info)&.construction_name %> <!-- 17-002 工事名(一次) -->
-              </td>
-              <td class="doc_17_s10" colspan="7" rowspan="2">会社名</td>
-              <td class="doc_17_s11" dir="ltr" colspan="7" rowspan="2">
-                <%= primary_subcon_info(document_info)&.content&.[]("subcon_name") %> <!-- 17-003 会社名(一次) -->
-              </td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s10" colspan="7" rowspan="2">代表者名</td>
-              <td class="doc_17_s11" dir="ltr" colspan="7" rowspan="2">
-                <%= primary_subcon_info(document_info)&.content&.[]("subcon_representative_name") %> <!-- 17-004 代表者名(一次) -->
-              </td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s10" colspan="7" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                <!-- 17-005 建設業許可番号(短縮)(一次) ※未実装※ -->
-              </td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s15" rowspan="3"></td>
-              <td class="doc_17_s10" colspan="7" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                <%= primary_subcon_info(document_info)&.safety_manager_name %> <!-- 17-006 安全衛生責任者名(一次) -->
-              </td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s14"></td>
-              <td class="doc_17_s10" colspan="7" rowspan="2">主任技術者</td>
-              <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                <%= primary_subcon_info(document_info)&.lead_engineer_name %> <!-- 17-007 主任技術者名(一次) -->
-              </td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s16" colspan="7" rowspan="2">専門技術者</td>
-              <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                <%= primary_subcon_info(document_info)&.professional_engineer_name %> <!-- 17-008 専門技術者名(一次) -->
-              </td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s10" colspan="6" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s13" dir="ltr" colspan="7" rowspan="2">
-                <%= primary_subcon_info(document_info)&.professional_engineer_details %> <!-- 17-009 担当工事内容(一次) -->
-              </td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s18" colspan="2" rowspan="2">工</td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s19"></td>
-              <td class="doc_17_s17" colspan="7" rowspan="2">特定専門工事の有無</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(primary_subcon_info(document_info)&.professional_construction) %> <!-- 17-010 特定専門工事の有無(一次) -->
-              </td>
-              <td class="doc_17_s21" dir="ltr" colspan="3" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(primary_subcon_info(document_info)&.professional_construction) %> <!-- 17-010 特定専門工事の有無(一次) -->
-              </td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s23"></td>
-              <td class="doc_17_s23"></td>
-              <td class="doc_17_s23"></td>
-              <td class="doc_17_s23"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s19"></td>
-              <td class="doc_17_s18" colspan="2" rowspan="2">事</td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s23"></td>
-              <td class="doc_17_s23"></td>
-              <td class="doc_17_s23"></td>
-              <td class="doc_17_s23"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s19"></td>
-              <td class="doc_17_s10" colspan="7" rowspan="2">登録基幹技能者</td>
-              <td class="doc_17_s11" dir="ltr" colspan="7" rowspan="2">
-                <%= primary_subcon_info(document_info)&.professional_engineer_details %> <!-- 17-011 登録基幹技能者(一次) -->
-              </td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s14" colspan="4" rowspan="3"></td>
-              <td class="doc_17_s19"></td>
-              <td class="doc_17_s7" style="border-top: none; border-right: none;"></td> <!-- s7 -->
-              <td class="doc_17_s17" style="border-top: none; border-left: none;"></td> <!-- s17 -->
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s6"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s12"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s17" colspan="3" rowspan="2">工期</td>
-              <td class="doc_17_s24" dir="ltr" colspan="6" rowspan="2">
-                <%= document_date(primary_subcon_info(document_info)&.start_date) %> <!-- 17-012 各会社の工期(自)(一次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" rowspan="2">~</td>
-              <td class="doc_17_s25" dir="ltr" colspan="6" rowspan="2">
-                <%= document_date(primary_subcon_info(document_info)&.end_date) %> <!-- 17-013 各会社の工期(至)(一次) -->
-              </td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s8"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s26"></td>
-              <td class="doc_17_s27" colspan="2"></td>
-              <td class="doc_17_s26"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s29"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s28"></td>
-              <td class="doc_17_s30"></td>
-              <td class="doc_17_s30"></td>
-              <td class="doc_17_s30"></td>
-              <td class="doc_17_s30"></td>
-              <td class="doc_17_s30"></td>
-              <td class="doc_17_s30"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s31"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s31"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s3"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s32"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-              <td class="doc_17_s1"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s9" dir="ltr" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s34" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s34" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(二次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 2)&.content&.[]("subcon_representative_name") %> <!-- 17-016-3 代表者名(二次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                <!-- 17-017-1 建設業許可番号(短縮)(二次) ※未実装※ -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <!-- 17-017-2 建設業許可番号(短縮)(二次) ※未実装※ -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <!-- 17-017-3 建設業許可番号(短縮)(二次) ※未実装※ -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(二次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 2)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(二次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 2)&.professional_engineer_name %> <!-- 17-020-3 専門技術者名(二次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= secondary_subcon_info(document_info, 2)&.professional_engineer_details %> <!-- 17-021-3 担当工事内容(二次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18">工</td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">工</td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">工</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(secondary_subcon_info(document_info, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(二次) -->
-              </td>
-              <td class="doc_17_s21" dir="ltr" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(secondary_subcon_info(document_info, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(secondary_subcon_info(document_info, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(二次) -->
-              </td>
-              <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(secondary_subcon_info(document_info, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(secondary_subcon_info(document_info, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(二次) -->
-              </td>
-              <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(secondary_subcon_info(document_info, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(二次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s17" style="border-top: none;"></td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" style="border-top: none;"></td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" style="border-top: none;"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s24" dir="ltr" colspan="4" rowspan="2">
-                <%= document_date(secondary_subcon_info(document_info, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(二次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s25" dir="ltr" colspan="4" rowspan="2">
-                <%= document_date(secondary_subcon_info(document_info, 0)&.end_date) %> <!-- 17-024-1 各会社の工期(自)(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s36" colspan="4" rowspan="2">
-                <%= document_date(secondary_subcon_info(document_info, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(二次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s37" colspan="4" rowspan="2">
-                <%= document_date(secondary_subcon_info(document_info, 1)&.end_date) %> <!-- 17-024-2 各会社の工期(自)(二次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s36" colspan="4" rowspan="2">
-                <%= document_date(secondary_subcon_info(document_info, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(二次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s37" colspan="4" rowspan="2">
-                <%= document_date(secondary_subcon_info(document_info, 2)&.end_date) %> <!-- 17-024-3 各会社の工期(自)(二次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s38"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s40"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s42"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s38"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s38"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s44"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s34" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s34" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s34" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 2)&.content&.[]("subcon_representative_name") %> <!-- 17-016-3 代表者名(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <!-- 17-017-1 建設業許可番号(短縮)(三次) ※未実装※ -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <!-- 17-017-2 建設業許可番号(短縮)(三次) ※未実装※ -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <!-- 17-017-3 建設業許可番号(短縮)(三次) ※未実装※ -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 2)&.lead_engineer_name %> <!-- 17-019-3 主任技術者名(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 2)&.professional_engineer_name %> <!-- 17-020-3 専門技術者名(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 2, 2)&.professional_engineer_details %> <!-- 17-021-3 担当工事内容(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18">工</td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">工</td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">工</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(三次) -->
-              </td>
-              <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(三次) -->
-              </td>
-              <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(三次) -->
-              </td>
-              <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s17" style="border-top: none;"></td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" style="border-top: none;"></td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" style="border-top: none;"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s36" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 2, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(三次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s37" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 2, 0)&.end_date) %> <!-- 17-023-1 各会社の工期(自)(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s36" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 2, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(三次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s37" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 2, 1)&.end_date) %> <!-- 17-023-2 各会社の工期(自)(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s36" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 2, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(三次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s37" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 2, 2)&.end_date) %> <!-- 17-023-3 各会社の工期(自)(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s38"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s40"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s39"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s41"></td>
-              <td class="doc_17_s42"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s38"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s38"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s44"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s34" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s34" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s34" rowspan="12"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(四次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 2)&.content&.[]("subcon_representative_name") %> <!-- 17-016-3 代表者名(四次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <!-- 17-017-1 建設業許可番号(短縮)(四次) ※未実装※ -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <!-- 17-017-2 建設業許可番号(短縮)(四次) ※未実装※ -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <!-- 17-017-3 建設業許可番号(短縮)(四次) ※未実装※ -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(四次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 2)&.lead_engineer_name %> <!-- 17-019-3 主任技術者名(四次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(三次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 2)&.professional_engineer_name %> <!-- 17-020-3 専門技術者名(三次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18"></td>
-              <td class="doc_17_s49" rowspan="2"></td>
-              <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
-              <td class="doc_17_s35" colspan="6" rowspan="2">
-                <%= hierarchy_subcon_info(document_info, 3, 2)&.professional_engineer_details %> <!-- 17-021-3 担当工事内容(四次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18">工</td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">工</td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">工</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(四次) -->
-              </td>
-              <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(四次) -->
-              </td>
-              <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s18">事</td>
-              <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-              <td class="doc_17_s20" colspan="2" rowspan="2">
-                <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(四次) -->
-              </td>
-              <td class="doc_17_s7" colspan="2" rowspan="2">・</td>
-              <td class="doc_17_s22" colspan="2" rowspan="2">
-                <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(四次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s17" style="border-top: none;"></td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" style="border-top: none;"></td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" style="border-top: none;"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s36" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 3, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(四次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s37" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 3, 0)&.end_date) %> <!-- 17-023-1 各会社の工期(自)(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s36" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 3, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(四次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s37" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 3, 1)&.end_date) %> <!-- 17-023-2 各会社の工期(自)(四次) -->
-              </td>
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
-              <td class="doc_17_s36" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 3, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(四次) -->
-              </td>
-              <td class="doc_17_s7" dir="ltr" colspan="2" rowspan="2">~</td>
-              <td class="doc_17_s37" colspan="4" rowspan="2">
-                <%= document_date(hierarchy_subcon_info(document_info, 3, 2)&.end_date) %> <!-- 17-023-3 各会社の工期(自)(四次) -->
-              </td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 12px">
-              <td class="doc_17_s16"></td>
-              <td class="doc_17_s16"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 9px">
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-              <td class="doc_17_s43"></td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 19px">
-              <td class="doc_17_s33" colspan="4">（記入要領）</td>
-              <td class="doc_17_s33">1</td>
-              <td class="doc_17_s33" colspan="33">一次下請負業者は、二次下請負業者以下の業者から提出された「届出書」(様式第１号－甲) に基づいて本表を作成</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 19px">
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33" colspan="33">の上、元請に届け出ること。</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 19px">
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33">2</td>
-              <td class="doc_17_s33" colspan="33">この下請負業者編成表でまとめきれない場合には、本様式をコピーするなどして適宜使用すること。</td>
-            </tr>
-            <tr class="doc_17_s45" style="height: 19px">
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33"></td>
-              <td class="doc_17_s33">3</td>
-              <td class="doc_17_s33" colspan="33">二次下請負業者を使用しない場合は、この書類は提出不要。</td>
-            </tr>
-          </tbody>
-        </table>
+<% 25.times do |i| %>
+  <% if (instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}").present?) ||
+        (instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}").present?) ||
+        (instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}").present?) %>
+    <div id="doc_17" class="document-outer" style="overflow: auto;">
+      <div class="document-inner">
+        <section class="doc_17_sheet">
+          <div class="ritz grid-container" dir="ltr">
+            <table class="waffle" cellspacing="0" cellpadding="0" style="width: 100%; zoom: 90%;">
+              <thead>
+                <tr class="doc_17_s45">
+                  <th style="width:30px;">&nbsp;</th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:30px;"></th>
+                  <th style="width:20px;"></th>
+                  <th style="width:20px;"></th>
+                  <th style="width:20px;"></th>
+                  <th style="width:40px;"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="doc_17_s45" style="height: 4px;">
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s0"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 14px;">
+                  <td class="doc_17_s47" colspan="9" rowspan="2">全建統一様式第１号-乙</td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 14px;">
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <% if i == 0 %>
+                    <td class="doc_17_s4" dir="ltr" colspan="8">
+                      <%= doc_content_date(@document.content&.[]("date_submitted")) %> <!--17-001 提出日(西暦) -->
+                    </td>
+                  <% else %>
+                    <td class="doc_17_s1" dir="ltr" colspan="8"></td>
+                  <% end %>
+                </tr>
+                <tr class="doc_17_s45" style="height: 14px;">
+                  <% if i == 0 %>
+                    <td class="doc_17_s50">※緑枠は入力項目です。必要あれば入力してください。</td>
+                  <% else %>
+                    <td class="doc_17_s50"></td>
+                  <% end %>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45">
+                  <td class="doc_17_s48" colspan="9"></td>
+                  <td colspan="29" style="border: none;"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 19px;">
+                  <td class="doc_17_s5" colspan="38" rowspan="2">下請負業者編成表</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 19px">
+                </tr>
+                <tr class="doc_17_s45" style="height: 9px">
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 14px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s7" colspan="16" rowspan="2">（一次下請負業者＝作成下請負業者）</td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 14px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s9" dir="ltr" colspan="1" rowspan="12">
+                    <%= request_order_info(@primary_subcon_id_17th)&.construction_name %>
+                  </td><!--17-002 工事名(一次)-->
+                  <td class="doc_17_s10" colspan="7" rowspan="2">会社名</td>
+                  <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                    <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_name") %>
+                  </td><!--17-003 会社名(一次)-->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s10" colspan="7" rowspan="2">代表者名</td>
+                  <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                    <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-004 代表者名(一次)-->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s10" colspan="7" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                    <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-005 建設業許可番号(短縮)(一次) -->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s15" rowspan="3"></td>
+                  <td class="doc_17_s10" colspan="7" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                    <%= request_order_info(@primary_subcon_id_17th)&.safety_manager_name %>
+                  </td><!--17-006 安全衛生責任者名(一次) -->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s14"></td>
+                  <td class="doc_17_s10" colspan="7" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                    <%= request_order_info(@primary_subcon_id_17th)&.lead_engineer_name %>
+                  </td><!--17-007 主任技術者名(一次) -->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s16" colspan="7" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                    <%= request_order_info(@primary_subcon_id_17th)&.professional_engineer_name %>
+                  </td><!--17-008 専門技術者名(一次)-->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s10" colspan="6" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                    <%= request_order_info(@primary_subcon_id_17th)&.professional_engineer_details %>
+                  </td><!--17-009 担当工事内容(一次)-->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s18" colspan="1" rowspan="2">工</td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s19"></td>
+                  <td class="doc_17_s17" colspan="7" rowspan="2">特定専門工事の有無</td>
+                  <td class="doc_17_s20" colspan="3" rowspan="2">
+                    <%= professional_construction_yes(request_order_info(@primary_subcon_id_17th)&.professional_construction) %>
+                  </td><!--17-010 特定専門工事の有無(一次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="3" rowspan="2">
+                    <%= professional_construction_no(request_order_info(@primary_subcon_id_17th)&.professional_construction) %>
+                  </td><!--17-010 特定専門工事の有無(一次)-->
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s23"></td>
+                  <td class="doc_17_s23"></td>
+                  <td class="doc_17_s23"></td>
+                  <td class="doc_17_s23"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s19"></td>
+                  <td class="doc_17_s18" colspan="1" rowspan="2">事</td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s23"></td>
+                  <td class="doc_17_s23"></td>
+                  <td class="doc_17_s23"></td>
+                  <td class="doc_17_s23"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s19"></td>
+                  <td class="doc_17_s10" colspan="7" rowspan="2">登録基幹技能者</td>
+                  <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                    <%= request_order_info(@primary_subcon_id_17th)&.registered_core_engineer_name %>
+                  </td><!--17-011 登録基幹技能者(一次)-->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s14" colspan="4" rowspan="3"></td>
+                  <td class="doc_17_s19"></td>
+                  <td class="doc_17_s7" style="border-top: none; border-right: none;"></td> <!-- s7 -->
+                  <!--<td class="doc_17_s17" style="border-top: none; border-left: none;"></td>--> <!-- s17 -->
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s6"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s12"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s17" colspan="3" rowspan="2">工期</td>
+                  <td class="doc_17_s24" dir="ltr" colspan="5" rowspan="2">
+                    <%= document_date(request_order_info(@primary_subcon_id_17th)&.start_date) %>
+                  </td><!--17-012 各会社の工期(自)(一次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="3" rowspan="2">~</td>
+                  <td class="doc_17_s25" dir="ltr" colspan="5" rowspan="2">
+                    <%= document_date(request_order_info(@primary_subcon_id_17th)&.end_date) %>
+                  </td><!--17-013 各会社の工期(至)(一次)-->
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s8"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s26"></td>
+                  <td class="doc_17_s27" colspan="2"></td>
+                  <td class="doc_17_s26"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s29"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s28"></td>
+                  <td class="doc_17_s30"></td>
+                  <td class="doc_17_s30"></td>
+                  <td class="doc_17_s30"></td>
+                  <td class="doc_17_s30"></td>
+                  <td class="doc_17_s30"></td>
+                  <td class="doc_17_s30"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s31"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s31"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s3"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s32"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                  <td class="doc_17_s1"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s9" dir="ltr" rowspan="12">
+                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
+                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-1 会社名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s9" rowspan="12">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-2 会社名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s9" rowspan="12">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-3 会社名(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
+                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-1 代表者名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-2 代表者名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-3 代表者名(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-1 建設業許可番号(短縮)(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-2 建設業許可番号(短縮)(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-3 建設業許可番号(短縮)(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-1 安全衛生責任者名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-2 安全衛生責任者名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-3 安全衛生責任者名(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-1 主任技術者名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-2 主任技術者名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-2 主任技術者名(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-1 専門技術者名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-2 専門技術者名(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-3 専門技術者名(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-1 担当工事内容(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-2 担当工事内容(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-3 担当工事内容(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18">工</td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">工</td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">工</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-1 特定専門工事の有無(二次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-1 特定専門工事の有無(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-2 特定専門工事の有無(二次)-->
+                  <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-2 特定専門工事の有無(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-3 特定専門工事の有無(二次)-->
+                  <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-3 特定専門工事の有無(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s24" dir="ltr" colspan="4" rowspan="2">
+                    <%= document_date(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-1 各会社の工期(自)(二次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s25" dir="ltr" colspan="4" rowspan="2">
+                    <%= document_date(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                  </td><!--17-024-1 各会社の工期(自)(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s36" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-2 各会社の工期(自)(二次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s37" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                  </td><!--17-024-2 各会社の工期(自)(二次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s36" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-3 各会社の工期(自)(二次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s37" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                  </td><!--17-024-3 各会社の工期(自)(二次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s38"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s40"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s42"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s38"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s38"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s44"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s9" rowspan="12">
+                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-1 会社名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s9" rowspan="12">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-2 会社名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s9" rowspan="12">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-3 会社名(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-1 代表者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-2 代表者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-3 代表者名(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-1 建設業許可番号(短縮)(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-2 建設業許可番号(短縮)(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-3 建設業許可番号(短縮)(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-1 安全衛生責任者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-2 安全衛生責任者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-3 安全衛生責任者名(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-1 主任技術者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-2 主任技術者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-3 主任技術者名(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-1 専門技術者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-2 専門技術者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-3 専門技術者名(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-1 担当工事内容(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-2 担当工事内容(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-3 担当工事内容(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18">工</td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">工</td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">工</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-1 特定専門工事の有無(三次)-->
+                  <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-1 特定専門工事の有無(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-2 特定専門工事の有無(三次)-->
+                  <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-2 特定専門工事の有無(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-3 特定専門工事の有無(三次)-->
+                  <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-3 特定専門工事の有無(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s36" colspan="4" rowspan="2">
+                    <%= document_date(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-1 各会社の工期(自)(三次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s37" colspan="4" rowspan="2">
+                    <%= document_date(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                  </td><!--17-023-1 各会社の工期(自)(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s36" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-2 各会社の工期(自)(三次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s37" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                  </td><!--17-023-2 各会社の工期(自)(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s36" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-3 各会社の工期(自)(三次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s37" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                  </td><!--17-023-3 各会社の工期(自)(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s38"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s40"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s39"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s41"></td>
+                  <td class="doc_17_s42"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s38"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s38"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s44"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s9" rowspan="12">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-1 会社名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s9" rowspan="12">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-2 会社名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s9" rowspan="12">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                  </td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                  </td><!--17-015-3 会社名(四次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-1 代表者名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-2 代表者名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                  </td><!--17-016-3 代表者名(四次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-1 建設業許可番号(短縮)(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-2 建設業許可番号(短縮)(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                  </td><!--17-017-3 建設業許可番号(短縮)(四次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-1 安全衛生責任者名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-2 安全衛生責任者名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                  </td><!--17-018-3 安全衛生責任者名(四次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-1 主任技術者名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-2 主任技術者名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                  </td><!--17-019-3 主任技術者名(四次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-1 専門技術者名(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-2 専門技術者名(三次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                  </td><!--17-020-3 専門技術者名(三次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-1 担当工事内容(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-2 担当工事内容(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18"></td>
+                  <td class="doc_17_s49" rowspan="2"></td>
+                  <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                  <td class="doc_17_s35" colspan="6" rowspan="2">
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                  </td><!--17-021-3 担当工事内容(四次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18">工</td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">工</td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">工</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-1 特定専門工事の有無(四次)-->
+                  <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-1 特定専門工事の有無(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-2 特定専門工事の有無(四次)-->
+                  <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-2 特定専門工事の有無(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s18">事</td>
+                  <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                  <td class="doc_17_s20" colspan="2" rowspan="2">
+                    <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-3 特定専門工事の有無(四次)-->
+                  <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                  <td class="doc_17_s22" colspan="2" rowspan="2">
+                    <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                  </td><!--17-022-3 特定専門工事の有無(四次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" style="border-top: none;"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s36" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-1 各会社の工期(自)(四次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s37" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                  </td><!--17-023-1 各会社の工期(自)(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s36" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-2 各会社の工期(自)(四次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s37" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                  </td><!--17-023-2 各会社の工期(自)(四次)-->
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                  <td class="doc_17_s36" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                  </td><!--17-023-3 各会社の工期(自)(四次)-->
+                  <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                  <td class="doc_17_s37" colspan="4" rowspan="2">
+                    <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                  </td><!--17-023-3 各会社の工期(自)(四次)-->
+                </tr>
+                <tr class="doc_17_s45" style="height: 12px">
+                  <td class="doc_17_s16"></td>
+                  <td class="doc_17_s16"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 9px">
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                  <td class="doc_17_s43"></td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 19px">
+                  <td class="doc_17_s33" colspan="4">（記入要領）</td>
+                  <td class="doc_17_s33">1</td>
+                  <td class="doc_17_s33" colspan="33">一次下請負業者は、二次下請負業者以下の業者から提出された「届出書」(様式第１号－甲) に基づいて本表を作成</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 19px">
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33" colspan="33">の上、元請に届け出ること。</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 19px">
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33">2</td>
+                  <td class="doc_17_s33" colspan="33">この下請負業者編成表でまとめきれない場合には、本様式をコピーするなどして適宜使用すること。</td>
+                </tr>
+                <tr class="doc_17_s45" style="height: 19px">
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33"></td>
+                  <td class="doc_17_s33">3</td>
+                  <td class="doc_17_s33" colspan="33">二次下請負業者を使用しない場合は、この書類は提出不要。</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
       </div>
-    </section>
-  </div>
-</div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/users/documents/doc_17th/_show.pdf.erb
+++ b/app/views/users/documents/doc_17th/_show.pdf.erb
@@ -1,2479 +1,2665 @@
 <!-- (17)全建統一様式第1号－乙(下請負業者編成表) -->
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
+  integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 
 <body class="doc_17_sheet" style="font-family: Noto Sans JP, Hiragino Kaku Gothic ProN, Meiryo, sans-serif;">
-  <div class="ritz grid-container" dir="ltr">
-    <table class="waffle" cellspacing="0" cellpadding="0">
-      <thead>
-        <tr class="s45">
-          <th style="width:30px;">&nbsp;</th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:30px;"></th>
-          <th style="width:20px;"></th>
-          <th style="width:20px;"></th>
-          <th style="width:20px;"></th>
-          <th style="width:20px;"></th>
-          <th style="width:20px;"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr class="s45" style="height: 4px;">
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s0"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 14px;">
-          <td class="s47" colspan="9" rowspan="2">全建統一様式第１号-乙</td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 14px;">
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s4" dir="ltr" colspan="8">
-            <%= doc_content_date(@document.content&.[]("date_submitted")) %> <!-- 17-001 提出日(西暦) -->
-          </td>
-        </tr>
-        <tr class="s45">
-          <td class="s48" colspan="9"></td>
-          <td colspan="29" style="border: none;"></td>
-        </tr>
-        <tr class="s45" style="height: 19px;">
-          <td class="s5" colspan="38" rowspan="2">下請負業者編成表</td>
-        </tr>
-        <tr class="s45" style="height: 19px">
-        </tr>
-        <tr class="s45" style="height: 9px">
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 14px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s7" colspan="16" rowspan="2">（一次下請負業者＝作成下請負業者）</td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-        </tr>
-        <tr class="s45" style="height: 14px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s9" dir="ltr" colspan="2" rowspan="13" style="writing-mode: tb-rl; display: flex;">
-            <%= primary_subcon_info(document_info)&.construction_name %> <!-- 17-002 工事名(一次) -->
-          </td>
-          <td class="s10" colspan="7" rowspan="2">会社名</td>
-          <td class="s11" dir="ltr" colspan="7" rowspan="2">
-            <%= primary_subcon_info(document_info)&.content&.[]("subcon_name") %> <!-- 17-003 会社名(一次) -->
-          </td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s10" colspan="7" rowspan="2">代表者名</td>
-          <td class="s11" dir="ltr" colspan="7" rowspan="2">
-            <%= primary_subcon_info(document_info)&.content&.[]("subcon_representative_name") %> <!-- 17-004 代表者名(一次) -->
-          </td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s12"></td>
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s10" colspan="7" rowspan="2">建設業許可番号</td>
-          <td class="s13" dir="ltr" colspan="7" rowspan="2">
-            <!-- 17-005 建設業許可番号(短縮)(一次) ※未実装※ -->
-          </td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s15" rowspan="3"></td>
-          <td class="s10" colspan="7" rowspan="2">安全衛生責任者</td>
-          <td class="s13" dir="ltr" colspan="7" rowspan="2">
-            <%= primary_subcon_info(document_info)&.safety_manager_name %> <!-- 17-006 安全衛生責任者名(一次) -->
-          </td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s14"></td>
-          <td class="s10" colspan="7" rowspan="2">主任技術者</td>
-          <td class="s13" dir="ltr" colspan="7" rowspan="2">
-            <%= primary_subcon_info(document_info)&.lead_engineer_name %> <!-- 17-007 主任技術者名(一次) -->
-          </td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s16" colspan="7" rowspan="2">専門技術者</td>
-          <td class="s13" dir="ltr" colspan="7" rowspan="2">
-            <%= primary_subcon_info(document_info)&.professional_engineer_name %> <!-- 17-008 専門技術者名(一次) -->
-          </td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s17" rowspan="2"></td>
-          <td class="s10" colspan="6" rowspan="2">担当工事内容</td>
-          <td class="s13" dir="ltr" colspan="7" rowspan="2">
-            <%= primary_subcon_info(document_info)&.professional_engineer_details %> <!-- 17-009 担当工事内容(一次) -->
-          </td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s3"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s18" colspan="2" rowspan="2">工</td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s19"></td>
-          <td class="s17" colspan="7" rowspan="2">特定専門工事の有無</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(primary_subcon_info(document_info)&.professional_construction) %> <!-- 17-010 特定専門工事の有無(一次) -->
-          </td>
-          <td class="s21" dir="ltr" colspan="3" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(primary_subcon_info(document_info)&.professional_construction) %> <!-- 17-010 特定専門工事の有無(一次) -->
-          </td>
-          <td class="s12"></td>
-          <td class="s23"></td>
-          <td class="s23"></td>
-          <td class="s23"></td>
-          <td class="s23"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s19"></td>
-          <td class="s18" colspan="2" rowspan="2">事</td>
-          <td class="s12"></td>
-          <td class="s23"></td>
-          <td class="s23"></td>
-          <td class="s23"></td>
-          <td class="s23"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s12"></td>
-          <td class="s19"></td>
-          <td class="s10" colspan="7" rowspan="2">登録基幹技能者</td>
-          <td class="s11" dir="ltr" colspan="7" rowspan="2">
-            <%= primary_subcon_info(document_info)&.professional_engineer_details %> <!-- 17-011 登録基幹技能者(一次) -->
-          </td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s12"></td>
-          <td class="s14" colspan="4" rowspan="3"></td>
-          <td class="s19"></td>
-          <td class="s7" style="border-top: none; border-right: none;"></td>
-          <td class="s17" style="border-left: none;"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s6"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s12"></td>
-          <td class="s8"></td>
-          <td class="s17" colspan="3" rowspan="2">工期</td>
-          <td class="s24" dir="ltr" colspan="6" rowspan="2">
-            <%= document_date(primary_subcon_info(document_info)&.start_date) %> <!-- 17-012 各会社の工期(自)(一次) -->
-          </td>
-          <td class="s7" dir="ltr" rowspan="2">~</td>
-          <td class="s25" dir="ltr" colspan="6" rowspan="2">
-            <%= document_date(primary_subcon_info(document_info)&.end_date) %> <!-- 17-013 各会社の工期(至)(一次) -->
-          </td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s8"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s26"></td>
-          <td class="s27" colspan="2"></td>
-          <td class="s26"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s29"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s28"></td>
-          <td class="s30"></td>
-          <td class="s30"></td>
-          <td class="s30"></td>
-          <td class="s30"></td>
-          <td class="s30"></td>
-          <td class="s30"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s31"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s31"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s3"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s32"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-          <td class="s1"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s7" colspan="12">（二次下請負業者）</td>
-          <td class="s33"></td>
-          <td class="s7" colspan="12">（二次下請負業者）</td>
-          <td class="s33"></td>
-          <td class="s7" colspan="12">（二次下請負業者）</td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s9" dir="ltr" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s11" dir="ltr" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s34" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s34" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(二次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s11" dir="ltr" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 2)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(二次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s13" dir="ltr" colspan="6" rowspan="2">
-            <!-- 17-017-1 建設業許可番号(短縮)(二次) ※未実装※ -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <!-- 17-017-2 建設業許可番号(短縮)(二次) ※未実装※ -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <!-- 17-017-3 建設業許可番号(短縮)(二次) ※未実装※ -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s13" dir="ltr" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(二次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s13" dir="ltr" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 2)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(二次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s13" dir="ltr" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 2)&.professional_engineer_name %> <!-- 17-020-3 専門技術者名(二次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none;"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s13" dir="ltr" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none;"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none;"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= secondary_subcon_info(document_info, 2)&.professional_engineer_details %> <!-- 17-021-3 担当工事内容(二次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18">工</td>
-          <td class="s16"></td>
-          <td class="s18">工</td>
-          <td class="s16"></td>
-          <td class="s18">工</td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(secondary_subcon_info(document_info, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(二次) -->
-          </td>
-          <td class="s21" dir="ltr" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(secondary_subcon_info(document_info, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(secondary_subcon_info(document_info, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(二次) -->
-          </td>
-          <td class="s7" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(secondary_subcon_info(document_info, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(secondary_subcon_info(document_info, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(二次) -->
-          </td>
-          <td class="s7" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(secondary_subcon_info(document_info, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(二次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s17"></td>
-          <td class="s16"></td>
-          <td class="s17"></td>
-          <td class="s16"></td>
-          <td class="s17"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s24" dir="ltr" colspan="4" rowspan="2">
-            <%= document_date(secondary_subcon_info(document_info, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(二次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s25" dir="ltr" colspan="4" rowspan="2">
-            <%= document_date(secondary_subcon_info(document_info, 0)&.end_date) %> <!-- 17-024-1 各会社の工期(自)(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s36" colspan="4" rowspan="2">
-            <%= document_date(secondary_subcon_info(document_info, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(二次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s37" colspan="4" rowspan="2">
-            <%= document_date(secondary_subcon_info(document_info, 1)&.end_date) %> <!-- 17-024-2 各会社の工期(自)(二次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s36" colspan="4" rowspan="2">
-            <%= document_date(secondary_subcon_info(document_info, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(二次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s37" colspan="4" rowspan="2">
-            <%= document_date(secondary_subcon_info(document_info, 2)&.end_date) %> <!-- 17-024-3 各会社の工期(自)(二次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s38"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s40"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s41"></td>
-          <td class="s41"></td>
-          <td class="s41"></td>
-          <td class="s41"></td>
-          <td class="s41"></td>
-          <td class="s42"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s38"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s38"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s44"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s7" colspan="12">（三次下請負業者）</td>
-          <td class="s33"></td>
-          <td class="s7" colspan="12">（三次下請負業者）</td>
-          <td class="s33"></td>
-          <td class="s7" colspan="12">（三次下請負業者）</td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s34" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s34" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s34" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 2)&.content&.[]("subcon_representative_name") %> <!-- 17-016-3 代表者名(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <!-- 17-017-1 建設業許可番号(短縮)(三次) ※未実装※ -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <!-- 17-017-2 建設業許可番号(短縮)(三次) ※未実装※ -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <!-- 17-017-3 建設業許可番号(短縮)(三次) ※未実装※ -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 2)&.lead_engineer_name %> <!-- 17-019-3 主任技術者名(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 2)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 2, 2)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18">工</td>
-          <td class="s16"></td>
-          <td class="s18">工</td>
-          <td class="s16"></td>
-          <td class="s18">工</td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(三次) -->
-          </td>
-          <td class="s7" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(三次) -->
-          </td>
-          <td class="s7" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(hierarchy_subcon_info(document_info, 2, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(三次) -->
-          </td>
-          <td class="s7" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(hierarchy_subcon_info(document_info, 2, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s17"></td>
-          <td class="s16"></td>
-          <td class="s17"></td>
-          <td class="s16"></td>
-          <td class="s17"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s36" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 2, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(三次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s37" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 2, 0)&.end_date) %> <!-- 17-023-1 各会社の工期(自)(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s36" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 2, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(三次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s37" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 2, 1)&.end_date) %> <!-- 17-023-2 各会社の工期(自)(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s36" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 2, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(三次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s37" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 2, 2)&.end_date) %> <!-- 17-023-3 各会社の工期(自)(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s38"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s40"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s39"></td>
-          <td class="s41"></td>
-          <td class="s41"></td>
-          <td class="s41"></td>
-          <td class="s41"></td>
-          <td class="s41"></td>
-          <td class="s42"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s38"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s38"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s44"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s7" colspan="12">（四次下請負業者）</td>
-          <td class="s33"></td>
-          <td class="s7" colspan="12">（四次下請負業者）</td>
-          <td class="s33"></td>
-          <td class="s7" colspan="12">（四次下請負業者）</td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s34" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 0)&.content&.[]("subcon_name") %> <!-- 17-015-1 会社名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s34" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 1)&.content&.[]("subcon_name") %> <!-- 17-015-2 会社名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s34" rowspan="12"></td>
-          <td class="s10" colspan="5" rowspan="2">会社名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 2)&.content&.[]("subcon_name") %> <!-- 17-015-3 会社名(四次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 0)&.content&.[]("subcon_representative_name") %> <!-- 17-016-1 代表者名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 1)&.content&.[]("subcon_representative_name") %> <!-- 17-016-2 代表者名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">代表者名</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 2)&.content&.[]("subcon_representative_name") %> <!-- 17-016-3 代表者名(四次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <!-- 17-017-1 建設業許可番号(短縮)(四次) ※未実装※ -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <!-- 17-017-2 建設業許可番号(短縮)(四次) ※未実装※ -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">建設業許可番号</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <!-- 17-017-3 建設業許可番号(短縮)(四次) ※未実装※ -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 0)&.safety_manager_name %> <!-- 17-018-1 安全衛生責任者名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 1)&.safety_manager_name %> <!-- 17-018-2 安全衛生責任者名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">安全衛生責任者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 2)&.safety_manager_name %> <!-- 17-018-3 安全衛生責任者名(四次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 0)&.lead_engineer_name %> <!-- 17-019-1 主任技術者名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 1)&.lead_engineer_name %> <!-- 17-019-2 主任技術者名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s10" colspan="5" rowspan="2">主任技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 2)&.lead_engineer_name %> <!-- 17-019-3 主任技術者名(四次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 0)&.professional_engineer_name %> <!-- 17-020-1 専門技術者名(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 1)&.professional_engineer_name %> <!-- 17-020-2 専門技術者名(三次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s16" colspan="5" rowspan="2">専門技術者</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 2)&.professional_engineer_name %> <!-- 17-020-3 専門技術者名(三次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none;"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 0)&.professional_engineer_details %> <!-- 17-021-1 担当工事内容(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none;"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 1)&.professional_engineer_details %> <!-- 17-021-2 担当工事内容(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18"></td>
-          <td class="s10" rowspan="2" style="border-top: none;"></td>
-          <td class="s17" colspan="4" rowspan="2" style="border-top: 1px solid #000000;">担当工事内容</td>
-          <td class="s35" colspan="6" rowspan="2">
-            <%= hierarchy_subcon_info(document_info, 3, 2)&.professional_engineer_details %> <!-- 17-021-3 担当工事内容(四次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18">工</td>
-          <td class="s16"></td>
-          <td class="s18">工</td>
-          <td class="s16"></td>
-          <td class="s18">工</td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(四次) -->
-          </td>
-          <td class="s7" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 0)&.professional_construction) %> <!-- 17-022-1 特定専門工事の有無(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(四次) -->
-          </td>
-          <td class="s7" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 1)&.professional_construction) %> <!-- 17-022-2 特定専門工事の有無(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s18">事</td>
-          <td class="s17" colspan="5" rowspan="2">特定専門工事の該当</td>
-          <td class="s20" colspan="2" rowspan="2">
-            <%= professional_construction_yes(hierarchy_subcon_info(document_info, 3, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(四次) -->
-          </td>
-          <td class="s7" colspan="2" rowspan="2">・</td>
-          <td class="s22" colspan="2" rowspan="2">
-            <%= professional_construction_no(hierarchy_subcon_info(document_info, 3, 2)&.professional_construction) %> <!-- 17-022-3 特定専門工事の有無(四次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s17"></td>
-          <td class="s16"></td>
-          <td class="s17"></td>
-          <td class="s16"></td>
-          <td class="s17"></td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s36" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 3, 0)&.start_date) %> <!-- 17-023-1 各会社の工期(自)(四次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s37" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 3, 0)&.end_date) %> <!-- 17-023-1 各会社の工期(自)(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s36" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 3, 1)&.start_date) %> <!-- 17-023-2 各会社の工期(自)(四次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s37" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 3, 1)&.end_date) %> <!-- 17-023-2 各会社の工期(自)(四次) -->
-          </td>
-          <td class="s16"></td>
-          <td class="s17" colspan="2" rowspan="2">工期</td>
-          <td class="s36" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 3, 2)&.start_date) %> <!-- 17-023-3 各会社の工期(自)(四次) -->
-          </td>
-          <td class="s7" dir="ltr" colspan="2" rowspan="2">~</td>
-          <td class="s37" colspan="4" rowspan="2">
-            <%= document_date(hierarchy_subcon_info(document_info, 3, 2)&.end_date) %> <!-- 17-023-3 各会社の工期(自)(四次) -->
-          </td>
-        </tr>
-        <tr class="s45" style="height: 12px">
-          <td class="s16"></td>
-          <td class="s16"></td>
-        </tr>
-        <tr class="s45" style="height: 9px">
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-          <td class="s43"></td>
-        </tr>
-        <tr class="s45" style="height: 19px">
-          <td class="s33" colspan="4">（記入要領）</td>
-          <td class="s33">1</td>
-          <td class="s33" colspan="33">一次下請負業者は、二次下請負業者以下の業者から提出された「届出書」(様式第１号－甲) に基づいて本表を作成</td>
-        </tr>
-        <tr class="s45" style="height: 19px">
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33" colspan="33">の上、元請に届け出ること。</td>
-        </tr>
-        <tr class="s45" style="height: 19px">
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33">2</td>
-          <td class="s33" colspan="33">この下請負業者編成表でまとめきれない場合には、本様式をコピーするなどして適宜使用すること。</td>
-        </tr>
-        <tr class="s45" style="height: 19px">
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33"></td>
-          <td class="s33">3</td>
-          <td class="s33" colspan="33">二次下請負業者を使用しない場合は、この書類は提出不要。</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+  <% 25.times do |i| %>
+    <% if (instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}").present?) ||
+          (instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}").present?) ||
+          (instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}").present?) %>
+      <section class="doc_17_sheet" style="page-break-after: always">
+        <div class="ritz grid-container" dir="ltr" >
+          <table class="waffle" cellspacing="0" cellpadding="0">
+            <thead>
+              <tr class="doc_17_s45">
+                <th style="width:30px;">&nbsp;</th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:30px;"></th>
+                <th style="width:20px;"></th>
+                <th style="width:20px;"></th>
+                <th style="width:20px;"></th>
+                <th style="width:40px;"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="doc_17_s45" style="height: 4px;">
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s0"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"><%= "#{i+1}/#{@total_pages_17th+1}" %></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 14px;">
+                <td class="doc_17_s47" colspan="9" rowspan="2">全建統一様式第１号-乙</td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 14px;">
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1" dir="ltr" colspan="8">
+                  <%= doc_content_date(@document.content&.[]("date_submitted")) %> <!--17-001 提出日(西暦) -->
+                </td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 14px;">
+                <td class="doc_17_s50"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45">
+                <td class="doc_17_s48" colspan="9"></td>
+                <td colspan="29" style="border: none;"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 19px;">
+                <td class="doc_17_s5" colspan="38" rowspan="2">下請負業者編成表</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 19px">
+              </tr>
+              <tr class="doc_17_s45" style="height: 9px">
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 14px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s7" colspan="16" rowspan="2">（一次下請負業者＝作成下請負業者）</td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 14px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s9" dir="ltr" colspan="1" rowspan="12">
+                  <%= request_order_info(@primary_subcon_id_17th)&.construction_name %>
+                </td><!--17-002 工事名(一次)-->
+                <td class="doc_17_s10" colspan="7" rowspan="2">会社名</td>
+                <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                  <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_name") %>
+                </td><!--17-003 会社名(一次)-->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s10" colspan="7" rowspan="2">代表者名</td>
+                <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                  <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_representative_name") %>
+                </td><!--17-004 代表者名(一次)-->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s10" colspan="7" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                  <%= request_order_info(@primary_subcon_id_17th)&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-005 建設業許可番号(短縮)(一次) -->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s15" rowspan="3"></td>
+                <td class="doc_17_s10" colspan="7" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                  <%= request_order_info(@primary_subcon_id_17th)&.safety_manager_name %>
+                </td><!--17-006 安全衛生責任者名(一次) -->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s14"></td>
+                <td class="doc_17_s10" colspan="7" rowspan="2">主任技術者</td>
+                <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                  <%= request_order_info(@primary_subcon_id_17th)&.lead_engineer_name %>
+                </td><!--17-007 主任技術者名(一次) -->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s16" colspan="7" rowspan="2">専門技術者</td>
+                <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                  <%= request_order_info(@primary_subcon_id_17th)&.professional_engineer_name %>
+                </td><!--17-008 専門技術者名(一次)-->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s10" colspan="6" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s13" dir="ltr" colspan="8" rowspan="2">
+                  <%= request_order_info(@primary_subcon_id_17th)&.professional_engineer_details %>
+                </td><!--17-009 担当工事内容(一次)-->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s18" colspan="1" rowspan="2">工</td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s19"></td>
+                <td class="doc_17_s17" colspan="7" rowspan="2">特定専門工事の有無</td>
+                <td class="doc_17_s20" colspan="3" rowspan="2">
+                  <%= professional_construction_yes(request_order_info(@primary_subcon_id_17th)&.professional_construction) %>
+                </td><!--17-010 特定専門工事の有無(一次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="3" rowspan="2">
+                  <%= professional_construction_no(request_order_info(@primary_subcon_id_17th)&.professional_construction) %>
+                </td><!--17-010 特定専門工事の有無(一次)-->
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s23"></td>
+                <td class="doc_17_s23"></td>
+                <td class="doc_17_s23"></td>
+                <td class="doc_17_s23"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s19"></td>
+                <td class="doc_17_s18" colspan="1" rowspan="2">事</td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s23"></td>
+                <td class="doc_17_s23"></td>
+                <td class="doc_17_s23"></td>
+                <td class="doc_17_s23"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s19"></td>
+                <td class="doc_17_s10" colspan="7" rowspan="2">登録基幹技能者</td>
+                <td class="doc_17_s11" dir="ltr" colspan="8" rowspan="2">
+                  <%= request_order_info(@primary_subcon_id_17th)&.registered_core_engineer_name %>
+                </td><!--17-011 登録基幹技能者(一次)-->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s14" colspan="4" rowspan="3"></td>
+                <td class="doc_17_s19"></td>
+                <td class="doc_17_s7" style="border-top: none; border-right: none;"></td> <!-- s7 -->
+                <!--<td class="doc_17_s17" style="border-top: none; border-left: none;"></td>--> <!-- s17 -->
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s6"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s12"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s17" colspan="3" rowspan="2">工期</td>
+                <td class="doc_17_s24" dir="ltr" colspan="6" rowspan="2">
+                  <%= document_date(request_order_info(@primary_subcon_id_17th)&.start_date) %>
+                </td><!--17-012 各会社の工期(自)(一次)-->
+                <td class="doc_17_s51" dir="ltr" rowspan="2">~</td>
+                <td class="doc_17_s25" dir="ltr" colspan="6" rowspan="2">
+                  <%= document_date(request_order_info(@primary_subcon_id_17th)&.end_date) %>
+                </td><!--17-013 各会社の工期(至)(一次)-->
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s8"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s26"></td>
+                <td class="doc_17_s27" colspan="2"></td>
+                <td class="doc_17_s26"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s29"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s28"></td>
+                <td class="doc_17_s30"></td>
+                <td class="doc_17_s30"></td>
+                <td class="doc_17_s30"></td>
+                <td class="doc_17_s30"></td>
+                <td class="doc_17_s30"></td>
+                <td class="doc_17_s30"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s31"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s31"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s3"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s32"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+                <td class="doc_17_s1"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s7" colspan="12">（二次下請負業者）</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s9" dir="ltr" rowspan="12">
+                  <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
+                  <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-1 会社名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s9" rowspan="12">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-2 会社名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s9" rowspan="12">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-3 会社名(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s11" dir="ltr" colspan="6" rowspan="2">
+                  <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-1 代表者名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-2 代表者名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-3 代表者名(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                  <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-1 建設業許可番号(短縮)(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-2 建設業許可番号(短縮)(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-3 建設業許可番号(短縮)(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                  <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-1 安全衛生責任者名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-2 安全衛生責任者名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-3 安全衛生責任者名(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                  <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-1 主任技術者名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-2 主任技術者名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-2 主任技術者名(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                  <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-1 専門技術者名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-2 専門技術者名(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-3 専門技術者名(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s13" dir="ltr" colspan="6" rowspan="2">
+                  <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-1 担当工事内容(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-2 担当工事内容(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-3 担当工事内容(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18">工</td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">工</td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">工</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-1 特定専門工事の有無(二次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-1 特定専門工事の有無(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-2 特定専門工事の有無(二次)-->
+                <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-2 特定専門工事の有無(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-3 特定専門工事の有無(二次)-->
+                <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-3 特定専門工事の有無(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s17" style="border-top: none;"></td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" style="border-top: none;"></td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" style="border-top: none;"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s24" dir="ltr" colspan="4" rowspan="2">
+                  <%= document_date(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                </td><!--17-023-1 各会社の工期(自)(二次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s25" dir="ltr" colspan="4" rowspan="2">
+                  <%= document_date(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                </td><!--17-024-1 各会社の工期(自)(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s36" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                </td><!--17-023-2 各会社の工期(自)(二次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s37" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                </td><!--17-024-2 各会社の工期(自)(二次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s36" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                </td><!--17-023-3 各会社の工期(自)(二次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s37" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@secondary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                </td><!--17-024-3 各会社の工期(自)(二次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s38"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s40"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s42"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s38"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s38"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s44"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s7" colspan="12">（三次下請負業者）</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s9" rowspan="12">
+                  <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-1 会社名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s9" rowspan="12">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-2 会社名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s9" rowspan="12">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-3 会社名(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-1 代表者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-2 代表者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-3 代表者名(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-1 建設業許可番号(短縮)(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-2 建設業許可番号(短縮)(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-3 建設業許可番号(短縮)(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-1 安全衛生責任者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-2 安全衛生責任者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-3 安全衛生責任者名(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-1 主任技術者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-2 主任技術者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-3 主任技術者名(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-1 専門技術者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-2 専門技術者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-3 専門技術者名(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-1 担当工事内容(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-2 担当工事内容(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-3 担当工事内容(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18">工</td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">工</td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">工</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-1 特定専門工事の有無(三次)-->
+                <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-1 特定専門工事の有無(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-2 特定専門工事の有無(三次)-->
+                <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-2 特定専門工事の有無(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-3 特定専門工事の有無(三次)-->
+                <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-3 特定専門工事の有無(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s17" style="border-top: none;"></td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" style="border-top: none;"></td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" style="border-top: none;"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s36" colspan="4" rowspan="2">
+                  <%= document_date(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                </td><!--17-023-1 各会社の工期(自)(三次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s37" colspan="4" rowspan="2">
+                  <%= document_date(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_17th_#{1+3*(i)}"),instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                </td><!--17-023-1 各会社の工期(自)(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s36" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                </td><!--17-023-2 各会社の工期(自)(三次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s37" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                </td><!--17-023-2 各会社の工期(自)(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s36" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                </td><!--17-023-3 各会社の工期(自)(三次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s37" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@tertiary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                </td><!--17-023-3 各会社の工期(自)(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s38"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s40"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s39"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s41"></td>
+                <td class="doc_17_s42"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s38"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s38"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s44"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s7" colspan="12">（四次下請負業者）</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s9" rowspan="12">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-1 会社名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s9" rowspan="12">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-2 会社名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s9" rowspan="12">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.construction_name %>
+                </td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">会社名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_name") %>
+                </td><!--17-015-3 会社名(四次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-1 代表者名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-2 代表者名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">代表者名</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_representative_name") %>
+                </td><!--17-016-3 代表者名(四次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-1 建設業許可番号(短縮)(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-2 建設業許可番号(短縮)(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">建設業許可番号</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.content&.[]("subcon_construction_license_number") %>
+                </td><!--17-017-3 建設業許可番号(短縮)(四次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-1 安全衛生責任者名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-2 安全衛生責任者名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">安全衛生責任者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.safety_manager_name %>
+                </td><!--17-018-3 安全衛生責任者名(四次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-1 主任技術者名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-2 主任技術者名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s10" colspan="5" rowspan="2">主任技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.lead_engineer_name %>
+                </td><!--17-019-3 主任技術者名(四次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-1 専門技術者名(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-2 専門技術者名(三次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16" colspan="5" rowspan="2">専門技術者</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_name %>
+                </td><!--17-020-3 専門技術者名(三次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-1 担当工事内容(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-2 担当工事内容(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18"></td>
+                <td class="doc_17_s49" rowspan="2"></td>
+                <td class="doc_17_s17" colspan="4" rowspan="2">担当工事内容</td>
+                <td class="doc_17_s35" colspan="6" rowspan="2">
+                  <%= request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_engineer_details %>
+                </td><!--17-021-3 担当工事内容(四次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18">工</td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">工</td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">工</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-1 特定専門工事の有無(四次)-->
+                <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-1 特定専門工事の有無(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-2 特定専門工事の有無(四次)-->
+                <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-2 特定専門工事の有無(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s18">事</td>
+                <td class="doc_17_s17" colspan="5" rowspan="2">特定専門工事の該当</td>
+                <td class="doc_17_s20" colspan="2" rowspan="2">
+                  <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-3 特定専門工事の有無(四次)-->
+                <td class="doc_17_s51" colspan="2" rowspan="2">・</td>
+                <td class="doc_17_s22" colspan="2" rowspan="2">
+                  <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.professional_construction) %>
+                </td><!--17-022-3 特定専門工事の有無(四次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s17" style="border-top: none;"></td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" style="border-top: none;"></td>
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" style="border-top: none;"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s36" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.start_date) %>
+                </td><!--17-023-1 各会社の工期(自)(四次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s37" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{1+3*(i)}"))&.end_date) %>
+                </td><!--17-023-1 各会社の工期(自)(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s36" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.start_date) %>
+                </td><!--17-023-2 各会社の工期(自)(四次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s37" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{2+3*(i)}"))&.end_date) %>
+                </td><!--17-023-2 各会社の工期(自)(四次)-->
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s17" colspan="2" rowspan="2">工期</td>
+                <td class="doc_17_s36" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.start_date) %>
+                </td><!--17-023-3 各会社の工期(自)(四次)-->
+                <td class="doc_17_s51" dir="ltr" colspan="2" rowspan="2">~</td>
+                <td class="doc_17_s37" colspan="4" rowspan="2">
+                  <%= document_date(request_order_info(instance_variable_get("@quaternary_subcon_id_17th_#{3+3*(i)}"))&.end_date) %>
+                </td><!--17-023-3 各会社の工期(自)(四次)-->
+              </tr>
+              <tr class="doc_17_s45" style="height: 12px">
+                <td class="doc_17_s16"></td>
+                <td class="doc_17_s16"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 9px">
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+                <td class="doc_17_s43"></td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 19px">
+                <td class="doc_17_s33" colspan="4">（記入要領）</td>
+                <td class="doc_17_s33">1</td>
+                <td class="doc_17_s33" colspan="33">一次下請負業者は、二次下請負業者以下の業者から提出された「届出書」(様式第１号-甲) に基づいて本表を作成</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 19px">
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33" colspan="33">の上、元請に届け出ること。</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 19px">
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33">2</td>
+                <td class="doc_17_s33" colspan="33">この下請負業者編成表でまとめきれない場合には、本様式をコピーするなどして適宜使用すること。</td>
+              </tr>
+              <tr class="doc_17_s45" style="height: 19px">
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33"></td>
+                <td class="doc_17_s33">3</td>
+                <td class="doc_17_s33" colspan="33">二次下請負業者を使用しない場合は、この書類は提出不要。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    <% end %>
+  <% end %>
 </body>
 
 <style>
-  .ritz .waffle a {
-    color: inherit;
-  }
+.ritz .waffle a {
+  color: inherit;
+}
 
-  .ritz .waffle .s32 {
-    border-top: none;
-    border-right: none;
-    border-left: none;
-    border-right: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: bottom;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s32 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-right: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: bottom;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s2 {
-    border-top: none;
-    border-bottom: none;
-    border-left: none;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s2 {
+  border-top: none;
+  border-bottom: none;
+  border-left: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s16 {
-    border-top: none;
-    border-bottom: none;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s16 {
+  border-top: none;
+  border-bottom: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s8 {
-    border-top: none;
-    border-left: none;
-    border-right: 1px SOLID #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s8 {
+  border-top: none;
+  border-left: none;
+  border-right: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s17 {
-    border-top: none;
-    border-right: 1px SOLID #000000;
-    border-bottom: 1px SOLID #000000;
-    border-left: 1px SOLID #000000;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s17 {
+  border-top: 1px SOLID #000000;
+  border-right: 1px SOLID #000000;
+  border-bottom: 1px SOLID #000000;
+  border-left: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s7 {
-    border: 1px SOLID #000000;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s7 {
+  border: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s41 {
-    border-top: none;
-    border-right: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: bottom;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s51 {
+  border-top: 1px SOLID #000000;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s3 {
-    border: none;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s41 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: bottom;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s6 {
-    border: none;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s3 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s24 {
-    border-top: none;
-    border-bottom: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: normal;
-    overflow: hidden;
-    word-wrap: break-word;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s50 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #e60033;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: top;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s30 {
-    border-top: none;
-    border-right: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: bottom;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s6 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s35 {
-    border-top: none;
-    border-bottom: 1px SOLID #000000;
-    border-right: 1px SOLID #000000;
-    border-left: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: left;
-    color: #000000;
-    font-family: 'docs-Calibri', Arial;
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s24 {
+  border-top: none;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s11 {
-    border: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: left;
-    color: #000000;
-    font-family: 'docs-Calibri', Arial;
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s30 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: bottom;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s14 {
-    border: none;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 14pt;
-    vertical-align: middle;
-    white-space: normal;
-    overflow: hidden;
-    word-wrap: break-word;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s35 {
+  border-top: none;
+  border-bottom: 1px SOLID #000000;
+  border-right: 1px SOLID #000000;
+  border-left: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s22 {
-    border-right: 1px SOLID #000000;
-    border-bottom: none;
-    background-color: #ccffcc;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s11 {
+  border: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s33 {
-    border: none;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s14 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 14pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s20 {
-    border: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s22 {
+  border-right: 1px SOLID #000000;
+  border-bottom: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s21 {
-    border: 1px SOLID #000000;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: normal;
-    overflow: hidden;
-    word-wrap: break-word;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s33 {
+  border: none;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s5 {
-    border: none;
-    background-color: #ffffff;
-    text-align: center;
-    font-weight: bold;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 24pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s20 {
+  border-top: 1px SOLID #000000;
+  border-right: none;
+  border-left: 1px SOLID #000000;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s13 {
-    border: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: left;
-    color: #000000;
-    font-family: 'docs-Calibri', Arial;
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: normal;
-    overflow: hidden;
-    word-wrap: break-word;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s21 {
+  border: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s34 {
-    border: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: center;
-    color: #0000ff;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s5 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  font-weight: bold;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 24pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s23 {
-    border: none;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: normal;
-    overflow: hidden;
-    word-wrap: break-word;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s13 {
+  border: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s1 {
-    border: none;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: bottom;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s34 {
+  border: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #0000ff;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s39 {
-    border-top: none;
-    border-right: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s23 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s40 {
-    border-top: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    border-right: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s1 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: bottom;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s43 {
-    border: none;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: bottom;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s39 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s29 {
-    border-top: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    border-right: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s40 {
+  border-top: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  border-right: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s10 {
-    border: 1px SOLID #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s43 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: bottom;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s28 {
-    border-right: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s29 {
+  border-top: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  border-right: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s36 {
-    border-bottom: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: center;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s10 {
+  border: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s27 {
-    border-top: none;
-    border-right: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 14pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s28 {
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s18 {
-    border-top: none;
-    border-bottom: none;
-    border-right: 1px SOLID #000000;
-    border-left: 1px SOLID #000000;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s36 {
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s26 {
-    border-top: none;
-    border-right: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 14pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s27 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 14pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s38 {
-    border-top: none;
-    border-left: none;
-    border-bottom: none;
-    border-right: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s18 {
+  border-top: none;
+  border-bottom: none;
+  border-right: 1px SOLID #000000;
+  border-left: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s9 {
-    border: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: center;
-    color: #000000;
-    font-family: 'docs-Calibri', Arial;
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: normal;
-    overflow: hidden;
-    word-wrap: break-word;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s26 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 14pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s12 {
-    border: none;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'docs-Calibri', Arial;
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s38 {
+  border-top: none;
+  border-left: none;
+  border-bottom: none;
+  border-right: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s19 {
-    border-top: none;
-    border-bottom: none;
-    border-left: none;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s9 {
+  border: 1px SOLID #000000;
+  border-bottom: 1px SOLID #ffffff;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  writing-mode: vertical-lr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s42 {
-    border-top: none;
-    border-left: none;
-    border-bottom: 1px DOTTED #000000;
-    border-right: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: bottom;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s12 {
+  border: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s0 {
-    border-top: none;
-    border-right: none;
-    border-left: none;
-    border-bottom: 1px SOLID #000000;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s19 {
+  border-top: none;
+  border-bottom: none;
+  border-left: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s31 {
-    border-top: none;
-    border-bottom: none;
-    border-left: none;
-    border-right: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s42 {
+  border-top: none;
+  border-left: none;
+  border-bottom: 1px DOTTED #000000;
+  border-right: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: bottom;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s4 {
-    border: none;
-    background-color: #ccffcc;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s0 {
+  border-top: none;
+  border-right: none;
+  border-left: none;
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s25 {
-    border-bottom: 1px SOLID #000000;
-    border-right: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: normal;
-    overflow: hidden;
-    word-wrap: break-word;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s31 {
+  border-top: none;
+  border-bottom: none;
+  border-left: none;
+  border-right: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s37 {
-    border-bottom: 1px SOLID #000000;
-    border-right: 1px SOLID #000000;
-    background-color: #ccffcc;
-    text-align: center;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s4 {
+  border: none;
+  background-color: #ccffcc;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s15 {
-    border: none;
-    border-bottom: none;
-    border-left: none;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 14pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s25 {
+  border-top: 1px SOLID #000000;
+  border-bottom: 1px SOLID #000000;
+  border-right: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s44 {
-    border-top: none;
-    border-left: none;
-    border-bottom: none;
-    border-right: 1px DOTTED #000000;
-    background-color: #ffffff;
-    text-align: left;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 10pt;
-    vertical-align: bottom;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s37 {
+  border-top: 1px SOLID #000000;
+  border-bottom: 1px SOLID #000000;
+  border-right: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s45 {
-    border: 0px solid #ffffff;
-    background-color: #ffffff;
-  }
+.ritz .waffle .doc_17_s15 {
+  border: none;
+  border-bottom: none;
+  border-left: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 14pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s46 {
-    border: none;
-    background-color: #ffffff;
-  }
+.ritz .waffle .doc_17_s44 {
+  border-top: none;
+  border-left: none;
+  border-bottom: none;
+  border-right: 1px DOTTED #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 9pt;
+  vertical-align: bottom;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .ritz .waffle .s47 {
-    border-right: 1px solid #000000;
-    border-bottom: 1px solid #000000;
-    border-left: 1px solid #000000;
-    background-color: #ffffff;
-    text-align: center;
-    color: #000000;
-    font-family: 'Arial';
-    font-size: 11pt;
-    vertical-align: middle;
-    white-space: nowrap;
-    direction: ltr;
-    padding: 0px 3px 0px 3px;
-  }
+.ritz .waffle .doc_17_s45 {
+  border: 0px solid #ffffff;
+  background-color: #ffffff;
+}
 
-  .s48 {
-    border: none  ;
-    background-color: #ffffff;
-  }
+.ritz .waffle .doc_17_s46 {
+  border: none;
+  background-color: #ffffff;
+}
 
-  .circle {
-    border: 2px solid #000000;
-    border-radius: 25px;
-    padding: 4px;
-  }
+.ritz .waffle .doc_17_s47 {
+  border-right: 1px solid #000000;
+  border-bottom: 1px solid #000000;
+  border-left: 1px solid #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
 
-  .doc_17_sheet {
-    width: 250mm;
-    height: 297mm;
-    margin-bottom: 100px;
-    size: A4;
-  }
+.doc_17_s48 {
+  border: none  ;
+  background-color: #ffffff;
+}
+
+.doc_17_s49 {
+  border: none;
+  background-color: #ffffff;
+}
+
+.circle {
+  border: 2px solid #000000;
+  border-radius: 25px;
+  padding: 4px;
+}
+
+.doc_17_sheet {
+  width: 250mm;
+  height: 320mm;
+  margin-bottom: 100px;
+  size: A4;
+}
+
 </style>

--- a/app/views/users/documents/doc_18th/_show.html.erb
+++ b/app/views/users/documents/doc_18th/_show.html.erb
@@ -876,40 +876,40 @@
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s14"></td>
                   <td class="doc_18_s18"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s14"></td>
                   <td class="doc_18_s18"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                   </td>
@@ -1575,40 +1575,40 @@
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                   </td>
@@ -2391,40 +2391,40 @@
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                   </td>
@@ -3207,40 +3207,40 @@
                   <td class="doc_18_s34"></td>
                   <td class="doc_18_s50"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                  <td class="doc_18_s17" dir="ltr" colspan="3">
+                  <td class="doc_18_s54" dir="ltr" colspan="3">
                     <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                   </td>
-                  <td class="doc_18_s21" dir="ltr" colspan="3">・</td>
+                  <td class="doc_18_s53" dir="ltr" colspan="3">・</td>
                   <td class="doc_18_s17" dir="ltr" colspan="3">
                     <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                   </td>

--- a/app/views/users/documents/doc_18th/_show.pdf.erb
+++ b/app/views/users/documents/doc_18th/_show.pdf.erb
@@ -228,7 +228,7 @@
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s4">
-                      <%= "#{i+1}/#{@total_pages+1}" %>
+                      <%= "#{i+1}/#{@total_pages_18th+1}" %>
                     </td>
                   </tr>
                   <tr class="doc_18_s51">
@@ -883,40 +883,40 @@
                     <td class="doc_18_s2"></td>
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" colspan="3">
+                    <td class="doc_18_s54" colspan="3">
                       <%= professional_construction_yes(provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" colspan="5">・</td>
+                    <td class="doc_18_s53" colspan="5">・</td>
                     <td class="doc_18_s17" colspan="3">
                       <%= professional_construction_no(provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s2"></td>
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s14"></td>
                     <td class="doc_18_s18"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s14"></td>
                     <td class="doc_18_s18"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.professional_construction) %>
                     </td>
@@ -1583,40 +1583,40 @@
                     <td class="doc_18_s2"></td>
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" colspan="3">
+                    <td class="doc_18_s54" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" colspan="5">・</td>
+                    <td class="doc_18_s53" colspan="5">・</td>
                     <td class="doc_18_s17" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.professional_construction) %>
                     </td>
@@ -2400,40 +2400,40 @@
                     <td class="doc_18_s2"></td>
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" colspan="3">
+                    <td class="doc_18_s54" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" colspan="5">・</td>
+                    <td class="doc_18_s53" colspan="5">・</td>
                     <td class="doc_18_s17" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.professional_construction) %>
                     </td>
@@ -3217,40 +3217,40 @@
                     <td class="doc_18_s34"></td>
                     <td class="doc_18_s50"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" colspan="3">
+                    <td class="doc_18_s54" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" colspan="5">・</td>
+                    <td class="doc_18_s53" colspan="5">・</td>
                     <td class="doc_18_s17" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s25" colspan="6">指定専門工事該当の有無</td>
-                    <td class="doc_18_s17" dir="ltr" colspan="3">
+                    <td class="doc_18_s54" dir="ltr" colspan="3">
                       <%= professional_construction_yes(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                     </td>
-                    <td class="doc_18_s21" dir="ltr" colspan="4">・</td>
+                    <td class="doc_18_s53" dir="ltr" colspan="4">・</td>
                     <td class="doc_18_s17" dir="ltr" colspan="3">
                       <%= professional_construction_no(request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.professional_construction) %>
                     </td>
@@ -3775,6 +3775,21 @@
   padding: 0px 3px 0px 3px;
 }
 
+.ritz .waffle .doc_18_s54 {
+  border-bottom: 1px SOLID #000000;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'docs-Calibri', Arial;
+  font-size: 14pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
 .ritz .waffle .doc_18_s29 {
   border-bottom: 1px DASHED #000000;
   border-right: 1px SOLID #000000;
@@ -3784,6 +3799,24 @@
   font-size: 14pt;
   vertical-align: top;
   white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_18_s53 {
+  border-top: 1px SOLID #000000;
+  border-right: none;
+  border-bottom: 1px SOLID #000000;
+  border-left: none;
+  background-color: #ffffff;
+  text-align: center;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 11pt;
+  vertical-align: middle;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
   direction: ltr;
   padding: 0px 3px 0px 3px;
 }


### PR DESCRIPTION
### 概要
⑰下請負業者編成表の値反映
⑱工事作業所災害防止協議会兼施工体系図のロジックおよびレイアウト修正
サイドメニューの修正

### タスク
- [] なし
- [x] あり [タスクのリンクがあれば貼る](https://trello.com/c/WjqdfAec/317-%E6%9B%B8%E9%A1%9E%E3%83%87%E3%83%BC%E3%82%BF%E5%8F%8D%E6%98%A0%E3%80%9017%E4%B8%8B%E8%AB%8B%E8%B2%A0%E6%A5%AD%E8%80%85%E7%B7%A8%E6%88%90%E8%A1%A8%E3%80%91)

### 実装内容・手法
⑰下請負業者編成表のロジック作成
⑰下請負業者編成表のshow画面、edit画面、pdf画面の値当てはめおよびレイアウト等の修正
⑱工事作業所災害防止協議会兼施工体系図のロジックの修正(pdfのページ番号割り振り)
⑱工事作業所災害防止協議会兼施工体系図のレイアウトの修正(指定専門工事該当の有無にあった線の削除)
サイドメニューの修正(協力会社情報および特殊車両情報の位置修正)

### 実装画像などあれば添付する
⑰下請負業者編成表のshow画面
<img width="870" alt="show画面_1" src="https://user-images.githubusercontent.com/77228994/224207873-11ff82fd-341b-4199-bd97-989d57a9758d.png">
<img width="829" alt="show画面_2" src="https://user-images.githubusercontent.com/77228994/224207959-2a5415ed-2b13-4d82-b154-9d15195b02bf.png">
⑰下請負業者編成表のedit画面
<img width="821" alt="edit画面_1" src="https://user-images.githubusercontent.com/77228994/224208043-2c729385-5468-49fb-b7c4-a4920a53585a.png">
<img width="826" alt="edit画面_2" src="https://user-images.githubusercontent.com/77228994/224208073-b5652812-c51b-4a2b-bde9-f2243ef284cd.png">
⑰下請負業者編成表のpdf画面
[PDF画面_17_20230309.pdf](https://github.com/kensuma-1122/kensuma/files/10937942/PDF._17_20230309.pdf)

⑱工事作業所災害防止協議会兼施工体系図のshow画面
<img width="1124" alt="show画面_18_20230310" src="https://user-images.githubusercontent.com/77228994/224209204-02b61f2d-c0a0-49c5-9397-fe382a362319.png">

サイドメニュー画面
<img width="191" alt="サイドメニュー_20230310" src="https://user-images.githubusercontent.com/77228994/224209441-004fc4c9-0f50-4962-8f4a-4c26d70eadd3.png">