### PR TITLE
会社情報表示時のエラー解消等（原）

### DIFF
--- a/app/controllers/users/businesses_controller.rb
+++ b/app/controllers/users/businesses_controller.rb
@@ -30,15 +30,7 @@ module Users
           business_employment_insurance_join_status:                   0, # 雇用保険(加入状況)
           business_employment_insurance_number:                        '01234567890', # 雇用保険(番号)
           business_retirement_benefit_mutual_aid_status:               0, # 退職金共済制度(加入状況)
-          construction_license_status:                                 0, # 建設許可証(取得状況)
-          construction_license_permission_type_minister_governor:      0, # 建設許可証(種別)
-          construction_license_governor_permission_prefecture:         0, # 建設許可証(都道府県)
-          construction_license_permission_type_identification_general: 0, # 建設許可証(種別)
-          construction_license_number_double_digit:                    29, # 建設許可証(番号)
-          construction_license_number_six_digits:                      5000, # 建設許可証(番号)
-          construction_license_number:                                 '国土交通大臣(特－29)第5000号', # 建設許可証(建設許可番号)
-          construction_license_updated_at:                             Date.today, # 建設許可証(更新日)
-          industry_ids:                                                1
+          construction_license_status:                                 0 # 建設許可証(取得状況)
           # =============================================
         )
         @business.business_occupations.build

--- a/app/views/users/businesses/_business_industry_fields.html.erb
+++ b/app/views/users/businesses/_business_industry_fields.html.erb
@@ -12,7 +12,7 @@
     </div>
     <div id="disabled-form" class="col-md-2">
       <%= f.label :construction_license_governor_permission_prefecture %>
-      <%= f.select :construction_license_governor_permission_prefecture, BusinessIndustry.construction_license_governor_permission_prefectures_i18n.invert, {include_blank: false}, {class: "form-control"} %>
+      <%= f.select :construction_license_governor_permission_prefecture, BusinessIndustry.construction_license_governor_permission_prefectures_i18n.invert, {include_blank: true}, {class: "form-control"} %>
     </div>
     <div class="col-md-1">
       <%= f.label :construction_license_permission_type_identification_general %>
@@ -41,27 +41,15 @@
 </div>
 
 <script>
-$('input[name="business[business_industries_attributes][1][construction_license_permission_type_minister_governor]"]').change(function() {
-  // 「大臣許可」が選択されたら、テキストボックスを有効化する
-  if ($(this).val() == "governor_permission") {
-    $('#business_business_industries_attributes_1_construction_license_governor_permission_prefecture').prop('disabled', false);
-  }
-  // 「大臣許可」以外が選択されたら、テキストボックスを無効化し、中身を空にする
-  else {
-    $('#business_business_industries_attributes_1_construction_license_governor_permission_prefecture').val('').prop('disabled', true);
-  }
-});
-
-//上記コードに、各追加フォームで動作するようにeach処理追加途中↓
-// $('input[name$="[construction_license_permission_type_minister_governor]"]').each(function() {
-//   var $prefectureInput = $(this).closest('.nested-fields').find('input[name$="[construction_license_governor_permission_prefecture]"]');
-  
-//   $(this).change(function() {
-//     if ($(this).val() == "governor_permission") {
-//       $prefectureInput.prop('disabled', false);
-//     } else {
-//       $prefectureInput.val('').prop('disabled', true);
-//     }
-//   });
-// });
+  $(document).on('change', 'input[name^="business[business_industries_attributes]"][name$="[construction_license_permission_type_minister_governor]"]', function() {
+    var index = $(this).attr('name').match(/\d+/)[0];
+    // 「大臣許可」が選択されたら、テキストボックスを有効化する
+    if ($(this).val() == "governor_permission") {
+      $('#business_business_industries_attributes_' + index + '_construction_license_governor_permission_prefecture').prop('disabled', false);
+    }
+    // 「大臣許可」以外が選択されたら、テキストボックスを無効化し、中身を空にする
+    else {
+      $('#business_business_industries_attributes_' + index + '_construction_license_governor_permission_prefecture').val('').prop('disabled', true);
+    }
+  });
 </script>

--- a/app/views/users/businesses/_business_industry_fields.html.erb
+++ b/app/views/users/businesses/_business_industry_fields.html.erb
@@ -41,6 +41,7 @@
 </div>
 
 <script>
+//建設許可種別の内容（大臣・知事）によって、都道府県知事許可フォームの有効・無効切り替え
   $(document).on('change', 'input[name^="business[business_industries_attributes]"][name$="[construction_license_permission_type_minister_governor]"]', function() {
     var index = $(this).attr('name').match(/\d+/)[0];
     // 「大臣許可」が選択されたら、テキストボックスを有効化する

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -105,11 +105,17 @@
 <div id="available-form">
   <%= f.collection_radio_buttons(:construction_license_status, Business.construction_license_statuses_i18n, :first, :last) %><br>
 </div>
-<!-- BusinessIndustryここから -->
+<!-- BusinessIndustryここから（建設許可証「有」かつデータがまだ無い場合は、一つのフォームのみデフォルトで表示） -->
 <div id="hidden-form" class="list-group">
   <div class="list-group-item">
-    <%= f.fields_for :business_industries do |b_industry| %>
-      <%= render "business_industry_fields", f: b_industry %>
+    <% if f.object.business_industries.size == 0 %>
+      <%= f.fields_for :business_industries, BusinessIndustry.new do |b_industry| %>
+        <%= render "business_industry_fields", f: b_industry %>
+      <% end %>
+    <% else %>
+      <%= f.fields_for :business_industries do |b_industry| %>
+        <%= render "business_industry_fields", f: b_industry %>
+      <% end %>
     <% end %>
     <div id="license-insertion-point"></div>
     <%= link_to_add_association "＋フォーム追加", f, :business_industries,
@@ -140,25 +146,44 @@
 
 <script>
 //建設許可証の有無によってフォームの表示・非表示の切り替え
-  const available_form = document.getElementById('available-form')
-  const list_group = document.getElementById('hidden-form')
-  function getRadioHealthInsuranceName(object) {
-    const value = $('input[name="business[construction_license_status]"]:checked').val();
-    if (value == 'available'){
-      list_group.classList.remove('hidden');
-    } else {
-      list_group.classList.add('hidden');
-    }
-  };
-  getRadioHealthInsuranceName(available_form); //ページの読み込み時に判定
+  // const available_form = document.getElementById('available-form')
+  // const list_group = document.getElementById('hidden-form')
+  // function getRadioHealthInsuranceName(object) {
+  //   const value = $('input[name="business[construction_license_status]"]:checked').val();
+  //   if (value == 'available'){
+  //     list_group.classList.remove('hidden');
+  //   } else {
+  //     list_group.classList.add('hidden');
+  //   }
+  // };
+  // getRadioHealthInsuranceName(available_form); //ページの読み込み時に判定
 
-  $('input[name="business[construction_license_status]"]').change(function() {
-    if ($(this).val() == 'available') {
-      list_group.classList.remove('hidden');
+  // $('input[name="business[construction_license_status]"]').change(function() {
+  //   if ($(this).val() == 'available') {
+  //     list_group.classList.remove('hidden');
+  //   } else {
+  //     list_group.classList.add('hidden');
+  //   }
+  // });
+$(document).on('turbolinks:load', function() {
+  var availableForm = $('#available-form');
+  var hiddenForm = $('#hidden-form');
+
+  function toggleFormVisibility() {
+    if (availableForm.find(':checked').val() === 'available') {
+      hiddenForm.show();
+      if (hiddenForm.find('.nested-fields').length === 0) {
+        hiddenForm.find('.add_nested_fields').click();
+      }
     } else {
-      list_group.classList.add('hidden');
+      hiddenForm.hide();
     }
-  });
+  }
+
+  availableForm.on('change', 'input[type="radio"]', toggleFormVisibility);
+
+  toggleFormVisibility();
+});
 
 
 // フォームを29個まで制限かける（実装途中）

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -105,6 +105,7 @@
 <div id="available-form">
   <%= f.collection_radio_buttons(:construction_license_status, Business.construction_license_statuses_i18n, :first, :last) %><br>
 </div>
+
 <!-- BusinessIndustryここから（建設許可証「有」かつデータがまだ無い場合は、一つのフォームのみデフォルトで表示） -->
 <div id="hidden-form" class="list-group">
   <div class="list-group-item">
@@ -127,6 +128,7 @@
   </div>
 </div>
 <!-- BusinessIndustryここまで -->
+
 <br>
 <%= f.label :specific_skilled_foreigners_exist %><br>
 <%= f.collection_radio_buttons(:specific_skilled_foreigners_exist, Business.specific_skilled_foreigners_exists_i18n, :first, :last) %><br>
@@ -146,45 +148,25 @@
 
 <script>
 //建設許可証の有無によってフォームの表示・非表示の切り替え
-  // const available_form = document.getElementById('available-form')
-  // const list_group = document.getElementById('hidden-form')
-  // function getRadioHealthInsuranceName(object) {
-  //   const value = $('input[name="business[construction_license_status]"]:checked').val();
-  //   if (value == 'available'){
-  //     list_group.classList.remove('hidden');
-  //   } else {
-  //     list_group.classList.add('hidden');
-  //   }
-  // };
-  // getRadioHealthInsuranceName(available_form); //ページの読み込み時に判定
-
-  // $('input[name="business[construction_license_status]"]').change(function() {
-  //   if ($(this).val() == 'available') {
-  //     list_group.classList.remove('hidden');
-  //   } else {
-  //     list_group.classList.add('hidden');
-  //   }
-  // });
-$(document).on('turbolinks:load', function() {
-  var availableForm = $('#available-form');
-  var hiddenForm = $('#hidden-form');
-
-  function toggleFormVisibility() {
-    if (availableForm.find(':checked').val() === 'available') {
-      hiddenForm.show();
-      if (hiddenForm.find('.nested-fields').length === 0) {
-        hiddenForm.find('.add_nested_fields').click();
-      }
+  const available_form = document.getElementById('available-form')
+  const list_group = document.getElementById('hidden-form')
+  function getRadioHealthInsuranceName(object) {
+    const value = $('input[name="business[construction_license_status]"]:checked').val();
+    if (value == 'available'){
+      list_group.classList.remove('hidden');
     } else {
-      hiddenForm.hide();
+      list_group.classList.add('hidden');
     }
-  }
+  };
+  getRadioHealthInsuranceName(available_form); //ページの読み込み時に判定
 
-  availableForm.on('change', 'input[type="radio"]', toggleFormVisibility);
-
-  toggleFormVisibility();
-});
-
+  $('input[name="business[construction_license_status]"]').change(function() {
+    if ($(this).val() == 'available') {
+      list_group.classList.remove('hidden');
+    } else {
+      list_group.classList.add('hidden');
+    }
+  });
 
 // フォームを29個まで制限かける（実装途中）
   // $(function() {

--- a/app/views/users/businesses/show.html.erb
+++ b/app/views/users/businesses/show.html.erb
@@ -7,54 +7,119 @@
         <tr>
           <th><%= Business.human_attribute_name(:name) %></th>
           <td><%= @business.name %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:name_kana) %></th>
           <td><%= @business.name_kana %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:branch_name) %></th>
           <td><%= @business.branch_name %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:representative_name) %></th>
           <td><%= @business.representative_name %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:email) %></th>
           <td><%= @business.email %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:address) %></th>
           <td><%= @business.address %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:post_code) %></th>
           <td><%= @business.post_code %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:phone_number) %></th>
           <td><%= @business.phone_number %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:fax_number) %></th>
           <td><%= @business.fax_number %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:career_up_id) %></th>
           <td><%= @business.career_up_id %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_type) %></th>
           <td><%= @business.business_type_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:industry_ids) %></th>
           <td><%= Industry.where(id: @business.tem_industry_ids).pluck(:name).join(', ') %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:occupation_ids) %></th>
           <td><%= @business.occupations.pluck(:name).join(', ') %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:stamp_images) %></th>
@@ -63,46 +128,101 @@
               <%= image_tag(image.url) %>
             <% end %>
           </td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_health_insurance_status) %></th>
           <td><%= @business.business_health_insurance_status_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_health_insurance_association) %></th>
           <td><%= @business.business_health_insurance_association %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_health_insurance_office_number) %></th>
           <td><%= @business.business_health_insurance_office_number %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_welfare_pension_insurance_join_status) %></th>
           <td><%= @business.business_welfare_pension_insurance_join_status_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_welfare_pension_insurance_office_number) %></th>
           <td><%= @business.business_welfare_pension_insurance_office_number %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_pension_insurance_join_status) %></th>
           <td><%= @business.business_pension_insurance_join_status_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_employment_insurance_join_status) %></th>
           <td><%= @business.business_employment_insurance_join_status_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_employment_insurance_number) %></th>
           <td><%= @business.business_employment_insurance_number %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:business_retirement_benefit_mutual_aid_status) %></th>
           <td><%= @business.business_retirement_benefit_mutual_aid_status_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:construction_license_status) %></th>
           <td><%= @business.construction_license_status_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <!-- business_industryここから（建設許可証「有」の場合のみ下記表示 -->
         <% if @business.construction_license_status_available? %>
@@ -137,18 +257,38 @@
         <tr>
           <th><%= Business.human_attribute_name(:specific_skilled_foreigners_exist) %></th>
           <td><%= @business.specific_skilled_foreigners_exist_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:foreign_construction_workers_exist) %></th>
           <td><%= @business.foreign_construction_workers_exist_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:foreign_technical_intern_trainees_exist) %></th>
           <td><%= @business.foreign_technical_intern_trainees_exist_i18n %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
           <th><%= Business.human_attribute_name(:employment_manager_name) %></th>
           <td><%= @business.employment_manager_name %></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
### 概要
１、会社情報表示時のエラー解消
２、会社情報の建設許可証フォームのJS修正

### タスク
- [x] なし
- [ ] あり

### 実装内容・手法
１、会社情報を表示する際のエラーの原因だった、businessコントローラのnew時の初期値から不要カラムの削除
２、建設許可証の、大臣許可・知事許可によるフォーム表示のJS微修正
　（①ラジオボタンを発火とする表示・非表示を複数フォームにて反映できるようeach文追加
　　②建設許可証「有」かつデータがまだ未入力の場合に、一つのフォームのみデフォルトで表示させる）
３、会社情報show画面の調整

### 実装画像などあれば添付する
＜２-①挙動＞

https://user-images.githubusercontent.com/63439936/227732718-5f29df02-c348-41fd-b889-16293ecdfb64.mov


＜２-②＞
【before】
![スクリーンショット 2023-03-26 2 28 15](https://user-images.githubusercontent.com/63439936/227732651-f2092b61-1a61-4249-92dd-3324441c3e57.png)

【after】
![スクリーンショット 2023-03-26 2 28 02](https://user-images.githubusercontent.com/63439936/227732654-fd1094a8-8d28-4a54-8a1e-07598cd03aa1.png)


