### PR TITLE
書類情報の残タスク（書類No-24自動入力/No-5建設許可証の反映等）（森本）

### DIFF
--- a/app/controllers/users/request_orders/field_special_vehicles_controller.rb
+++ b/app/controllers/users/request_orders/field_special_vehicles_controller.rb
@@ -76,14 +76,10 @@ module Users::RequestOrders
       if worker.present?
         skill_tr_table = worker.skill_trainings.where(driving_related: 1).pluck(:name)
         sp_education_table = worker.special_educations.where(driving_related: 1).pluck(:name)
-        dr_license_table = ['大型免許', '中型免許', '中型免許(8t)に限る', '準中型免許',
-                            '普通免許', '大型特殊免許', '大型二輪免許', '普通二輪免許',
-                            '小型特殊免許', '原付免許', '牽引自動車第一種運転免許']
-        tem_table = skill_tr_table + sp_education_table + dr_license_table
-      else
-        tem_table = License.all.pluck(:name)
+        dr_license_table = worker.driver_licence.split(' ')
+        driver_table = skill_tr_table + sp_education_table + dr_license_table
       end
-      render partial: 'dr-license-select', locals: { dr_licenses: tem_table }
+      render partial: 'dr-license-select', locals: { dr_licenses: driver_table }
     end
 
     private

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1475,18 +1475,16 @@ module DocumentsHelper
   # 下請発注情報詳細画面
   
   # 現場情報-特殊車両-資格内容
-  def target_license(vehicle_info)
-      worker = Worker.find_by(id: vehicle_info.driver_worker_id)
+  def target_license(worker_id)
+      worker = Worker.find_by(id: worker_id)
     if worker.present?
       skill_tr_table = worker.skill_trainings.where(driving_related: 1)
       sp_education_table = worker.special_educations.where(driving_related: 1)
-      dr_license_table = ["大型免許", "中型免許", "中型免許(8t)に限る", "準中型免許",
-                            "普通免許", "大型特殊免許", "大型二輪免許", "普通二輪免許",
-                            "小型特殊免許", "原付免許", "牽引自動車第一種運転免許"]
+      dr_license_table = worker.driver_licence&.split(" ")
       tem_table = skill_tr_table + sp_education_table
-      tem_table = tem_table.pluck(:name) + dr_license_table
+      tem_table.pluck(:name) + dr_license_table
     else
-      License.all.pluck(:name)
+      "作業員を選択してください。"
     end
   end
   

--- a/app/views/users/documents/doc_13th/_show.html.erb
+++ b/app/views/users/documents/doc_13th/_show.html.erb
@@ -231,7 +231,7 @@
               <td class="doc_13_s6" style="font-size: 100px;" rowspan="5">［ </td>
               <td class="doc_13_s6"></td>
               <td class="doc_13_s14" colspan="9" rowspan="2">
-                <%= vehicle_type_crane(field_special_vehicle.vehicle_type) %> <!-- 13-002 移動式クレーンor車両系建設機械 -->
+                <%= vehicle_type_crane(field_special_vehicle.content&.[]('vehicle_type')) %> <!-- 13-002 移動式クレーンor車両系建設機械 -->
               </td>
               <td class="doc_13_s15" colspan="2" rowspan="4" style="background-color: #e9ecef;">等</td>
               <td class="doc_13_s6" style="font-size: 100px;" rowspan="5">］</td>
@@ -315,7 +315,7 @@
               <td class="doc_13_s19"></td>
               <td class="doc_13_s6"></td>
               <td class="doc_13_s14" colspan="9" rowspan="2">
-                <%= vehicle_type_construction(field_special_vehicle.vehicle_type) %> <!-- 13-002 移動式クレーンor車両系建設機械 -->
+                <%= vehicle_type_construction(field_special_vehicle.content&.[]('vehicle_type')) %> <!-- 13-002 移動式クレーンor車両系建設機械 -->
               </td>
               <td class="doc_13_s2"></td>
               <td class="doc_13_s3"></td>
@@ -329,10 +329,10 @@
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s23" dir="ltr" colspan="14" rowspan="3" style="border-left: 1px solid #000;">
-                <%= field_special_vehicle.owning_company_name %> <!-- 13-101 所有会社名 -->
+                <%= field_special_vehicle.content&.[]('owning_company_name') %> <!-- 13-101 所有会社名 -->
               </td>
               <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3">
-                <%= field_special_vehicle.owning_company_representative_name %> <!-- 13-102 所有会社の代表者名 -->
+                <%= @current_business.representative_name %> <!-- 13-102 所有会社の代表者名 -->
               </td>
               <td class="doc_13_s24" dir="ltr" colspan="2" rowspan="3">
                 ㊞ <!-- 13-261 印 -->
@@ -1415,7 +1415,7 @@
                 <%= field_special_vehicle.driver_name %> <!-- 13-021 入場する作業員名(運転者名・正) -->
               </td>
               <td class="doc_13_s23" dir="ltr" colspan="19" rowspan="2">
-                <%= field_special_vehicle.driver_license.split[0][0..20] if field_special_vehicle.driver_license %>　<!-- 13-022 資格の種類 --> 
+                <%= field_special_vehicle.driver_licenses&.shift && field_special_vehicle.driver_licenses&.join(", ") if field_special_vehicle.driver_licenses %>　<!-- 13-022 資格の種類 --> 
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s35"></td>
@@ -1474,7 +1474,7 @@
                 <%= field_special_vehicle.sub_driver_name %> <!-- 13-023 入場する作業員名(運転者名・副) -->
               </td>
               <td class="doc_13_s23" dir="ltr" colspan="19" rowspan="2">
-                <%= field_special_vehicle.sub_driver_license.split[0][0..20] if field_special_vehicle.sub_driver_license %>　<!-- 13-024 資格の種類 --> 
+                <%= field_special_vehicle.sub_driver_licenses&.shift && field_special_vehicle.sub_driver_licenses&.join(", ") if field_special_vehicle.sub_driver_licenses %>　<!-- 13-024 資格の種類 --> 
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s35"></td>

--- a/app/views/users/documents/doc_13th/_show.pdf.erb
+++ b/app/views/users/documents/doc_13th/_show.pdf.erb
@@ -232,7 +232,7 @@
             <td class="s6" style="font-size: 90px;" rowspan="5">［</td>
             <td class="s6"></td>
             <td class="s14" colspan="9" rowspan="2" style="border-bottom: 1px SOLID #ffffff;">
-              <%= vehicle_type_crane(field_special_vehicle.vehicle_type) %> <!-- 13-002 移動式クレーンor車両系建設機械 -->
+              <%= vehicle_type_crane(field_special_vehicle.content&.[]('vehicle_type')) %> <!-- 13-002 移動式クレーンor車両系建設機械 -->
             </td>
             <td class="s15" colspan="2" rowspan="4">　等</td>
             <td class="s6" style="font-size: 90px;" rowspan="5">］</td>
@@ -316,7 +316,7 @@
             <td class="s19"></td>
             <td class="s6"></td>
             <td class="s14" colspan="9" rowspan="2">
-              <%= vehicle_type_construction(field_special_vehicle.vehicle_type) %> <!-- 13-002 移動式クレーンor車両系建設機械 -->
+              <%= vehicle_type_construction(field_special_vehicle.content&.[]('vehicle_type')) %> <!-- 13-002 移動式クレーンor車両系建設機械 -->
             </td>
             <td class="s2"></td>
             <td class="s3"></td>
@@ -330,10 +330,10 @@
             <td class="s4"></td>
             <td class="s4" style="border-right: 1px solid #000;"></td>
             <td class="s23" dir="ltr" colspan="14" rowspan="3">
-              <%= field_special_vehicle.owning_company_name %> <!-- 13-101 所有会社名 -->
+              <%= field_special_vehicle.content&.[]('owning_company_name') %> <!-- 13-101 所有会社名 -->
             </td>
             <td class="s23" dir="ltr" colspan="12" rowspan="3">
-              <%= field_special_vehicle.owning_company_representative_name %>　<!-- 13-102 所有会社の代表者名 -->
+              <%= @current_business.representative_name %>　<!-- 13-102 所有会社の代表者名 -->
             </td>
             <td class="s24" dir="ltr" colspan="2" rowspan="3">
               印 <!-- 13-261 印 -->
@@ -1417,7 +1417,7 @@
               <%= field_special_vehicle.driver_name %> <!-- 13-021 入場する作業員名(運転者名・正) -->
             </td>
             <td class="s23" dir="ltr" colspan="19" rowspan="2">
-              <%= field_special_vehicle.driver_license.split[0][0..20] if field_special_vehicle.driver_license %>　<!-- 13-022 資格の種類 --> 
+              <%= field_special_vehicle.driver_licenses&.shift && field_special_vehicle.driver_licenses&.join(", ") if field_special_vehicle.driver_licenses %>　<!-- 13-022 資格の種類 --> 
             </td>
             <td class="s4"></td>
             <td class="s35"></td>
@@ -1476,7 +1476,7 @@
               <%= field_special_vehicle.sub_driver_name %> <!-- 13-023 入場する作業員名(運転者名・副) -->
             </td>
             <td class="s23" dir="ltr" colspan="19" rowspan="2">
-              <%= field_special_vehicle.sub_driver_license.split[0][0..20] if field_special_vehicle.sub_driver_license %>　<!-- 13-024 資格の種類 --> 
+              <%= field_special_vehicle.sub_driver_licenses&.shift && field_special_vehicle.sub_driver_licenses&.join(", ") if field_special_vehicle.sub_driver_licenses %>　<!-- 13-024 資格の種類 --> 
             </td>
             <td class="s4"></td>
             <td class="s35"></td>

--- a/app/views/users/documents/doc_5th/_form.html.erb
+++ b/app/views/users/documents/doc_5th/_form.html.erb
@@ -908,22 +908,15 @@
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
-            <td class="s_5b_205" dir="ltr" colspan="11" rowspan="4">
-              <%= child_check(@child) == "FALSE" ? "" : Industry.find(Business.find(@child.business_id).industry_ids.join("','")).name.delete("工事業") %> <!-- 5-112 各会社の建設許可業種 -->
-            </td>
+            <td class="s_5b_205" dir="ltr" colspan="10" rowspan="4"><%= constr_license_info(1, @child, "industry_name") %></td>
             <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
-            <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("大臣", @child) %></td>
-            <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("特定", @child) %></td>
-            <td class="s_5b_211" dir="ltr" colspan="2" rowspan="4"><%#= @child&.content&.[]('subcon_construction_construction_license_number_double_digit') %></td>
+            <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(1, "大臣", @child) %></td>
+            <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(1, "特定", @child) %></td>
+            <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= constr_license_info(1, @child, "number_double_digit") %></td>
             <td class="s_5b_216" dir="ltr" colspan="2" rowspan="4">第</td>
-            <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4">
-              <%= @child&.content&.[]('subcon_construction_license_number_six_digits') %> <!-- 5-115 建設許可番号 -->
-            </td>
+            <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= constr_license_info(1, @child, "number_six_digits") %> <!-- 5-115 建設許可番号 --></td>
             <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
-            <td class="s_5b_214" dir="ltr" colspan="15" rowspan="4">
-              <%= @child&.content&.[]('subcon_construction_license_updated_at') %> <!--5-116 建設許可証更新日(西暦) -->
-            </td>
-          </tr>
+            <td class="s_5b_214" dir="ltr" colspan="15" rowspan="4"><%= constr_license_info(1, @child, "updated_at") %> <!-- 5-116 建設許可証更新日(西暦) --></td>
           <tr><!-- 24行目 -->
             <td class="s_5a_000"></td><!-- 1列目 -->
             <td class="s_5a_000"></td>
@@ -1011,8 +1004,8 @@
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
-            <td class="s_5b_208" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("知事", @child) %></td>
-            <td class="s_5b_210" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("一般", @child) %></td>
+            <td class="s_5b_208" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(1, "知事", @child) %></td>
+            <td class="s_5b_210" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(1, "一般", @child) %></td>
           </tr>
           <tr><!-- 26行目 -->
             <td class="s_5c_00"></td>
@@ -1029,21 +1022,15 @@
             <td class="s_5c_00"></td>
           </tr>
           <tr><!-- 27行目 -->
-            <td class="s_5a_305" dir="ltr" colspan="10" rowspan="4">
-              <%= Industry.find(Business.find(document_info.business_id).industry_ids.join("','")).name.delete("工事業") %> <!-- 5-019 各会社の建設許可業種 -->
-            </td>
+            <td class="s_5a_305" dir="ltr" colspan="10" rowspan="4"><%= constr_license_info(1, document_info, "industry_name") %></td>
             <td class="s_5a_306" dir="ltr" colspan="4" rowspan="4">工事業</td>
-            <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification("大臣", document_info) %></td>
-            <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type("特定", document_info) %></td>
-            <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= document_info&.content&.[]('subcon_construction_construction_license_number_double_digit') %></td>
+            <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(1, "大臣", document_info) %></td>
+            <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(1, "特定", document_info) %></td>
+            <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= constr_license_info(1, document_info, "number_double_digit") %></td>
             <td class="s_5a_316" dir="ltr" colspan="2" rowspan="4">第</td>
-            <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4">
-              <%= document_info&.content&.[]('subcon_construction_license_number_six_digits') %> <!-- 5-022 建設許可番号 -->
-            </td>
+            <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4"><%= constr_license_info(1, document_info, "number_six_digits") %> <!-- 5-022 建設許可番号 --></td>
             <td class="s_5a_313" dir="ltr" colspan="2" rowspan="4">号</td>
-            <td class="s_5a_314" dir="ltr" colspan="15" rowspan="4">
-              <%= document_info&.content&.[]('subcon_construction_license_updated_at') %> <!-- 5-023 建設許可証更新日(西暦) -->
-            </td>
+            <td class="s_5a_314" dir="ltr" colspan="15" rowspan="4"><%= constr_license_info(1, document_info, "updated_at") %> <!-- 5-023 建設許可証更新日(西暦) --></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
@@ -1056,22 +1043,15 @@
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
-            <td class="s_5b_205" dir="ltr" colspan="11" rowspan="4">
-              <%#= child_check(@child) == "FALSE" ? "" : Industry.find(Business.find(@child.business_id).industry_ids.join("','")).name %> <!-- 5-117 各会社の建設許可業種 -->
-            </td>
+            <td class="s_5b_205" dir="ltr" colspan="10" rowspan="4"><%= constr_license_info(2, @child, "industry_name") %></td>
             <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
-            <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("大臣", @child) %></td>
-            <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("特定", @child) %></td>
-            <td class="s_5b_211" dir="ltr" colspan="2" rowspan="4"><%#= @child&.content&.[]('subcon_construction_construction_license_number_double_digit') %></td>
+            <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(2, "大臣", @child) %></td>
+            <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(2, "特定", @child) %></td>
+            <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= constr_license_info(2, @child, "number_double_digit") %></td>
             <td class="s_5b_216" dir="ltr" colspan="2" rowspan="4">第</td>
-            <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4">
-              <%#= @child&.content&.[]('subcon_construction_license_number_six_digits') %> <!--5-120 建設許可番号 -->
-            </td>
+            <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= constr_license_info(2, @child, "number_six_digits") %> <!-- 5-120 建設許可番号 --></td>
             <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
-            <td class="s_5b_214" dir="ltr" colspan="15" rowspan="4">
-              <%#= @child&.content&.[]('subcon_construction_license_updated_at') %> <!-- 5-121 建設許可証更新日(西暦) -->
-            </td>
-          </tr>
+            <td class="s_5b_214" dir="ltr" colspan="15" rowspan="4"><%= constr_license_info(2, @child, "updated_at") %> <!-- 5-121 建設許可証更新日(西暦) --></td>
           <tr><!-- 28行目 -->
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
@@ -1087,8 +1067,8 @@
             <td class="s_5c_00"></td>
           </tr>
           <tr><!-- 29行目 -->
-            <td class="s_5a_308" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification("知事", document_info) %></td>
-            <td class="s_5a_310" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type("一般", document_info) %></td>
+            <td class="s_5a_308" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(1, "知事", document_info) %></td>
+            <td class="s_5a_310" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(1, "一般", document_info) %></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
@@ -1101,8 +1081,8 @@
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
-            <td class="s_5b_208" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("知事", @child) %></td>
-            <td class="s_5b_210" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("一般", @child) %></td>
+            <td class="s_5b_208" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(2, "知事", @child) %></td>
+            <td class="s_5b_210" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(2, "一般", @child) %></td>
           </tr>
           <tr><!-- 30行目 -->
             <td class="s_5c_00"></td>
@@ -1119,21 +1099,15 @@
             <td class="s_5c_00"></td>
           </tr>
           <tr><!-- 31行目 -->
-            <td class="s_5a_305" dir="ltr" colspan="10" rowspan="4">
-              <%#= Industry.find(Business.find(document_info.business_id).industry_ids.join("','")).name %> <!-- 5-024 各会社の建設許可業種 -->
-            </td>
+            <td class="s_5a_305" dir="ltr" colspan="10" rowspan="4"><%= constr_license_info(2, document_info, "industry_name") %></td>
             <td class="s_5a_306" dir="ltr" colspan="4" rowspan="4">工事業</td>
-            <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("大臣", document_info) %></td>
-            <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("特定", document_info) %></td>
-            <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%#= document_info&.content&.[]('subcon_construction_construction_license_number_double_digit') %></td>
+            <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(2, "大臣", document_info) %></td>
+            <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(2, "特定", document_info) %></td>
+            <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= constr_license_info(2, document_info, "number_double_digit") %></td>
             <td class="s_5a_316" dir="ltr" colspan="2" rowspan="4">第</td>
-            <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4">
-              <%#= document_info&.content&.[]('subcon_construction_license_number_six_digits') %> <!-- 5-027 建設許可番号 -->
-            </td>
+            <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4"><%= constr_license_info(2, document_info, "number_six_digits") %> <!-- 5-027 建設許可番号 --></td>
             <td class="s_5a_313" dir="ltr" colspan="2" rowspan="4">号</td>
-            <td class="s_5a_314" dir="ltr" colspan="15" rowspan="4">
-              <%#= document_info&.content&.[]('subcon_construction_license_updated_at') %> <!-- 5-028 建設許可証更新日(西暦) -->
-            </td>
+            <td class="s_5a_314" dir="ltr" colspan="15" rowspan="4"><%= constr_license_info(2, document_info, "updated_at") %> <!-- 5-028 建設許可証更新日(西暦) --></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
@@ -1204,8 +1178,8 @@
             </td>
           </tr>
           <tr><!-- 33行目 -->
-            <td class="s_5a_308" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("知事", document_info) %></td>
-            <td class="s_5a_310" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("一般", document_info) %></td>
+            <td class="s_5a_308" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(2, "知事", document_info) %></td>
+            <td class="s_5a_310" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(2, "一般", document_info) %></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>
@@ -1355,7 +1329,7 @@
             <td class="s_5b_000"></td><!-- 70列目 -->
             <td class="s_5b_303" dir="ltr" colspan="10" rowspan="3">雇用管理責任者名</td>
             <td class="s_5b_302" dir="ltr" colspan="16" rowspan="3">
-              <%= @child&.content&.[]('subcon_employment_manager_name') %> <!-- 5-129 各会社の雇用管理責任者名 -->
+              <%= Business.find(@child.business_id).employment_manager_name %> <!-- 5-129 各会社の雇用管理責任者名 -->
             </td>
           </tr>
           <tr><!-- 39行目 -->
@@ -1430,7 +1404,7 @@
             <td class="s_5a_000"></td>
             <td class="s_5a_403" dir="ltr" colspan="10" rowspan="3">雇用管理責任者名</td>
             <td class="s_5a_402" dir="ltr" colspan="16" rowspan="3">
-              <%= document_info&.content&.[]('subcon_employment_manager_name') %> <!-- 5-038 各会社の雇用管理責任者名 -->
+              <%= @current_business.employment_manager_name %> <!-- 5-038 各会社の雇用管理責任者名 -->
             </td><!-- 30列目 -->
             <td class="s_5c_00"></td>
             <td class="s_5c_00"></td>

--- a/app/views/users/documents/doc_5th/_form.pdf.erb
+++ b/app/views/users/documents/doc_5th/_form.pdf.erb
@@ -915,22 +915,15 @@
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
-                <td class="s_5b_205" dir="ltr" colspan="11" rowspan="4">
-                  <%= child_check(@child) == "FALSE" ? "" : Industry.find(Business.find(@child.business_id).industry_ids.join("','")).name.delete("工事業") %> <!-- 5-112 各会社の建設許可業種 -->
-                </td>
+                <td class="s_5b_205" dir="ltr" colspan="10" rowspan="4"><%= constr_license_info(1, @child, "industry_name") %></td>
                 <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
-                <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("大臣", @child) %></td>
-                <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("特定", @child) %></td>
-                <td class="s_5b_211" dir="ltr" colspan="2" rowspan="4"><%#= @child&.content&.[]('subcon_construction_construction_license_number_double_digit') %></td>
+                <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(1, "大臣", @child) %></td>
+                <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(1, "特定", @child) %></td>
+                <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= constr_license_info(1, @child, "number_double_digit") %></td>
                 <td class="s_5b_212" dir="ltr" colspan="2" rowspan="4">第</td>
-                <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4">
-                  <%#= @child&.content&.[]('subcon_construction_license_number_six_digits') %> <!-- 5-115 建設許可番号 -->
-                </td>
+                <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= constr_license_info(1, @child, "number_six_digits") %> <!-- 5-145 建設許可番号 --></td>
                 <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
-                <td class="s_5b_214" dir="ltr" colspan="15" rowspan="4">
-                  <%#= @child&.content&.[]('subcon_construction_license_updated_at') %> <!--5-116 建設許可証更新日(西暦) -->
-                </td>
-              </tr>
+                <td class="s_5b_214" dir="ltr" colspan="15" rowspan="4"><%= constr_license_info(1, @child, "updated_at") %> <!-- 5-115 建設許可証更新日(西暦) --></td>
               <tr><!-- 24行目 -->
                 <td class="s_5a_000"></td><!-- 1列目 -->
                 <td class="s_5a_000"></td>
@@ -1018,8 +1011,8 @@
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
-                <td class="s_5b_208" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("知事", @child) %></td>
-                <td class="s_5b_210" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("一般", @child) %></td>
+                <td class="s_5b_208" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(1, "知事", @child) %></td>
+                <td class="s_5b_210" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(1, "一般", @child) %></td>
               </tr>
               <tr><!-- 26行目 -->
                 <td class="s_5c_00"></td>
@@ -1036,21 +1029,15 @@
                 <td class="s_5c_00"></td>
               </tr>
               <tr><!-- 27行目 -->
-              <td class="s_5a_305" dir="ltr" colspan="10" rowspan="4">
-                <%= Industry.find(Business.find(document_info.business_id).industry_ids.join("','")).name.delete("工事業") %> <!-- 5-019 各会社の建設許可業種 -->
-              </td>
-              <td class="s_5a_306" dir="ltr" colspan="4" rowspan="4">工事業</td>
-              <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification("大臣", document_info) %></td>
-              <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type("特定", document_info) %></td>
-              <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%#= document_info&.content&.[]('subcon_construction_construction_license_number_double_digit') %></td>
-              <td class="s_5a_312" dir="ltr" colspan="2" rowspan="4">第</td>
-              <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4">
-                <%#= document_info&.content&.[]('subcon_construction_license_number_six_digits') %> <!-- 5-022 建設許可番号 -->
-              </td>
-              <td class="s_5a_313" dir="ltr" colspan="2" rowspan="4">号</td>
-              <td class="s_5a_314" dir="ltr" colspan="15" rowspan="4">
-                <%#= document_info&.content&.[]('subcon_construction_license_updated_at') %> <!-- 5-023 建設許可証更新日(西暦) -->
-              </td>
+                <td class="s_5a_305" dir="ltr" colspan="10" rowspan="4"><%= constr_license_info(1, document_info, "industry_name") %></td>
+                <td class="s_5a_306" dir="ltr" colspan="4" rowspan="4">工事業</td>
+                <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(1, "大臣", document_info) %></td>
+                <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(1, "特定", document_info) %></td>
+                <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= constr_license_info(1, document_info, "number_double_digit") %></td>
+                <td class="s_5a_312" dir="ltr" colspan="2" rowspan="4">第</td>
+                <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4"><%= constr_license_info(1, document_info, "number_six_digits") %> <!-- 5-022 建設許可番号 --></td>
+                <td class="s_5a_313" dir="ltr" colspan="2" rowspan="4">号</td>
+                <td class="s_5a_314" dir="ltr" colspan="15" rowspan="4"><%= constr_license_info(1, document_info, "updated_at") %> <!-- 5-023 建設許可証更新日(西暦) --></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
@@ -1063,22 +1050,15 @@
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
-                <td class="s_5b_205" dir="ltr" colspan="11" rowspan="4">
-                  <%#= child_check(@child) == "FALSE" ? "" : Industry.find(Business.find(@child.business_id).industry_ids.join("','")).name %> <!-- 5-117 各会社の建設許可業種 -->
-                </td>
+                <td class="s_5b_205" dir="ltr" colspan="10" rowspan="4"><%= constr_license_info(2, @child, "industry_name") %></td>
                 <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
-                <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("大臣", @child) %></td>
-                <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("特定", @child) %></td>
-                <td class="s_5b_211" dir="ltr" colspan="2" rowspan="4"><%#= @child&.content&.[]('subcon_construction_construction_license_number_double_digit') %></td>
+                <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(2, "大臣", @child) %></td>
+                <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(2, "特定", @child) %></td>
+                <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= constr_license_info(2, @child, "number_double_digit") %></td>
                 <td class="s_5b_212" dir="ltr" colspan="2" rowspan="4">第</td>
-                <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4">
-                  <%#= @child&.content&.[]('subcon_construction_license_number_six_digits') %> <!--5-120 建設許可番号 -->
-                </td>
+                <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= constr_license_info(2, @child, "number_six_digits") %> <!-- 5-146 建設許可番号 --></td>
                 <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
-                <td class="s_5b_214" dir="ltr" colspan="15" rowspan="4">
-                  <%#= @child&.content&.[]('subcon_construction_license_updated_at') %> <!-- 5-121 建設許可証更新日(西暦) -->
-                </td>
-              </tr>
+                <td class="s_5b_214" dir="ltr" colspan="15" rowspan="4"><%= constr_license_info(2, @child, "updated_at") %> <!-- 5-120 建設許可証更新日(西暦) --></td>
               <tr><!-- 28行目 -->
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
@@ -1094,8 +1074,8 @@
                 <td class="s_5c_00"></td>
               </tr>
               <tr><!-- 29行目 -->
-                <td class="s_5a_308" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification("知事", document_info) %></td>
-                <td class="s_5a_310" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type("一般", document_info) %></td>
+                <td class="s_5a_308" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(1, "知事", document_info) %></td>
+                <td class="s_5a_310" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(1, "一般", document_info) %></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
@@ -1108,8 +1088,8 @@
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
-                <td class="s_5b_208" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("知事", @child) %></td>
-                <td class="s_5b_210" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("一般", @child) %></td>
+                <td class="s_5b_208" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(2, "知事", @child) %></td>
+                <td class="s_5b_210" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(2, "一般", @child) %></td>
               </tr>
               <tr><!-- 30行目 -->
                 <td class="s_5c_00"></td>
@@ -1126,21 +1106,15 @@
                 <td class="s_5c_00"></td>
               </tr>
               <tr><!-- 31行目 -->
-                <td class="s_5a_305" dir="ltr" colspan="10" rowspan="4">
-                  <%#= Industry.find(Business.find(document_info.business_id).industry_ids.join("','")).name %> <!-- 5-024 各会社の建設許可業種 -->
-                </td>
+                <td class="s_5a_305" dir="ltr" colspan="10" rowspan="4"><%= constr_license_info(2, document_info, "industry_name") %></td>
                 <td class="s_5a_306" dir="ltr" colspan="4" rowspan="4">工事業</td>
-                <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("大臣", document_info) %></td>
-                <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("特定", document_info) %></td>
-                <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%#= document_info&.content&.[]('subcon_construction_construction_license_number_double_digit') %></td>
+                <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(2, "大臣", document_info) %></td>
+                <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(2, "特定", document_info) %></td>
+                <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= constr_license_info(2, document_info, "number_double_digit") %></td>
                 <td class="s_5a_312" dir="ltr" colspan="2" rowspan="4">第</td>
-                <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4">
-                  <%#= document_info&.content&.[]('subcon_construction_license_number_six_digits') %> <!-- 5-027 建設許可番号 -->
-                </td>
+                <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4"><%= constr_license_info(2, document_info, "number_six_digits") %> <!-- 5-027 建設許可番号 --></td>
                 <td class="s_5a_313" dir="ltr" colspan="2" rowspan="4">号</td>
-                <td class="s_5a_314" dir="ltr" colspan="15" rowspan="4">
-                  <%#= document_info&.content&.[]('subcon_construction_license_updated_at') %> <!-- 5-028 建設許可証更新日(西暦) -->
-                </td>
+                <td class="s_5a_314" dir="ltr" colspan="15" rowspan="4"><%= constr_license_info(2, document_info, "updated_at") %> <!-- 5-028 建設許可証更新日(西暦) --></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
@@ -1211,8 +1185,8 @@
                 </td>
               </tr>
               <tr><!-- 33行目 -->
-                <td class="s_5a_308" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_certification("知事", document_info) %></td>
-                <td class="s_5a_310" dir="ltr" colspan="4" rowspan="2"><%#= construction_license_construction_type("一般", document_info) %></td>
+                <td class="s_5a_308" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_certification(2, "知事", document_info) %></td>
+                <td class="s_5a_310" dir="ltr" colspan="4" rowspan="2"><%= construction_license_construction_type(2, "一般", document_info) %></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>
@@ -1362,7 +1336,7 @@
                 <td class="s_5b_000"></td><!-- 70列目 -->
                 <td class="s_5b_303" dir="ltr" colspan="10" rowspan="3">雇用管理責任者名</td>
                 <td class="s_5b_302" dir="ltr" colspan="16" rowspan="3">
-                  <%= @child&.content&.[]('subcon_employment_manager_name') %> <!-- 5-129 各会社の雇用管理責任者名 -->
+                  <%= Business.find(@child.business_id).employment_manager_name %> <!-- 5-129 各会社の雇用管理責任者名 -->
                 </td>
               </tr>
               <tr><!-- 39行目 -->
@@ -1437,7 +1411,7 @@
                 <td class="s_5a_000"></td>
                 <td class="s_5a_403" dir="ltr" colspan="10" rowspan="3">雇用管理責任者名</td>
                 <td class="s_5a_402" dir="ltr" colspan="16" rowspan="3">
-                  <%= document_info&.content&.[]('subcon_employment_manager_name') %> <!-- 5-038 各会社の雇用管理責任者名 -->
+                  <%= @current_business.employment_manager_name %> <!-- 5-038 各会社の雇用管理責任者名 -->
                 </td><!-- 30列目 -->
                 <td class="s_5c_00"></td>
                 <td class="s_5c_00"></td>

--- a/app/views/users/request_orders/field_special_vehicles/edit_special_vehicles.html.erb
+++ b/app/views/users/request_orders/field_special_vehicles/edit_special_vehicles.html.erb
@@ -64,7 +64,7 @@
                     <td>
                       <%= fs.label :driver_licenses %>
                       <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
-                      <%= fs.select :driver_licenses, target_license(field_special_vehicle), { prompt: '選択してください', selected: field_special_vehicle.driver_licenses }, { class: 'form-control select2', id: "driver_license_#{i}", multiple: true, style: "width: 100%" } %>
+                      <%= fs.select :driver_licenses, target_license(field_special_vehicle&.driver_worker_id), { prompt: '選択してください', selected: field_special_vehicle&.driver_licenses }, { class: 'form-control select2', id: "driver_license_#{i}", multiple: true, style: "width: 100%" } %>
                     </td>
                     <td>
                       <%= fs.label :sub_driver_name %>
@@ -74,7 +74,7 @@
                     <td>
                       <%= fs.label :sub_driver_licenses %>
                       <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
-                      <%= fs.select :sub_driver_licenses, target_license(field_special_vehicle), { prompt: '選択してください', selected: field_special_vehicle.sub_driver_licenses }, { class: 'form-control select2', id: "sub_driver_license_#{i}", multiple: true, style: "width: 100%" } %>
+                      <%= fs.select :sub_driver_licenses, target_license(field_special_vehicle&.sub_driver_worker_id), { prompt: '選択してください', selected: field_special_vehicle&.sub_driver_licenses }, { class: 'form-control select2', id: "sub_driver_license_#{i}", multiple: true, style: "width: 100%" } %>
                     </td>
                   </tr>
                   <tr style="border-bottom: 0px #fff;">

--- a/app/views/users/request_orders/field_special_vehicles/index.html.erb
+++ b/app/views/users/request_orders/field_special_vehicles/index.html.erb
@@ -66,7 +66,7 @@
                   </td>
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:driver_licenses) %><br>
-                    <%= not_input_display(field_special_vehicle.driver_licenses.shift && field_special_vehicle.driver_licenses.join(", ")) %>
+                    <%= not_input_display(field_special_vehicle.driver_licenses&.shift && field_special_vehicle.driver_licenses&.join(", ")) %>
                   </td>
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:sub_driver_name) %><br>
@@ -74,7 +74,7 @@
                   </td>
                   <td>
                     <%= FieldSpecialVehicle.human_attribute_name(:sub_driver_licenses) %><br>
-                    <%= not_input_display(field_special_vehicle.sub_driver_licenses.shift && field_special_vehicle.sub_driver_licenses.join(", ")) %>
+                    <%= not_input_display(field_special_vehicle.sub_driver_licenses&.shift && field_special_vehicle.sub_driver_licenses&.join(", ")) %>
                   </td>
                 </tr>
                 <tr style="border: 0px #fff;">

--- a/app/views/users/workers/show.html.erb
+++ b/app/views/users/workers/show.html.erb
@@ -19,7 +19,6 @@
 
         <tr>
           <th><%= Worker.human_attribute_name(:business_owner_or_master) %></th>
-          <% byebug %>
           <td><%= 'はい' if @worker.business_owner_or_master %></td>
           <td></td>
           <td></td>


### PR DESCRIPTION
### 概要
- 24-1 作業員情報「事業主 又は 一人親方ですか？」の自動入力機能
- ⑤再下請負通知書（変更届）内の建設許可証のデータ反映
- ⑬移動式クレーン／車両系建設機械等使用届内の表示エラー
- 作業する中で発見した軽微なエラー（byebugが放置など）

### タスク
- [x] なし

### 実装内容・手法
実装内容を確認し、適切に自タスクへ取込
カラムの追加、ヘルパーメソッドの活用など

### 実装画像などあれば添付する
![24-1 作業員情報「事業主 又は 一人親方ですか？」の自動入力機能](https://user-images.githubusercontent.com/77308890/232465622-3358e963-f1ac-40af-a811-f7f690786fd2.png)

![⑤再下請負通知書（変更届）内の建設許可証のデータ反映](https://user-images.githubusercontent.com/77308890/232465661-a9b158f3-8d74-4a91-b4d7-547c4901e99e.png)

![⑬移動式クレーン／車両系建設機械等使用届内の表示エラー](https://user-images.githubusercontent.com/77308890/232466024-6a05cd03-ba7c-4830-8c1d-4405a5bc648b.png)
