### PR TITLE
DB関連整備・9.持込機械情報全般見直し・画面等の見直し対応（岡田）

### DIFF
--- a/app/views/users/machines/_form.html.erb
+++ b/app/views/users/machines/_form.html.erb
@@ -1,11 +1,7 @@
 <%= render 'shared/error_massages', object: f.object %>
 
 <%= f.label :name %><span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-<%= f.select :name, { 電動カンナ: '電動カンナ', 電動ドリル: '電動ドリル', 電動丸のこ: '電動丸のこ', グラインダー等: 'グラインダー等', アーク溶接機: 'アーク溶接機', ウインチ: 'ウインチ', 発電機: '発電機',
-                      トランス: 'トランス', コンプレッサー: 'コンプレッサー', 送風機: '送風機', ポンプ類: 'ポンプ類', ミキサー類: 'ミキサー類', コンベヤー: 'コンベヤー',
-                      吹付機: '吹付機', ボーリングマシン: 'ボーリングマシン', 振動コンパクター: '振動コンパクター', バイブレーター: 'バイブレーター', 鉄筋加工機: '鉄筋加工機', 電動チェーンブロック: '電動チェーンブロック' }.uniq,
-                    { include_blank: true, prompt: '選択してください' },
-                    {class: "form-control single-select", style: "100%"} %><br /><br />
+<%= f.text_field :name, class: "form-control", placeholder: Machine.human_attribute_name(:name) %><br />
 
 <%= f.label :standards_performance %><span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
 <%= f.text_field :standards_performance, class: "form-control", placeholder: Machine.human_attribute_name(:standards_performance) %><br>
@@ -25,20 +21,30 @@
                   { include_blank: true, prompt: "選択してください"  },
                   { class: "single-select form-control", style: "100%" }%><br><br>
 
-<div class="field">
-  <%= f.label :inspection_check %><br />
-  <%= collection_check_boxes(:machine, :tag_ids, Tag.where(id: ..18), :id, :name, include_hidden: false) do |t| %>
-    <%= t.label { t.check_box + t.text } %>
-  <% end %>
+<%= f.label :inspection_date %><span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+<%= f.date_field :inspection_date, class: "form-control", placeholder: SpecialVehicle.human_attribute_name(:inspection_date) %><br>
+
+<div class="list-group">
+  <%= f.label :extra_inspection %>
+  <div class="list-group-item">
+    <% i = 1 %>
+    <%= while i <= 6 do %>
+      <%= f.label :"extra_inspection_item#{i}" %><br>
+      <%= f.text_field :"extra_inspection_item#{i}", class: "form-control", placeholder: "※追加の点検事項名称#{i}" %><br>
+      <% i += 1 %>
+    <% end %>
+  </div>
+<div><br>
+<div class="list-group">
+  <div class="field">
+    <%= f.label :inspection_check %><br />
+    <div class="list-group-item">
+      <%= collection_check_boxes(:machine, :tag_ids, Tag.where(id: ..18), :id, :name, include_hidden: false) do |t| %>
+        <%= t.label { t.check_box + t.text } %>
+      <% end %>
+    </div>
+  </div>
 </div><br>
-
-<%= f.label "追加の点検事項" %><br />
-  <% i = 1 %>
-  <%= while i <= 6 do %>
-    <%= f.text_field :"extra_inspection_item#{i}", class: "form-control", placeholder: "※追加の点検事項名称#{i}" %><br>
-    <% i += 1 %>
-<% end %>
-
 <script>
 // hidden
   $(document).ready(function(){
@@ -69,6 +75,9 @@
         },
         "machine[handler]": {
           required: true
+        },
+        "machine[inspection_date]": {
+          required: true
         }
       },
 
@@ -87,6 +96,9 @@
         },
         "machine[handler]": {
           required: "取扱者を入力してください。"
+        },
+        "machine[inspection_date]": {
+          required: "点検年月日を入力してください。"
         }
       },
       errorClass: "input_form_error"

--- a/app/views/users/machines/show.html.erb
+++ b/app/views/users/machines/show.html.erb
@@ -25,21 +25,24 @@
           <td><%= @machine.handler %></td>
         </tr>
         <tr>
+          <th><%= Machine.human_attribute_name(:inspection_date) %></th>
+          <td><%= wareki(@machine.inspection_date) %></td>
+        </tr>
+        <tr>
+          <th><%= Machine.human_attribute_name(:extra_inspection) %></th>
+        </tr>
+        <% @count.times do |k| %>
+        <tr>
+          <th class="text_ind_1"><%= Machine.human_attribute_name(:"extra_inspection_item#{k+1}") %></th>
+          <td>
+            <%= @machine.send("extra_inspection_item#{k+1}") %>
+          </td>
+        </tr>
+        <% end %>
+        <tr>
           <th><%= Machine.human_attribute_name(:inspection_check) %></th>
           <% tag_arrays = Tag.where(id: Machine.find(@machine.id).tag_ids).pluck(:name) %>
           <td><%= tag_arrays.join(' / ') %></td>
-        </tr>
-        <tr>
-          <th><%= Machine.human_attribute_name(:extra_inspection_item1) %></th>
-          <td>
-            <% @count.times do |k| %>
-              <% if @count == k + 1 %>
-                <%= @machine.send("extra_inspection_item#{k + 1}") %>
-              <% else %>
-                <%= @machine.send("extra_inspection_item#{k + 1}") + " / " %>
-              <% end %>
-            <% end %>
-          </td>
         </tr>
       </tbody>
     </table>

--- a/config/locales/model_ja.yml
+++ b/config/locales/model_ja.yml
@@ -426,8 +426,14 @@ ja:
         inspector: 点検者
         handler: 取扱者
         inspection_date: 点検年月日
-        inspection_check: 点検事項
-        extra_inspection_item1: 追加の点検事項
+        inspection_check: 持込時の点検表
+        extra_inspection: 点検追加項目
+        extra_inspection_item1: 追加項目①
+        extra_inspection_item2: 追加項目②
+        extra_inspection_item3: 追加項目③
+        extra_inspection_item4: 追加項目④
+        extra_inspection_item5: 追加項目⑤
+        extra_inspection_item6: 追加項目⑥
       tag:
         name: 点検事項の名称
   attributes:

--- a/db/migrate/20230117061928_remove_inspection_date_from_machines.rb
+++ b/db/migrate/20230117061928_remove_inspection_date_from_machines.rb
@@ -1,5 +1,0 @@
-class RemoveInspectionDateFromMachines < ActiveRecord::Migration[6.1]
-  def change
-    remove_column :machines, :inspection_date, :date, null: false
-  end
-end


### PR DESCRIPTION
### 概要
_持込機械情報のDB・フォーム修正_

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
_持込機械情のDB・フォーム修正しました。_


