### PR TITLE
管理画面修正、協力会社一覧画面エラー再修正(平野)

### DIFF
--- a/app/admin/admins.rb
+++ b/app/admin/admins.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Admin do
-  actions :all, except: %i(new destroy)
+  actions :all, except: %i[new destroy]
   permit_params :email, :password, :password_confirmation
 
   index do

--- a/app/admin/admins.rb
+++ b/app/admin/admins.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register Admin do
+  actions :all, except: %i(new destroy)
   permit_params :email, :password, :password_confirmation
 
   index do

--- a/app/controllers/users/subcon_users_controller.rb
+++ b/app/controllers/users/subcon_users_controller.rb
@@ -16,7 +16,7 @@ module Users
     def approval
       # 自身が招待を受けたユーザー(自身の上にあたるユーザー)
       invited_user = Business.find_by(uuid: params[:id]).user
-      pending_invitation = invited_user.invitation_sent_user_ids
+      pending_invitation = invited_user.invitation_sent_user_ids || []
 
       # 自身が招待を受けたユーザーinvitation_sent_user_idsカラムの配列から自信のユーザーidを取り除く。
       pending_invitation.delete(current_user.id)
@@ -35,7 +35,7 @@ module Users
     def destroy_invited_pending
       # 自身が招待を受けたユーザー(自身の上にあたるユーザー)
       invited_user = Business.find_by(uuid: params[:id]).user
-      pending_invitation = invited_user.invitation_sent_user_ids
+      pending_invitation = invited_user.invitation_sent_user_ids || []
 
       # 自身が招待を受けたユーザーのinvitation_sent_user_idsカラムの配列から自身のユーザーidを取り除く。
       pending_invitation.delete(current_user.id)
@@ -49,7 +49,7 @@ module Users
     def destroy_invitation_pending
       # 自身が招待を送ったユーザー(自身の下請けにあたるユーザー)
       invited_user = User.find(params[:id])
-      pending_invitation = current_user.invitation_sent_user_ids
+      pending_invitation = current_user.invitation_sent_user_ids || []
 
       pending_invitation.delete(invited_user.id)
       current_user.update(invitation_sent_user_ids: pending_invitation)
@@ -61,7 +61,7 @@ module Users
     # 自身の下請け協力会社を解除
     def destroy_invited
       invited_user = Business.find_by(uuid: params[:id]).user
-      invitation = current_user.invited_user_ids
+      invitation = current_user.invited_user_ids || []
 
       invitation.delete(invited_user.id)
       current_user.update(invited_user_ids: invitation)


### PR DESCRIPTION
### 概要
- 管理画面で管理者(admin)の登録・削除をできないようにする
- 協力会社一覧画面のステージングエラー500の修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- 管理画面でのシステム管理者(admin)の登録、削除アクションを削除しシステム管理者を追加登録や削除できないように修正
- ステージング環境での協力会社一覧画面のエラー未解消の対応。配列周りを再度見直し、修正。

### 実装画像などあれば添付する


