### PR TITLE
⑱工事作業所災害防止協議会兼施工体系図の修正および現場情報関連修正(伊藤)

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -630,6 +630,12 @@ module DocumentsHelper
     end
   end
 
+  # 一次下請け会社名の取得
+  def primary_subcon_business_name
+    request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
+    Business.joins(:request_orders).where(request_orders: { parent_id: request_order.id }).pluck(:name)
+  end
+
   # (20)年間安全衛生計画書
 
   # 代表者名の役職取得

--- a/app/javascript/stylesheets/users/doc_18th.scss
+++ b/app/javascript/stylesheets/users/doc_18th.scss
@@ -244,6 +244,19 @@
 
 .ritz .waffle .doc_18_s27 {
   border-bottom: 1px DASHED #000000;
+  background-color: #ffffff;
+  text-align: left;
+  color: #000000;
+  font-family: 'Arial';
+  font-size: 14pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
+.ritz .waffle .doc_18_s56 {
+  border-bottom: 1px DASHED #000000;
   border-right: 1px SOLID #000000;
   background-color: #ffffff;
   text-align: left;
@@ -692,6 +705,18 @@
   padding: 0px 3px 0px 3px;
 }
 
+.ritz .waffle .doc_18_s57 {
+  background-color: #ffffff;
+  text-align: center;
+  color: #FF0000;
+  font-family: 'Arial';
+  font-size: 14pt;
+  vertical-align: middle;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 0px 3px 0px 3px;
+}
+
 .ritz .waffle .doc_18_s11 {
   border-bottom: 1px SOLID #000000;
   background-color: #ffffff;
@@ -770,4 +795,13 @@
   width: 420mm;
   height: 297mm;
   size: A3 landscape;
+}
+
+select {
+  &:invalid {
+    color: grey
+  }
+  option[value=""] {
+    display: none;
+  }
 }

--- a/app/views/users/documents/doc_18th/_edit.html.erb
+++ b/app/views/users/documents/doc_18th/_edit.html.erb
@@ -239,7 +239,13 @@
                         <div class="row-header-wrapper" style="line-height: 19px"></div>
                       </th>
                       <td class="doc_18_s2"></td>
-                      <td class="doc_18_s5" colspan="103">工事作業所災害防止協議会兼施工体系図</td>
+                      <% if i == 0 %>
+                        <td class="doc_18_s57" colspan="20">※ 緑枠は入力項目です。必要あれば入力してください。</td>
+                        <td class="doc_18_s5" colspan="63">工事作業所災害防止協議会兼施工体系図</td>
+                        <td class="doc_18_s4" colspan="20"></td>
+                      <% else %>
+                        <td class="doc_18_s5" colspan="103">工事作業所災害防止協議会兼施工体系図</td>
+                      <% end %>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s4"></td>
                     </tr>
@@ -798,25 +804,33 @@
                       <td class="doc_18_s24"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s17" dir="ltr" colspan="9">
-                        <%= provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                        <% provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s14"></td>
                       <td class="doc_18_s18"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                        <% provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s14"></td>
                       <td class="doc_18_s18"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                        <% provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s14"></td>
                       <td class="doc_18_s18"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                     </tr>
@@ -841,13 +855,13 @@
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s26"></td>
-                      <td class="doc_18_s27"></td>
+                      <td class="doc_18_s56"></td>
                       <td class="doc_18_s7" colspan="6">工 事 内 容</td>
                       <td class="doc_18_s17" dir="ltr" colspan="9">
                         <%= provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_details %>
                       </td>
                       <td class="doc_18_s26"></td>
-                      <td class="doc_18_s27"></td>
+                      <td class="doc_18_s56"></td>
                       <td class="doc_18_s7" colspan="6">工 事 内 容</td>
                       <td class="doc_18_s20" colspan="9">
                         <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_details %>
@@ -1161,7 +1175,7 @@
                       <td class="doc_18_s34"></td>
                       <td class="doc_18_s34"></td>
                       <td class="doc_18_s2"></td>
-                      <td class="doc_18_s27"></td>
+                      <td class="doc_18_s56"></td>
                       <td class="doc_18_s7" colspan="7">元方安全衛生管理者</td>
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s32"></td>
@@ -1496,7 +1510,16 @@
                       <td class="doc_18_s6"></td>
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s0"></td>
-                      <td class="doc_18_s55" dir="ltr" colspan="7">
+                      <% if i == 0 %>
+                        <td class="doc_18_s55" dir="ltr" colspan="7">
+                          <%= f.text_field name = 'content[secretary_name]', placeholder: Document.human_attribute_name(:secretary_name),
+                                          value: @document.content&.[]('secretary_name'),
+                                          class: "form-control form-control-sm"
+                          %>
+                        </td>
+                      <% else %>
+                        <td class="doc_18_s22" dir="ltr" colspan="7">同上</td>
+                      <% end %>
                       </td><!--「書記名」18-018-->
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s32"></td>
@@ -1504,25 +1527,33 @@
                       <td class="doc_18_s0"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                     </tr>
@@ -1532,7 +1563,12 @@
                       </th>
                       <td class="doc_18_s0"></td>
                       <td class="doc_18_s7" colspan="8" rowspan="2">副 会 長</td>
-                      <td class="doc_18_s55" dir="ltr" colspan="9">
+                      <% if i == 0 %>
+                        <td class="doc_18_s55" dir="ltr" colspan="9">
+                          <%= f.select 'content[vice_president_company_name]', primary_subcon_business_name, { include_blank: Document.human_attribute_name(:vice_president_company_name)}, { class: 'form-control form-control-sm', required: true } %></td>
+                      <% else %>
+                        <td class="doc_18_s22" dir="ltr" colspan="9">同上</td>
+                      <% end %>
                       </td><!--「副会長・会社名」18-015-->
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s2"></td>
@@ -1546,7 +1582,7 @@
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s32"></td>
                       <td class="doc_18_s26"></td>
-                      <td class="doc_18_s27"></td>
+                      <td class="doc_18_s56"></td>
                       <td class="doc_18_s7" colspan="6">工 事 内 容</td>
                       <td class="doc_18_s20" colspan="9">
                         <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.construction_details %>
@@ -1576,7 +1612,16 @@
                         <div class="row-header-wrapper" style="line-height: 27px"></div>
                       </th>
                       <td class="doc_18_s0"></td>
-                      <td class="doc_18_s55" dir="ltr" colspan="9">
+                      <% if i == 0 %>
+                        <td class="doc_18_s55" dir="ltr" colspan="9">
+                          <%= f.text_field name = 'content[vice_president_name]', placeholder: Document.human_attribute_name(:vice_president_name),
+                                          value: @document.content&.[]('vice_president_name'),
+                                          class: "form-control form-control-sm"
+                          %>
+                        </td>
+                      <% else %>
+                        <td class="doc_18_s22" dir="ltr" colspan="9">同上</td>
+                      <% end %>
                       </td><!--「副会長名」18-016-->
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s2"></td>
@@ -2295,25 +2340,33 @@
                       <td class="doc_18_s0"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                     </tr>
@@ -2351,7 +2404,7 @@
                       <td class="doc_18_s2"></td>
                       <td class="doc_18_s32"></td>
                       <td class="doc_18_s26"></td>
-                      <td class="doc_18_s27"></td>
+                      <td class="doc_18_s56"></td>
                       <td class="doc_18_s7" colspan="6">工 事 内 容</td>
                       <td class="doc_18_s20" colspan="9">
                         <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.construction_details %>
@@ -3115,25 +3168,33 @@
                       <td class="doc_18_s0"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                       <td class="doc_18_s30"></td>
                       <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                       <td class="doc_18_s20" colspan="9">
-                        <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                        <% request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                          <%= BusinessIndustry.find(id).construction_license_number %><br>
+                        <% end %>
                       </td>
                       <td class="doc_18_s4"></td>
                     </tr>

--- a/app/views/users/documents/doc_18th/_show.html.erb
+++ b/app/views/users/documents/doc_18th/_show.html.erb
@@ -231,7 +231,9 @@
                     <div class="row-header-wrapper" style="line-height: 19px"></div>
                   </th>
                   <td class="doc_18_s2"></td>
-                  <td class="doc_18_s5" colspan="103">工事作業所災害防止協議会兼施工体系図</td>
+                  <td class="doc_18_s57" colspan="20">※ 緑枠は入力項目です。必要あれば入力してください。</td>
+                  <td class="doc_18_s5" colspan="63">工事作業所災害防止協議会兼施工体系図</td>
+                  <td class="doc_18_s4" colspan="20"></td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s4"></td>
                 </tr>
@@ -790,25 +792,33 @@
                   <td class="doc_18_s24"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s17" dir="ltr" colspan="9">
-                    <%= provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                    <% provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s14"></td>
                   <td class="doc_18_s18"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                    <% provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s14"></td>
                   <td class="doc_18_s18"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                    <% provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s14"></td>
                   <td class="doc_18_s18"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                    <% request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                 </tr>
@@ -833,13 +843,13 @@
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s26"></td>
-                  <td class="doc_18_s27"></td>
+                  <td class="doc_18_s56"></td>
                   <td class="doc_18_s7" colspan="6">工 事 内 容</td>
                   <td class="doc_18_s17" dir="ltr" colspan="9">
                     <%= provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_details %>
                   </td>
                   <td class="doc_18_s26"></td>
-                  <td class="doc_18_s27"></td>
+                  <td class="doc_18_s56"></td>
                   <td class="doc_18_s7" colspan="6">工 事 内 容</td>
                   <td class="doc_18_s20" colspan="9">
                     <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_details %>
@@ -1153,7 +1163,7 @@
                   <td class="doc_18_s34"></td>
                   <td class="doc_18_s34"></td>
                   <td class="doc_18_s2"></td>
-                  <td class="doc_18_s27"></td>
+                  <td class="doc_18_s56"></td>
                   <td class="doc_18_s7" colspan="7">元方安全衛生管理者</td>
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s32"></td>
@@ -1489,6 +1499,7 @@
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s55" dir="ltr" colspan="7">
+                    <%= @document.content&.[]('secretary_name') %>
                   </td><!--「書記名」18-018-->
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s32"></td>
@@ -1496,25 +1507,33 @@
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                 </tr>
@@ -1525,6 +1544,7 @@
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s7" colspan="8" rowspan="2">副 会 長</td>
                   <td class="doc_18_s55" dir="ltr" colspan="9">
+                    <%= @document.content&.[]('vice_president_company_name') %>
                   </td><!--「副会長・会社名」18-015-->
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s2"></td>
@@ -1538,7 +1558,7 @@
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s32"></td>
                   <td class="doc_18_s26"></td>
-                  <td class="doc_18_s27"></td>
+                  <td class="doc_18_s56"></td>
                   <td class="doc_18_s7" colspan="6">工 事 内 容</td>
                   <td class="doc_18_s20" colspan="9">
                     <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.construction_details %>
@@ -1569,6 +1589,7 @@
                   </th>
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s55" dir="ltr" colspan="9">
+                    <%= @document.content&.[]('vice_president_name') %>
                   </td><!--「副会長名」18-016-->
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s2"></td>
@@ -2287,25 +2308,33 @@
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                 </tr>
@@ -2343,7 +2372,7 @@
                   <td class="doc_18_s2"></td>
                   <td class="doc_18_s32"></td>
                   <td class="doc_18_s26"></td>
-                  <td class="doc_18_s27"></td>
+                  <td class="doc_18_s56"></td>
                   <td class="doc_18_s7" colspan="6">工 事 内 容</td>
                   <td class="doc_18_s20" colspan="9">
                     <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.construction_details %>
@@ -3107,25 +3136,33 @@
                   <td class="doc_18_s0"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                   <td class="doc_18_s30"></td>
                   <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                   <td class="doc_18_s20" colspan="9">
-                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                    <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                      <%= BusinessIndustry.find(id).construction_license_number %><br>
+                    <% end %>
                   </td>
                   <td class="doc_18_s4"></td>
                 </tr>

--- a/app/views/users/documents/doc_18th/_show.pdf.erb
+++ b/app/views/users/documents/doc_18th/_show.pdf.erb
@@ -797,25 +797,33 @@
                     <td class="doc_18_s24"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s17" colspan="11">
-                      <%= provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                      <% provisional_primary_subcon_info(instance_variable_get("@primary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s14"></td>
                     <td class="doc_18_s18"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                      <% provisional_secondary_subcon_info(instance_variable_get("@secondary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s14"></td>
                     <td class="doc_18_s18"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                      <% provisional_tertiary_subcon_info(instance_variable_get("@tertiary_subcon_id_18th_#{1+4*(i)}"),instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s14"></td>
                     <td class="doc_18_s18"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license %>
+                      <% request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{1+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                   </tr>
@@ -1497,6 +1505,7 @@
                     <td class="doc_18_s2"></td>
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s10" dir="ltr" colspan="7">
+                      <%= @document.content&.[]('secretary_name') %>
                     </td><!--「書記名」18-018-->
                     <td class="doc_18_s2"></td>
                     <td class="doc_18_s32"></td>
@@ -1504,25 +1513,33 @@
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="11">
-                      <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{2+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                   </tr>
@@ -1533,6 +1550,7 @@
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s7" colspan="8" rowspan="2">副 会 長</td>
                     <td class="doc_18_s8" dir="ltr" colspan="9">
+                      <%= @document.content&.[]('vice_president_company_name') %>
                     </td><!--「副会長・会社名」18-015-->
                     <td class="doc_18_s2"></td>
                     <td class="doc_18_s2"></td>
@@ -1577,6 +1595,7 @@
                     </th>
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s8" dir="ltr" colspan="9">
+                      <%= @document.content&.[]('vice_president_name') %>
                     </td><!--「副会長名」18-016-->
                     <td class="doc_18_s2"></td>
                     <td class="doc_18_s2"></td>
@@ -2296,25 +2315,33 @@
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="11">
-                      <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{3+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                   </tr>
@@ -3117,25 +3144,33 @@
                     <td class="doc_18_s0"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="11">
-                      <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@primary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@secondary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@tertiary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                     <td class="doc_18_s30"></td>
                     <td class="doc_18_s7" colspan="6">建設業許可番号</td>
                     <td class="doc_18_s20" colspan="10">
-                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.construction_license %>
+                      <%= request_order_info(instance_variable_get("@quaternary_subcon_id_18th_#{4+4*(i)}"))&.construction_license&.each do |id| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><br>
+                      <% end %>
                     </td>
                     <td class="doc_18_s4"></td>
                   </tr>

--- a/app/views/users/orders/_form.html.erb
+++ b/app/views/users/orders/_form.html.erb
@@ -12,6 +12,7 @@
     <%= f.text_field :site_name, class: "form-control", maxlength: 100 %>
     <br>
     <%= f.label :site_address %> <!-- 施工場所住所 -->
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.text_field :site_address, class: "form-control", maxlength: 50 %>
     <br>
   </div>
@@ -216,7 +217,7 @@
     <%= f.label :submission_destination %> <!-- 提出先及び担当者名 -->
     <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= f.select :submission_destination, @business_workers_name.uniq,
-                  {},
+                  { include_blank: true },
                   { class: "form-select form-select-sm", style: "width: 100%" }
     %><br>
   </div>
@@ -228,7 +229,7 @@
         <% @business_construction_licenses.each do |id, license| %>
           <% industry = BusinessIndustry.find(id) %>
           <div class="form-check">
-            <%= f.check_box :construction_license, { multiple: true, checked: (@order.construction_license.present? && @order.construction_license.include?(id.to_s)) }, id, nil %>
+            <%= f.check_box :construction_license, { multiple: true, checked: (@order.construction_license.present? && @order.construction_license&.include?(id.to_s)) }, id, nil %>
             <%= f.label industry.construction_license_number %>
           </div>
         <% end %>

--- a/app/views/users/orders/show.html.erb
+++ b/app/views/users/orders/show.html.erb
@@ -195,8 +195,10 @@
         <tr>
           <th><%= Order.human_attribute_name(:construction_license) %></th> <!-- 工場に必要な建設許可証 -->
           <td>
-            <% @order.construction_license.each_with_index do |id, index| %>
-              <%= BusinessIndustry.find(id).construction_license_number %><%= ',' unless index == @order.construction_license.size - 1 %>
+            <% if @order.construction_license.present? %>
+              <% @order.construction_license.each_with_index do |id, index| %>
+                <%= BusinessIndustry.find(id).construction_license_number %><%= ',' unless index == @order.construction_license.size - 1 %>
+              <% end %>
             <% end %>
           </td>
         </tr>

--- a/app/views/users/request_orders/_form.html.erb
+++ b/app/views/users/request_orders/_form.html.erb
@@ -196,7 +196,7 @@
           <% @business_construction_licenses.each do |id, license| %>
             <% industry = BusinessIndustry.find(id) %>
             <div class="form-check">
-              <%= f.check_box :construction_license, { multiple: true, checked: (@request_order.construction_license.present? && @request_order.construction_license.include?(id.to_s)) }, id, nil %>
+              <%= f.check_box :construction_license, { multiple: true, checked: (@request_order.construction_license.present? && @request_order.construction_license&.include?(id.to_s)) }, id, nil %>
               <%= f.label industry.construction_license_number %>
             </div>
           <% end %>

--- a/app/views/users/request_orders/show.html.erb
+++ b/app/views/users/request_orders/show.html.erb
@@ -211,8 +211,10 @@
                 <tr>
                   <th><%= RequestOrder.human_attribute_name(:construction_license) %></th> <!-- 工場に必要な建設許可証 -->
                   <td>
-                    <% @request_order.construction_license.each_with_index do |id, index| %>
-                      <%= BusinessIndustry.find(id).construction_license_number %><%= ',' unless index == @request_order.construction_license.size - 1 %>
+                    <% if @request_order.construction_license.present? %>
+                      <% @request_order.construction_license.each_with_index do |id, index| %>
+                        <%= BusinessIndustry.find(id).construction_license_number %><%= ',' unless index == @request_order.construction_license.size - 1 %>
+                      <% end %>
                     <% end %>
                   </td>
                 </tr>

--- a/config/locales/model_ja.yml
+++ b/config/locales/model_ja.yml
@@ -275,14 +275,9 @@ ja:
         supervising_engineer_assistant: 監督技術者補佐
         supervising_engineer_assistant_name: 氏名
         supervising_engineer_assistant_qualification: 資格内容
-        # vice_president: 副会長
-        # vice_president_name: 氏名
-        # vice_president_company_name: 会社名
-        # secretary_name: 書記名
         health_and_safety_manager_name: 元方安全衛生管理者名
         submission_destination: 提出先及び担当者名
         construction_license: 工事に必要な建設許可証
-        # status: ステータス
       request_order:
         request_order_infomation: 現場情報
         subcontractor: 下請会社
@@ -401,6 +396,9 @@ ja:
         document_type: 書類項目
         created_on: 書類作成日
         submitted_on: 書類提出日
+        secretary_name: 書記名
+        vice_president_name: 副会長名
+        vice_president_company_name: 副会長会社名
       cover_document:
         business_name: 事業所名
         submitted_on: 書類提出日

--- a/erd.svg
+++ b/erd.svg
@@ -634,89 +634,87 @@
 <!-- m_Worker -->
 <g id="node42" class="node">
 <title>m_Worker</title>
-<path fill="none" stroke="black" d="M1648.5,-1170C1648.5,-1170 1813.5,-1170 1813.5,-1170 1819.5,-1170 1825.5,-1176 1825.5,-1182 1825.5,-1182 1825.5,-1656 1825.5,-1656 1825.5,-1662 1819.5,-1668 1813.5,-1668 1813.5,-1668 1648.5,-1668 1648.5,-1668 1642.5,-1668 1636.5,-1662 1636.5,-1656 1636.5,-1656 1636.5,-1182 1636.5,-1182 1636.5,-1176 1642.5,-1170 1648.5,-1170"/>
-<text text-anchor="start" x="1709.5" y="-1655.2" font-family="Arial Bold" font-size="11.00">Worker</text>
-<polyline fill="none" stroke="black" points="1636.5,-1648 1825.5,-1648 "/>
-<text text-anchor="start" x="1644" y="-1635" font-family="Arial" font-size="10.00">abo_blood_type </text>
-<text text-anchor="start" x="1716" y="-1635" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1644" y="-1622" font-family="Arial" font-size="10.00">birth_day_on </text>
-<text text-anchor="start" x="1703" y="-1622" font-family="Arial Italic" font-size="10.00" fill="#999999">date ∗</text>
-<text text-anchor="start" x="1644" y="-1609" font-family="Arial" font-size="10.00">blank_term </text>
-<text text-anchor="start" x="1696" y="-1609" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1644" y="-1596" font-family="Arial" font-size="10.00">business_id </text>
-<text text-anchor="start" x="1699" y="-1596" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="1644" y="-1583" font-family="Arial" font-size="10.00">career_up_id </text>
-<text text-anchor="start" x="1703" y="-1583" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1644" y="-1570" font-family="Arial" font-size="10.00">confirmed_check </text>
-<text text-anchor="start" x="1722" y="-1570" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
-<text text-anchor="start" x="1644" y="-1557" font-family="Arial" font-size="10.00">confirmed_check_date </text>
-<text text-anchor="start" x="1746" y="-1557" font-family="Arial Italic" font-size="10.00" fill="#999999">date</text>
-<text text-anchor="start" x="1644" y="-1544" font-family="Arial" font-size="10.00">country </text>
-<text text-anchor="start" x="1680" y="-1544" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1531" font-family="Arial" font-size="10.00">created_at </text>
-<text text-anchor="start" x="1693" y="-1531" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime (6,0) ∗</text>
-<text text-anchor="start" x="1644" y="-1518" font-family="Arial" font-size="10.00">email </text>
-<text text-anchor="start" x="1671" y="-1518" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1644" y="-1505" font-family="Arial" font-size="10.00">employment_condition </text>
-<text text-anchor="start" x="1745" y="-1505" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1644" y="-1492" font-family="Arial" font-size="10.00">employment_contract </text>
-<text text-anchor="start" x="1741" y="-1492" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1644" y="-1479" font-family="Arial" font-size="10.00">experience_term_before_hiring </text>
-<text text-anchor="start" x="1780" y="-1479" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1644" y="-1466" font-family="Arial" font-size="10.00">family_address </text>
-<text text-anchor="start" x="1714" y="-1466" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1453" font-family="Arial" font-size="10.00">family_name </text>
-<text text-anchor="start" x="1703" y="-1453" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1440" font-family="Arial" font-size="10.00">family_phone_number </text>
-<text text-anchor="start" x="1743" y="-1440" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1427" font-family="Arial" font-size="10.00">hiring_on </text>
-<text text-anchor="start" x="1687" y="-1427" font-family="Arial Italic" font-size="10.00" fill="#999999">date ∗</text>
-<text text-anchor="start" x="1644" y="-1414" font-family="Arial" font-size="10.00">images </text>
-<text text-anchor="start" x="1679" y="-1414" font-family="Arial Italic" font-size="10.00" fill="#999999">json</text>
-<text text-anchor="start" x="1644" y="-1401" font-family="Arial" font-size="10.00">job_title </text>
-<text text-anchor="start" x="1681" y="-1401" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1388" font-family="Arial" font-size="10.00">maturity_date </text>
-<text text-anchor="start" x="1707" y="-1388" font-family="Arial Italic" font-size="10.00" fill="#999999">date</text>
-<text text-anchor="start" x="1644" y="-1375" font-family="Arial" font-size="10.00">my_address </text>
-<text text-anchor="start" x="1701" y="-1375" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1362" font-family="Arial" font-size="10.00">my_phone_number </text>
-<text text-anchor="start" x="1730" y="-1362" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1349" font-family="Arial" font-size="10.00">name </text>
-<text text-anchor="start" x="1672" y="-1349" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1336" font-family="Arial" font-size="10.00">name_kana </text>
-<text text-anchor="start" x="1698" y="-1336" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1323" font-family="Arial" font-size="10.00">passport_back </text>
-<text text-anchor="start" x="1711" y="-1323" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1644" y="-1310" font-family="Arial" font-size="10.00">passport_front </text>
-<text text-anchor="start" x="1710" y="-1310" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1644" y="-1297" font-family="Arial" font-size="10.00">post_code </text>
-<text text-anchor="start" x="1693" y="-1297" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
-<text text-anchor="start" x="1644" y="-1284" font-family="Arial" font-size="10.00">relationship </text>
-<text text-anchor="start" x="1697" y="-1284" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1644" y="-1271" font-family="Arial" font-size="10.00">residence_card_back </text>
-<text text-anchor="start" x="1740" y="-1271" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1644" y="-1258" font-family="Arial" font-size="10.00">residence_card_front </text>
-<text text-anchor="start" x="1738" y="-1258" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1644" y="-1245" font-family="Arial" font-size="10.00">rh_blood_type </text>
-<text text-anchor="start" x="1708" y="-1245" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1644" y="-1232" font-family="Arial" font-size="10.00">safety_sanitary_education_ids </text>
-<text text-anchor="start" x="1780" y="-1232" font-family="Arial Italic" font-size="10.00" fill="#999999">json</text>
-<text text-anchor="start" x="1644" y="-1219" font-family="Arial" font-size="10.00">sex </text>
-<text text-anchor="start" x="1663" y="-1219" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1644" y="-1206" font-family="Arial" font-size="10.00">status_of_residence </text>
-<text text-anchor="start" x="1735" y="-1206" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
-<text text-anchor="start" x="1644" y="-1193" font-family="Arial" font-size="10.00">updated_at </text>
-<text text-anchor="start" x="1696" y="-1193" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime (6,0) ∗</text>
-<text text-anchor="start" x="1644" y="-1180" font-family="Arial" font-size="10.00">uuid </text>
-<text text-anchor="start" x="1666" y="-1180" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<path fill="none" stroke="black" d="M1648.5,-1176.5C1648.5,-1176.5 1813.5,-1176.5 1813.5,-1176.5 1819.5,-1176.5 1825.5,-1182.5 1825.5,-1188.5 1825.5,-1188.5 1825.5,-1649.5 1825.5,-1649.5 1825.5,-1655.5 1819.5,-1661.5 1813.5,-1661.5 1813.5,-1661.5 1648.5,-1661.5 1648.5,-1661.5 1642.5,-1661.5 1636.5,-1655.5 1636.5,-1649.5 1636.5,-1649.5 1636.5,-1188.5 1636.5,-1188.5 1636.5,-1182.5 1642.5,-1176.5 1648.5,-1176.5"/>
+<text text-anchor="start" x="1709.5" y="-1648.7" font-family="Arial Bold" font-size="11.00">Worker</text>
+<polyline fill="none" stroke="black" points="1636.5,-1641.5 1825.5,-1641.5 "/>
+<text text-anchor="start" x="1644" y="-1628" font-family="Arial" font-size="10.00">abo_blood_type </text>
+<text text-anchor="start" x="1716" y="-1628" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1644" y="-1615" font-family="Arial" font-size="10.00">birth_day_on </text>
+<text text-anchor="start" x="1703" y="-1615" font-family="Arial Italic" font-size="10.00" fill="#999999">date ∗</text>
+<text text-anchor="start" x="1644" y="-1602" font-family="Arial" font-size="10.00">blank_term </text>
+<text text-anchor="start" x="1696" y="-1602" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1644" y="-1589" font-family="Arial" font-size="10.00">business_id </text>
+<text text-anchor="start" x="1699" y="-1589" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="1644" y="-1576" font-family="Arial" font-size="10.00">career_up_id </text>
+<text text-anchor="start" x="1703" y="-1576" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1644" y="-1563" font-family="Arial" font-size="10.00">confirmed_check </text>
+<text text-anchor="start" x="1722" y="-1563" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
+<text text-anchor="start" x="1644" y="-1550" font-family="Arial" font-size="10.00">confirmed_check_date </text>
+<text text-anchor="start" x="1746" y="-1550" font-family="Arial Italic" font-size="10.00" fill="#999999">date</text>
+<text text-anchor="start" x="1644" y="-1537" font-family="Arial" font-size="10.00">country </text>
+<text text-anchor="start" x="1680" y="-1537" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1524" font-family="Arial" font-size="10.00">created_at </text>
+<text text-anchor="start" x="1693" y="-1524" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime (6,0) ∗</text>
+<text text-anchor="start" x="1644" y="-1511" font-family="Arial" font-size="10.00">email </text>
+<text text-anchor="start" x="1671" y="-1511" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1644" y="-1498" font-family="Arial" font-size="10.00">employment_condition </text>
+<text text-anchor="start" x="1745" y="-1498" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1644" y="-1485" font-family="Arial" font-size="10.00">employment_contract </text>
+<text text-anchor="start" x="1741" y="-1485" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1644" y="-1472" font-family="Arial" font-size="10.00">experience_term_before_hiring </text>
+<text text-anchor="start" x="1780" y="-1472" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1644" y="-1459" font-family="Arial" font-size="10.00">family_address </text>
+<text text-anchor="start" x="1714" y="-1459" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1446" font-family="Arial" font-size="10.00">family_name </text>
+<text text-anchor="start" x="1703" y="-1446" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1433" font-family="Arial" font-size="10.00">family_phone_number </text>
+<text text-anchor="start" x="1743" y="-1433" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1420" font-family="Arial" font-size="10.00">hiring_on </text>
+<text text-anchor="start" x="1687" y="-1420" font-family="Arial Italic" font-size="10.00" fill="#999999">date ∗</text>
+<text text-anchor="start" x="1644" y="-1407" font-family="Arial" font-size="10.00">images </text>
+<text text-anchor="start" x="1679" y="-1407" font-family="Arial Italic" font-size="10.00" fill="#999999">json</text>
+<text text-anchor="start" x="1644" y="-1394" font-family="Arial" font-size="10.00">job_title </text>
+<text text-anchor="start" x="1681" y="-1394" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1381" font-family="Arial" font-size="10.00">maturity_date </text>
+<text text-anchor="start" x="1707" y="-1381" font-family="Arial Italic" font-size="10.00" fill="#999999">date</text>
+<text text-anchor="start" x="1644" y="-1368" font-family="Arial" font-size="10.00">my_address </text>
+<text text-anchor="start" x="1701" y="-1368" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1355" font-family="Arial" font-size="10.00">my_phone_number </text>
+<text text-anchor="start" x="1730" y="-1355" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1342" font-family="Arial" font-size="10.00">name </text>
+<text text-anchor="start" x="1672" y="-1342" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1329" font-family="Arial" font-size="10.00">name_kana </text>
+<text text-anchor="start" x="1698" y="-1329" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1316" font-family="Arial" font-size="10.00">passport_back </text>
+<text text-anchor="start" x="1711" y="-1316" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1644" y="-1303" font-family="Arial" font-size="10.00">passport_front </text>
+<text text-anchor="start" x="1710" y="-1303" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1644" y="-1290" font-family="Arial" font-size="10.00">post_code </text>
+<text text-anchor="start" x="1693" y="-1290" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
+<text text-anchor="start" x="1644" y="-1277" font-family="Arial" font-size="10.00">relationship </text>
+<text text-anchor="start" x="1697" y="-1277" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1644" y="-1264" font-family="Arial" font-size="10.00">residence_card_back </text>
+<text text-anchor="start" x="1740" y="-1264" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1644" y="-1251" font-family="Arial" font-size="10.00">residence_card_front </text>
+<text text-anchor="start" x="1738" y="-1251" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1644" y="-1238" font-family="Arial" font-size="10.00">rh_blood_type </text>
+<text text-anchor="start" x="1708" y="-1238" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1644" y="-1225" font-family="Arial" font-size="10.00">sex </text>
+<text text-anchor="start" x="1663" y="-1225" font-family="Arial Italic" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1644" y="-1212" font-family="Arial" font-size="10.00">status_of_residence </text>
+<text text-anchor="start" x="1735" y="-1212" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
+<text text-anchor="start" x="1644" y="-1199" font-family="Arial" font-size="10.00">updated_at </text>
+<text text-anchor="start" x="1696" y="-1199" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime (6,0) ∗</text>
+<text text-anchor="start" x="1644" y="-1186" font-family="Arial" font-size="10.00">uuid </text>
+<text text-anchor="start" x="1666" y="-1186" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
 </g>
 <!-- m_Business&#45;&gt;m_Worker -->
 <g id="edge11" class="edge">
 <title>m_Business&#45;&gt;m_Worker</title>
-<path fill="none" stroke="black" d="M1493.7,-1732.5C1497.07,-1729.57 1500.5,-1726.73 1504,-1724 1546.88,-1690.51 1580.82,-1724.68 1621,-1688 1625.13,-1684.23 1629.11,-1680.28 1632.94,-1676.17"/>
+<path fill="none" stroke="black" d="M1493.7,-1732.5C1497.07,-1729.57 1500.5,-1726.73 1504,-1724 1546.88,-1690.51 1580.82,-1724.68 1621,-1688 1627.06,-1682.46 1632.8,-1676.54 1638.23,-1670.31"/>
 <ellipse fill="none" stroke="black" cx="1491.57" cy="-1734.39" rx="2.4" ry="2.4"/>
-<ellipse fill="black" stroke="black" cx="1638.54" cy="-1669.89" rx="2.4" ry="2.4"/>
-<polygon fill="black" stroke="black" points="1634.52,-1677.56 1636.95,-1671.68 1631.39,-1674.77 1634.52,-1677.56"/>
+<ellipse fill="black" stroke="black" cx="1643.91" cy="-1663.47" rx="2.4" ry="2.4"/>
+<polygon fill="black" stroke="black" points="1640.16,-1671.27 1642.38,-1665.32 1636.93,-1668.59 1640.16,-1671.27"/>
 </g>
 <!-- m_CarInsuranceCompany -->
 <g id="node8" class="node">
@@ -1847,15 +1845,15 @@
 <!-- m_Worker&#45;&gt;m_WorkerInsurance -->
 <g id="edge50" class="edge">
 <title>m_Worker&#45;&gt;m_WorkerInsurance</title>
-<path fill="none" stroke="black" d="M1731,-1164.58C1731,-1090.14 1731,-1013.47 1731,-956.4"/>
-<ellipse fill="none" stroke="black" cx="1731" cy="-1167.23" rx="2.4" ry="2.4"/>
-<ellipse fill="black" stroke="black" cx="1731" cy="-953.69" rx="2.4" ry="2.4"/>
+<path fill="none" stroke="black" d="M1731,-1171.28C1731,-1094.58 1731,-1014.8 1731,-955.97"/>
+<ellipse fill="none" stroke="black" cx="1731" cy="-1174.07" rx="2.4" ry="2.4"/>
+<ellipse fill="black" stroke="black" cx="1731" cy="-953.46" rx="2.4" ry="2.4"/>
 </g>
 <!-- m_Worker&#45;&gt;m_WorkerLicense -->
 <g id="edge51" class="edge">
 <title>m_Worker&#45;&gt;m_WorkerLicense</title>
-<path fill="none" stroke="black" d="M1639.85,-1166.28C1633.96,-1160.43 1627.68,-1154.98 1621,-1150 1491.34,-1053.42 1386.07,-1213.97 1259,-1114 1202.97,-1069.92 1182.92,-987.33 1175.81,-929.5"/>
-<ellipse fill="none" stroke="black" cx="1641.8" cy="-1168.26" rx="2.4" ry="2.4"/>
+<path fill="none" stroke="black" d="M1646.08,-1172.75C1638.43,-1164.42 1630.09,-1156.77 1621,-1150 1491.34,-1053.42 1386.07,-1213.97 1259,-1114 1202.97,-1069.92 1182.92,-987.33 1175.81,-929.5"/>
+<ellipse fill="none" stroke="black" cx="1647.72" cy="-1174.58" rx="2.4" ry="2.4"/>
 <ellipse fill="black" stroke="black" cx="1174.85" cy="-921.03" rx="2.4" ry="2.4"/>
 <polygon fill="black" stroke="black" points="1177.88,-929.15 1175.12,-923.42 1173.71,-929.62 1177.88,-929.15"/>
 </g>
@@ -1887,15 +1885,15 @@
 <!-- m_Worker&#45;&gt;m_WorkerMedical -->
 <g id="edge54" class="edge">
 <title>m_Worker&#45;&gt;m_WorkerMedical</title>
-<path fill="none" stroke="black" d="M1635.67,-1164.84C1629.31,-1147.65 1623.04,-1130.58 1617,-1114 1596.16,-1056.83 1573.23,-992.01 1556,-942.91"/>
-<ellipse fill="none" stroke="black" cx="1636.63" cy="-1167.45" rx="2.4" ry="2.4"/>
+<path fill="none" stroke="black" d="M1638.08,-1171.37C1630.9,-1151.97 1623.81,-1132.67 1617,-1114 1596.16,-1056.83 1573.23,-992.01 1556,-942.91"/>
+<ellipse fill="none" stroke="black" cx="1639.07" cy="-1174.05" rx="2.4" ry="2.4"/>
 <ellipse fill="black" stroke="black" cx="1555.15" cy="-940.47" rx="2.4" ry="2.4"/>
 </g>
 <!-- m_Worker&#45;&gt;m_WorkerSkillTraining -->
 <g id="edge52" class="edge">
 <title>m_Worker&#45;&gt;m_WorkerSkillTraining</title>
-<path fill="none" stroke="black" d="M1638.33,-1166.21C1632.88,-1160.46 1627.11,-1155.03 1621,-1150 1558.04,-1098.11 1502.95,-1167.09 1441,-1114 1386.93,-1067.65 1364.97,-986.32 1356.07,-929.37"/>
-<ellipse fill="none" stroke="black" cx="1640.06" cy="-1168.08" rx="2.4" ry="2.4"/>
+<path fill="none" stroke="black" d="M1643.97,-1172.4C1636.9,-1164.33 1629.25,-1156.8 1621,-1150 1558.04,-1098.11 1502.95,-1167.09 1441,-1114 1386.93,-1067.65 1364.97,-986.32 1356.07,-929.37"/>
+<ellipse fill="none" stroke="black" cx="1645.84" cy="-1174.59" rx="2.4" ry="2.4"/>
 <ellipse fill="black" stroke="black" cx="1354.85" cy="-921.05" rx="2.4" ry="2.4"/>
 <polygon fill="black" stroke="black" points="1358.14,-929.06 1355.2,-923.43 1353.99,-929.67 1358.14,-929.06"/>
 </g>


### PR DESCRIPTION
### 概要
⑱工事作業所災害防止協議会兼施工体系図の内容(現場情報からの移行分、建設許可証および編集画面のレイアウト)修正
現場情報の建設許可証の更新形式の変更およびエラーに対しての対応

### タスク
- [] なし
- [x] あり _([書類作成【(18)全建統一様式第4号(工事作業所災害防止協議会兼施工体系図)】](https://trello.com/c/BouOM51F/298-%E6%9B%B8%E9%A1%9E%E4%BD%9C%E6%88%90%E3%80%9018%E5%85%A8%E5%BB%BA%E7%B5%B1%E4%B8%80%E6%A7%98%E5%BC%8F%E7%AC%AC4%E5%8F%B7%E5%B7%A5%E4%BA%8B%E4%BD%9C%E6%A5%AD%E6%89%80%E7%81%BD%E5%AE%B3%E9%98%B2%E6%AD%A2%E5%8D%94%E8%AD%B0%E4%BC%9A%E5%85%BC%E6%96%BD%E5%B7%A5%E4%BD%93%E7%B3%BB%E5%9B%B3%E3%80%91))_

### 実装内容・手法
⑱工事作業所災害防止協議会兼施工体系図
・ 副会長の名前および会社名、書記名の更新の実装
・ 建設許可証番号の表示の修正
・ 編集画面のレイアウトの修正
現場情報
・ 建設許可証番号をidで保存するように修正
・ ステージング環境のエラーに対しての対応(ぼっち演算子の追加)
・ 岡田さんに指摘された建設許可証番号がない場合のエラーに対してのチェックボックスの修正

### 実装画像などあれば添付する
⑱工事作業所災害防止協議会兼施工体系図の編集画面
<img width="989" alt="編集画面_１ページ目" src="https://user-images.githubusercontent.com/77228994/230804035-cff6d521-4ef9-4415-adee-e5eb4930b797.png">
<img width="989" alt="編集画面_２ページ目" src="https://user-images.githubusercontent.com/77228994/230804055-2b52b47a-3490-4773-810d-7733f3d01deb.png">

⑱工事作業所災害防止協議会兼施工体系図のPDF
[⑱サンプルPDFデータ_20230409.pdf](https://github.com/kensuma-1122/kensuma/files/11186690/PDF._20230409.pdf)
