### PR TITLE
会社情報更新時のバリデーションエラー回避（原）

### DIFF
--- a/app/models/business_industry.rb
+++ b/app/models/business_industry.rb
@@ -6,11 +6,10 @@ class BusinessIndustry < ApplicationRecord
   enum construction_license_governor_permission_prefecture: { hokkaido: 0, aomori: 1, iwate: 2, miyagi: 3, akita: 4, yamagata: 5, fukushima: 6, ibaraki: 7, tochigi: 8, gunma: 9, saitama: 10, chiba: 11, tokyo: 12, kanagawa: 13, niigata: 14, toyama: 15, ishikawa: 16, fukui: 17, yamanashi: 18, nagano: 19, gifu: 20, shizuoka: 21, aichi: 22, mie: 23, shiga: 24, kyoto: 25, osaka: 26, hyogo: 27, nara: 28, wakayama: 29, tottori: 30, shimane: 31, okayama: 32, hiroshima: 33, yamaguchi: 34, tokushima: 35, kagawa: 36, ehime: 37, kochi: 38, fukuoka: 39, saga: 40, nagasaki: 41, kumamoto: 42, oita: 43, miyazaki: 44, kagoshima: 45, okinawa: 46 } # 建設許可証(都道府県)
   enum construction_license_permission_type_identification_general: { identification: 0, general: 1 }, _prefix: true # 建設許可証(許可種別)
 
-  validates :construction_license_permission_type_minister_governor, presence: true
-  validates :construction_license_governor_permission_prefecture, presence: true
-  validates :construction_license_permission_type_identification_general, presence: true
-  validates :construction_license_number_double_digit, format: { with: /\A\d{2}\z/, message: 'は数字2桁で入力してください' }, presence: true
-  validates :construction_license_number_six_digits, format: { with: /\A\d{1,6}\z/, message: 'は数字6桁以下で入力してください' }, presence: true
-  validates :construction_license_number, presence: true
-  validates :construction_license_updated_at, presence: true
+  validates :construction_license_permission_type_minister_governor, presence: true, if: -> { business.construction_license_status == "available" }
+  validates :construction_license_governor_permission_prefecture, presence: true, if: -> { construction_license_permission_type_minister_governor == "governor_permission" }
+  validates :construction_license_permission_type_identification_general, presence: true, if: -> { business.construction_license_status == "available" }
+  validates :construction_license_number_double_digit, format: { with: /\A\d{2}\z/, message: 'は数字2桁で入力してください' }, presence: true, if: -> { business.construction_license_status == "available" }
+  validates :construction_license_number_six_digits, format: { with: /\A\d{1,6}\z/, message: 'は数字6桁以下で入力してください' }, presence: true, if: -> { business.construction_license_status == "available" }
+  validates :construction_license_updated_at, presence: true, if: -> { business.construction_license_status == "available" }
 end

--- a/app/models/business_industry.rb
+++ b/app/models/business_industry.rb
@@ -6,10 +6,10 @@ class BusinessIndustry < ApplicationRecord
   enum construction_license_governor_permission_prefecture: { hokkaido: 0, aomori: 1, iwate: 2, miyagi: 3, akita: 4, yamagata: 5, fukushima: 6, ibaraki: 7, tochigi: 8, gunma: 9, saitama: 10, chiba: 11, tokyo: 12, kanagawa: 13, niigata: 14, toyama: 15, ishikawa: 16, fukui: 17, yamanashi: 18, nagano: 19, gifu: 20, shizuoka: 21, aichi: 22, mie: 23, shiga: 24, kyoto: 25, osaka: 26, hyogo: 27, nara: 28, wakayama: 29, tottori: 30, shimane: 31, okayama: 32, hiroshima: 33, yamaguchi: 34, tokushima: 35, kagawa: 36, ehime: 37, kochi: 38, fukuoka: 39, saga: 40, nagasaki: 41, kumamoto: 42, oita: 43, miyazaki: 44, kagoshima: 45, okinawa: 46 } # 建設許可証(都道府県)
   enum construction_license_permission_type_identification_general: { identification: 0, general: 1 }, _prefix: true # 建設許可証(許可種別)
 
-  validates :construction_license_permission_type_minister_governor, presence: true, if: -> { business.construction_license_status == "available" }
-  validates :construction_license_governor_permission_prefecture, presence: true, if: -> { construction_license_permission_type_minister_governor == "governor_permission" }
-  validates :construction_license_permission_type_identification_general, presence: true, if: -> { business.construction_license_status == "available" }
-  validates :construction_license_number_double_digit, format: { with: /\A\d{2}\z/, message: 'は数字2桁で入力してください' }, presence: true, if: -> { business.construction_license_status == "available" }
-  validates :construction_license_number_six_digits, format: { with: /\A\d{1,6}\z/, message: 'は数字6桁以下で入力してください' }, presence: true, if: -> { business.construction_license_status == "available" }
-  validates :construction_license_updated_at, presence: true, if: -> { business.construction_license_status == "available" }
+  validates :construction_license_permission_type_minister_governor, presence: true, if: -> { business.construction_license_status == 'available' }
+  validates :construction_license_governor_permission_prefecture, presence: true, if: -> { construction_license_permission_type_minister_governor == 'governor_permission' }
+  validates :construction_license_permission_type_identification_general, presence: true, if: -> { business.construction_license_status == 'available' }
+  validates :construction_license_number_double_digit, format: { with: /\A\d{2}\z/, message: 'は数字2桁で入力してください' }, presence: true, if: -> { business.construction_license_status == 'available' }
+  validates :construction_license_number_six_digits, format: { with: /\A\d{1,6}\z/, message: 'は数字6桁以下で入力してください' }, presence: true, if: -> { business.construction_license_status == 'available' }
+  validates :construction_license_updated_at, presence: true, if: -> { business.construction_license_status == 'available' }
 end

--- a/app/views/users/businesses/_business_industry_fields.html.erb
+++ b/app/views/users/businesses/_business_industry_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="nested-fields">
+<div id="nest-field" class="nested-fields">
   <div class="row">
     <div class="col-md-2">
       <%= f.label :industry_id %>

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -104,6 +104,7 @@
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
 <div id="available-form">
   <%= f.collection_radio_buttons(:construction_license_status, Business.construction_license_statuses_i18n, :first, :last) %><br>
+  <div id="error" class="text-red">【エラー】：残っているフォームを削除してからチェックを変更してください。</div>
 </div>
 
 <!-- BusinessIndustryここから（建設許可証「有」かつデータがまだ無い場合は、一つのフォームのみデフォルトで表示） -->
@@ -119,7 +120,7 @@
       <% end %>
     <% end %>
     <div id="license-insertion-point"></div>
-    <%= link_to_add_association "＋フォーム追加", f, :business_industries,
+    <%= link_to_add_association "＋フォーム追加", f, :business_industries, id: "form-link",
       data: {
         association_insertion_node: '#license-insertion-point',
         association_insertion_method: 'append'
@@ -150,12 +151,20 @@
 //建設許可証の有無によってフォームの表示・非表示の切り替え
   const available_form = document.getElementById('available-form')
   const list_group = document.getElementById('hidden-form')
+  const error = document.getElementById('error')
   function getRadioHealthInsuranceName(object) {
     const value = $('input[name="business[construction_license_status]"]:checked').val();
     if (value == 'available'){
       list_group.classList.remove('hidden');
+      //建設許可証「有」をチェック時は、エラー文を非表示
+      
+      error.classList.add('hidden');
     } else {
       list_group.classList.add('hidden');
+      //建設許可証「無」をチェック、かつフォームが残っている場合は、エラー文を表示し残フォーム削除を促す（nilが送信されてしまう為）
+      if ($("#nest-field").length) {
+        error.classList.remove('hidden');
+      }
     }
   };
   getRadioHealthInsuranceName(available_form); //ページの読み込み時に判定
@@ -163,35 +172,38 @@
   $('input[name="business[construction_license_status]"]').change(function() {
     if ($(this).val() == 'available') {
       list_group.classList.remove('hidden');
+      error.classList.add('hidden');
     } else {
       list_group.classList.add('hidden');
+      if ($("#nest-field").length) {
+        error.classList.remove('hidden');
+      }
     }
   });
 
-// フォームを29個まで制限かける（実装途中）
-  // $(function() {
-  //   var max_fields = 29;
-  //   var current_fields = $('form .nested-fields').length;
+// 建設許可証のフォーム追加を29個までで制限かける（実装途中）
+  // $(document).on('turbolinks:load', function() {
+  //   var maxForms = 4;
+  //   var formsCount = $('#nest-field').length;
+  //   updateAddButtonState(formsCount);
 
-  //   $('#new_sample').on('cocoon:after-insert', function() {
-  //     current_fields++;
-
-  //     if (current_fields >= max_fields) {
-  //       $('form .links').hide();
-  //     }
+  //   $('#hidden-form').on('cocoon:after-insert', function(e, insertedItem) {
+  //     formsCount = $('#nest-field').length;
+  //     updateAddButtonState(formsCount);
   //   });
 
-  //   $('#new_sample').on('cocoon:after-remove', function() {
-  //     current_fields--;
-
-  //     if (current_fields < max_fields) {
-  //       $('form .links').show();
+  //   function updateAddButtonState(count) {
+  //     if (count >= maxForms) {
+  //       $('#form-link').addClass('disabled').off('click');
+  //     } else {
+  //       $('#form-link').removeClass('disabled').on('click', function() {
+  //         return true;
+  //       });
   //     }
-  //   });
+  //   }
   // });
-</script>
-
-<script>
+  
+//各フォームのバリデーション
   $(function(){
     $.each(function(key){
       $.validator.addMethod(key, this);
@@ -246,7 +258,7 @@
         "business[construction_license_status]": {
           required: true
         },
-        "business[industry_ids][]": {
+        "business[industry_id][]": {
           required: true
         },
         "business[tem_industry_ids][]": {
@@ -255,25 +267,25 @@
         "business[occupation_ids][]": {
           required: true
         },
-        "business[construction_license_permission_type_minister_governor]": {
+        "business[business_industries_attributes][construction_license_permission_type_minister_governor]": {
           required: true
         },
-        "business[construction_license_governor_permission_prefecture]": {
+        "business[business_industries_attributes][construction_license_governor_permission_prefecture]": {
           required: true
         },
-        "business[construction_license_permission_type_identification_general]": {
+        "business[business_industries_attributes][construction_license_permission_type_identification_general]": {
           required: true
         },
-        "business[construction_license_number_double_digit]": {
+        "business[business_industries_attributes][construction_license_number_double_digit]": {
           required: true
         },
-        "business[construction_license_number_six_digits]": {
+        "business[business_industries_attributes][construction_license_number_six_digits]": {
           required: true
         },
-        "business[construction_license_number]": {
+        "business[business_industries_attributes][construction_license_number]": {
           required: true
         },
-        "business[construction_license_updated_at]": {
+        "business[business_industries_attributes][construction_license_updated_at]": {
           required: true
         }
       },
@@ -326,7 +338,7 @@
         "business[construction_license_status]": {
           required: "どちらかを選択してください。"
         },
-        "business[industry_ids][]": {
+        "business[industry_id][]": {
           required: "業種を選択してください。"
         },
         "business[tem_industry_ids][]": {
@@ -335,22 +347,22 @@
         "business[occupation_ids][]": {
           required: "職種を選択してください。"
         },
-        "business[construction_license_permission_type_minister_governor]": {
+        "business[business_industries_attributes][construction_license_permission_type_minister_governor]": {
           required: "どちらかを選択してください。"
         },
-        "business[construction_license_governor_permission_prefecture]": {
+        "business[business_industries_attributes][construction_license_governor_permission_prefecture]": {
           required: "どれか一つを選択してください。"
         },
-        "business[construction_license_permission_type_identification_general]": {
+        "business[business_industries_attributes][construction_license_permission_type_identification_general]": {
           required: "どちらかを選択してください。"
         },
-        "business[construction_license_number_double_digit]": {
+        "business[business_industries_attributes][construction_license_number_double_digit]": {
           required: "2桁の番号を入力してください。"
         },
-        "business[construction_license_number_six_digits]": {
+        "business[business_industries_attributes][construction_license_number_six_digits]": {
           required: "6桁以下の番号を入力してください。"
         },
-        "business[construction_license_updated_at]": {
+        "business[business_industries_attributes][construction_license_updated_at]": {
           required: "日付を選択してください。"
         }
       },


### PR DESCRIPTION
### 概要
_会社情報更新時のバリデーションエラー回避_

### タスク
- [x] なし
- [ ] あり

### 実装内容・手法
【問題箇所】
○会社情報の建設許可証フォームにて、建設許可証「無」にして更新した場合、「有」の時の入力フォームが残っており、nilが送られ必須項目のバリデーションに引っかかってしまう。”業種”項目以外はモデルのバリデーションにて設定できたが、”業種”は外部キーの為一工夫必要。

【解決策】
○建設許可証「有」から「無」にチェックを切り替えた際に、入力フォームが残っていた場合はエラー文を表示し、ユーザーに残フォームを削除してもらうように促す事でnilが送られることを回避。

### 実装画像などあれば添付する


https://user-images.githubusercontent.com/63439936/229258154-40ae0424-f960-4cbe-af62-ad752aa5d684.mov


