### PR TITLE
作業員情報のフォームの有無によるバリデーションの実装（奥野）

### DIFF
--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -194,7 +194,7 @@ module Users
 
     # 健康保険が健康保険組合もしくは建設国保でなければ保険名をnilにする
     def health_insurance_name_nil(health_insurance_type, worker)
-      unless health_insurance_type == :health_insurance_association || health_insurance_type == :construction_national_health_insurance
+      unless %w[health_insurance_association construction_national_health_insurance].include?(health_insurance_type)
         worker.update(health_insurance_name: nil)
       end
     end

--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -192,19 +192,17 @@ module Users
       @worker = current_business.workers.find_by(uuid: params[:uuid])
     end
 
-    # 健康保険が健康保険組合もしくは建設国保であれば保険名をnilにする
+    # 健康保険が健康保険組合もしくは建設国保でなければ保険名をnilにする
     def health_insurance_name_nil(health_insurance_type, worker)
       unless health_insurance_type == :health_insurance_association || health_insurance_type == :construction_national_health_insurance
         worker.update(health_insurance_name: nil)
-        byebug
       end
     end
 
-    # 雇用保険が被保険者であれば被保険者番号の下4桁をnilにする
+    # 雇用保険が被保険者であ無ければ被保険者番号の下4桁をnilにする
     def employment_insurance_number_nil(employment_insurance_type, worker)
       unless employment_insurance_type == :insured
         worker.update(employment_insurance_number: nil)
-        byebug
       end
     end
 

--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -108,6 +108,8 @@ module Users
     def create
       @worker = current_business.workers.build(worker_params)
       if @worker.save
+        health_insurance_name_nil(@worker.worker_insurance.health_insurance_type, @worker.worker_insurance)
+        employment_insurance_number_nil(@worker.worker_insurance.employment_insurance_type, @worker.worker_insurance)
         flash[:success] = '作業員情報を作成しました'
         redirect_to users_worker_path(@worker)
       else
@@ -125,6 +127,8 @@ module Users
 
     def update
       if @worker.update(worker_params)
+        health_insurance_name_nil(@worker.worker_insurance.health_insurance_type, @worker.worker_insurance)
+        employment_insurance_number_nil(@worker.worker_insurance.employment_insurance_type, @worker.worker_insurance)
         flash[:success] = '更新しました'
         redirect_to users_worker_path(@worker)
       else
@@ -186,6 +190,22 @@ module Users
 
     def set_worker
       @worker = current_business.workers.find_by(uuid: params[:uuid])
+    end
+
+    # 健康保険が健康保険組合もしくは建設国保であれば保険名をnilにする
+    def health_insurance_name_nil(health_insurance_type, worker)
+      unless health_insurance_type == :health_insurance_association || health_insurance_type == :construction_national_health_insurance
+        worker.update(health_insurance_name: nil)
+        byebug
+      end
+    end
+
+    # 雇用保険が被保険者であれば被保険者番号の下4桁をnilにする
+    def employment_insurance_number_nil(employment_insurance_type, worker)
+      unless employment_insurance_type == :insured
+        worker.update(employment_insurance_number: nil)
+        byebug
+      end
     end
 
     def worker_params

--- a/app/models/worker_insurance.rb
+++ b/app/models/worker_insurance.rb
@@ -31,8 +31,20 @@ class WorkerInsurance < ApplicationRecord
   enum has_labor_insurance: { join: 0, not_join: 1 }, _prefix: true       # 労働保険特別加入の有無
 
   validates :health_insurance_type, presence: true
+  validates :health_insurance_name, presence: true, if: :insurance_name_valid?
   validates :pension_insurance_type, presence: true
   validates :employment_insurance_type, presence: true
-  validates :employment_insurance_number, { length: { is: 4 } }
+  validates :employment_insurance_number, length: { is: 4 }, if: :employment_insurance_number_valid?
   validates :severance_pay_mutual_aid_type, presence: true
+
+  private
+    # 健康保険が健康保険組合もしくは建設国保であればtrue
+    def insurance_name_valid?
+      health_insurance_type == "health_insurance_association" || health_insurance_type == "construction_national_health_insurance"
+    end
+
+    # 雇用保険が被保険者であればtrue
+    def employment_insurance_number_valid?
+      employment_insurance_type == "insured"
+    end
 end

--- a/app/models/worker_insurance.rb
+++ b/app/models/worker_insurance.rb
@@ -38,13 +38,14 @@ class WorkerInsurance < ApplicationRecord
   validates :severance_pay_mutual_aid_type, presence: true
 
   private
-    # 健康保険が健康保険組合もしくは建設国保であればtrue
-    def insurance_name_valid?
-      health_insurance_type == "health_insurance_association" || health_insurance_type == "construction_national_health_insurance"
-    end
 
-    # 雇用保険が被保険者であればtrue
-    def employment_insurance_number_valid?
-      employment_insurance_type == "insured"
-    end
+  # 健康保険が健康保険組合もしくは建設国保であればtrue
+  def insurance_name_valid?
+    %w[health_insurance_association construction_national_health_insurance].include?(health_insurance_type)
+  end
+
+  # 雇用保険が被保険者であればtrue
+  def employment_insurance_number_valid?
+    employment_insurance_type == 'insured'
+  end
 end

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -30,6 +30,9 @@
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
 <%= f.text_field :my_phone_number, class: "form-control", placeholder: Worker.human_attribute_name(:my_phone_number) %><br>
 
+<%= f.label :email %>
+<%= f.text_field :email, class: "form-control", placeholder: Worker.human_attribute_name(:email) %><br>
+
 <%= f.label :family_name %>
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
 <%= f.text_field :family_name, class: "form-control", placeholder: Worker.human_attribute_name(:family_name) %><br>
@@ -239,7 +242,7 @@
   const health_insurance_name = document.getElementById('health_insurance_name')
   function getRadioHealthInsuranceName(object) {
     const value = $('input[name="worker[worker_insurance_attributes][health_insurance_type]"]:checked').val();
-    if (value === 'health_insurance_association' || value === 'construction_national_health_insurance'){
+    if (value == 'health_insurance_association' || value == 'construction_national_health_insurance'){
       health_insurance_name.classList.remove('hidden');
     } else {
       health_insurance_name.classList.add('hidden');
@@ -248,7 +251,7 @@
   getRadioHealthInsuranceName(health_insurance_type); //ページの読み込み時に判定
 
   $('input[name="worker[worker_insurance_attributes][health_insurance_type]"]').change(function() {
-    if ($(this).val() === 'health_insurance_association' || $(this).val() === 'construction_national_health_insurance'){
+    if ($(this).val() == 'health_insurance_association' || $(this).val() == 'construction_national_health_insurance'){
       health_insurance_name.classList.remove('hidden');
     } else {
       health_insurance_name.classList.add('hidden');

--- a/spec/models/worker_insurance_spec.rb
+++ b/spec/models/worker_insurance_spec.rb
@@ -45,7 +45,14 @@ RSpec.describe WorkerInsurance, type: :model do
           expect(subject).to be_invalid
         end
 
-        it 'バリデーションのエラーが正しいこと' do
+        it 'バリデーションのエラーが正しいこと(健康保険組合)' do
+          subject.health_insurance_type = :health_insurance_association
+          subject.valid?
+          expect(subject.errors.full_messages).to include('健康保険の名前を入力してください')
+        end
+
+        it 'バリデーションのエラーが正しいこと(建設国保)' do
+          subject.health_insurance_type = :construction_national_health_insurance
           subject.valid?
           expect(subject.errors.full_messages).to include('健康保険の名前を入力してください')
         end

--- a/spec/models/worker_insurance_spec.rb
+++ b/spec/models/worker_insurance_spec.rb
@@ -29,6 +29,50 @@ RSpec.describe WorkerInsurance, type: :model do
       end
     end
 
+    describe '#health_insurance_name' do
+      context '健康保険が健康保険組合または、建設国保の場合' do
+        before :each do
+          subject.health_insurance_name = nil
+        end
+
+        it 'バリデーションに落ちること(健康保険組合)' do
+          subject.health_insurance_type = :health_insurance_association
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションに落ちること(建設国保)' do
+          subject.health_insurance_type = :construction_national_health_insurance
+          expect(subject).to be_invalid
+        end
+
+        it 'バリデーションのエラーが正しいこと' do
+          subject.invalid?
+          expect(subject.errors.full_messages).to include('健康保険の名前を入力してください')
+        end
+      end
+
+      context '健康保険が健康保険組合、建設国保以外の場合' do
+        before :each do
+          subject.health_insurance_name = nil
+        end
+
+        it 'バリデーションにとおること(協会けんぽ)' do
+          subject.health_insurance_type = :japan_health_insurance_association
+          expect(subject).to be_valid
+        end
+
+        it 'バリデーションにとおること(国民健康保険)' do
+          subject.health_insurance_type = :national_health_insurance
+          expect(subject).to be_valid
+        end
+
+        it 'バリデーションにとおること(適応除外)' do
+          subject.health_insurance_type = :exemption
+          expect(subject).to be_valid
+        end
+      end
+    end
+
     describe '#pension_insurance_type' do
       context '存在しない場合' do
         before :each do
@@ -64,7 +108,7 @@ RSpec.describe WorkerInsurance, type: :model do
     end
 
     describe '#employment_insurance_number' do
-      context '4場合' do
+      context '被保険者の場合' do
         before :each do
           %i[
             12345
@@ -75,12 +119,35 @@ RSpec.describe WorkerInsurance, type: :model do
         end
 
         it 'バリデーションに落ちること' do
+          subject.employment_insurance_type = :insured
           expect(subject).to be_invalid
         end
 
         it 'バリデーションのエラーが正しいこと' do
+          subject.employment_insurance_type = :insured
           subject.valid?
           expect(subject.errors.full_messages).to include('被保険者番号の下4桁は4文字で入力してください')
+        end
+      end
+
+      context '被保険者の場合' do
+        before :each do
+          %i[
+            12345
+            123
+          ].each do |number|
+            subject.employment_insurance_number = number
+          end
+        end
+
+        it 'バリデーションにとおること' do
+          subject.employment_insurance_type = :day
+          expect(subject).to be_valid
+        end
+
+        it 'バリデーションにとおること' do
+          subject.employment_insurance_type = :exemption
+          expect(subject).to be_valid
         end
       end
     end

--- a/spec/models/worker_insurance_spec.rb
+++ b/spec/models/worker_insurance_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe WorkerInsurance, type: :model do
         end
 
         it 'バリデーションのエラーが正しいこと' do
-          subject.invalid?
+          subject.valid?
           expect(subject.errors.full_messages).to include('健康保険の名前を入力してください')
         end
       end
@@ -130,7 +130,7 @@ RSpec.describe WorkerInsurance, type: :model do
         end
       end
 
-      context '被保険者の場合' do
+      context '被保険者以外の場合' do
         before :each do
           %i[
             12345
@@ -140,12 +140,12 @@ RSpec.describe WorkerInsurance, type: :model do
           end
         end
 
-        it 'バリデーションにとおること' do
+        it 'バリデーションにとおること(日雇保険)' do
           subject.employment_insurance_type = :day
           expect(subject).to be_valid
         end
 
-        it 'バリデーションにとおること' do
+        it 'バリデーションにとおること(適応除外)' do
           subject.employment_insurance_type = :exemption
           expect(subject).to be_valid
         end


### PR DESCRIPTION
### 概要
〇健康保険名のバリデーション
〇被保険者番号のバリデーション
〇バリデーションの変更分のRSpecの変更

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
〇健康保険名のバリデーション
　・健康保険が健康保険組合、建設国保である場合、必須化
　・健康保険が健康保険組合、建設国保以外の場合、バリデーションの解除
〇被保険者番号のバリデーション
　・雇用保険が被保険者の場合、４文字でなければならない
　・雇用保険が被保険者以外の場合、バリデーションの解除
〇RSpecの編集
　・健康保険が健康保険組合、建設国保である場合、保険名が空のときバリデーションに通らない
　・健康保険が健康保険組合、建設国保以外の場合、バリデーションに通る
　・雇用保険が被保険者の場合、４文字でなければならない
　・雇用保険が被保険者以外の場合、バリデーションにとおる

### 実装画像などあれば添付する


