### PR TITLE
キャッシュを使用した時に強制リロードするように設定

### DIFF
--- a/app/javascript/packs/users.js
+++ b/app/javascript/packs/users.js
@@ -45,6 +45,14 @@ document.addEventListener("turbolinks:load", () => {
   })
 });
 
+// 強制リロード
+window.addEventListener('pageshow', function (event) {
+  if (event.persisted) {
+    window.location.reload();
+  }
+});
+
+
 import 'select2';                       // globally assign select2 fn to $ element
 import 'select2/dist/css/select2.css';  // optional if you have css loader
 

--- a/app/javascript/packs/users.js
+++ b/app/javascript/packs/users.js
@@ -46,6 +46,7 @@ document.addEventListener("turbolinks:load", () => {
 });
 
 // 強制リロード
+history.pushState(null, null, location.href);
 window.addEventListener('pageshow', function (event) {
   if (event.persisted) {
     window.location.reload();


### PR DESCRIPTION
### 概要
キャッシュを使用した時に強制リロードするように設定

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
キャッシュを使用した時に強制リロードするようjsにて設定

### 動作確認
safariにてログイン後のブラウザバックをすると再読み込みし、ログイン後の画面になることを確認
