### PR TITLE
書類18,19の一覧表示修正(平野)

### DIFF
--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -11,6 +11,7 @@ module Users
 
     def show
       @sub_request_orders = @request_order.children
+      @system_chart_documents = RequestOrder.find_by(uuid: @request_order.uuid).documents.system_chart_documents_type
       @genecon_documents = RequestOrder.find_by(uuid: @request_order.uuid).documents.genecon_documents_type
       @first_subcon_documents = RequestOrder.find_by(uuid: @request_order.uuid).documents.first_subcon_documents_type
       @second_subcon_documents = RequestOrder.find_by(uuid: @request_order.uuid).documents.second_subcon_documents_type

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1562,20 +1562,6 @@ module DocumentsHelper
     end
   end
 
-  # 書類一覧テーブルの色分け
-  def document_table_color(document)
-    case document.document_type_before_type_cast
-    when 3, 4, 5, 6, 7
-      'table-success'
-    when 8, 9, 10, 11, 12, 13, 14, 15, 16, 21, 24
-      'table-warning'
-    when 17, 19, 20, 23
-      'table-primary'
-    when 18, 22
-      'bg-warning'
-    end
-  end
-
   #doc_9
   # 自身の一つ上階層の会社情報&現場情報取得
   def get_myself_and_myparent_site

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -11,10 +11,11 @@ class Document < ApplicationRecord
   before_create -> { self.uuid = SecureRandom.uuid }
 
   # 自身の書類一覧取得(自身が元請の場合、一次の場合、二次の場合、三次以降の場合)
-  scope :genecon_documents_type, -> { where(document_type: [1, 2, 3, 4, 7, 18, 19, 20, 22, 23]).order(Arel.sql("FIELD(document_type, 1, 2, 3, 4, 7, 19, 20, 23, 18, 22)")) }
-  scope :first_subcon_documents_type, -> { where(document_type: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).order(Arel.sql("FIELD(document_type, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 23, 18, 22)")) }
-  scope :second_subcon_documents_type, -> { where(document_type: [3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 21, 22, 24]).order(Arel.sql("FIELD(document_type, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 21, 24, 18, 22)")) }
-  scope :third_or_later_subcon_documents_type, -> { where(document_type: [3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 21, 22, 24]).order(Arel.sql("FIELD(document_type, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 21, 24, 18, 22)")) }
+  scope :system_chart_documents_type, -> { where(document_type: [18, 22]) }
+  scope :genecon_documents_type, -> { where(document_type: [1, 2, 3, 4, 7, 19, 20, 23]) }
+  scope :first_subcon_documents_type, -> { where(document_type: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 23]) }
+  scope :second_subcon_documents_type, -> { where(document_type: [3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 21, 24]) }
+  scope :third_or_later_subcon_documents_type, -> { where(document_type: [3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 21, 24]) }
   # 元請け配下の一次下請け書類一覧取得
   scope :current_lower_first_documents_type, -> { where(document_type: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 23, 24]) }
   # 一次下請け配下の二次下請け書類一覧取得

--- a/app/views/users/request_orders/_current_user_documents.html.erb
+++ b/app/views/users/request_orders/_current_user_documents.html.erb
@@ -1,7 +1,6 @@
 <table class="table table-sm table-hover text-nowrap">
   <thead>
     <tr>
-      <th width="5%">No.</th>
       <th>書類名</th>
       <th width="10%"></th>
       <th width="10%"></th>
@@ -10,16 +9,13 @@
   <tbody>
     <% current_user_documents(request_order).each do |current_user_document| %>
       <tr>
-        <td class="<%= document_table_color(current_user_document) %>">
-          <%= current_user_document.document_type_before_type_cast %>
-        </td>
-        <td class="<%= document_table_color(current_user_document) %>">
+        <td >
           <%= current_user_document.document_type_i18n %>
         </td>
-        <td class="<%= document_table_color(current_user_document) %> text-right">
+        <td class="text-right">
           <%= link_to '詳細', users_request_order_document_path(@request_order.uuid, current_user_document.uuid) %>
         </td>
-        <td class="<%= document_table_color(current_user_document) %> text-right">
+        <td class="text-right">
           <%= link_to 'PDF', users_request_order_document_path(@request_order.uuid, current_user_document.uuid, format: :pdf), target: :_blank, rel: "noopener noreferrer" %>
         </td>
       </tr>

--- a/app/views/users/request_orders/_current_user_lower_first_documents.html.erb
+++ b/app/views/users/request_orders/_current_user_lower_first_documents.html.erb
@@ -1,7 +1,6 @@
 <table class="table table-sm table-hover text-nowrap">
   <thead>
     <tr>
-      <th width="5%">No.</th>
       <th>書類名</th>
       <th width="10%"></th>
       <th width="10%"></th>
@@ -10,16 +9,13 @@
   <tbody>
     <% current_lower_first_documents_type(first_request_order)&.each do |first_document| %>
       <tr>
-        <td class="<%= document_table_color(first_document) %>">
-          <%= first_document.document_type_before_type_cast %>
-        </td>
-        <td class="<%= document_table_color(first_document) %>">
+        <td>
           <%= first_document.document_type_i18n %>
         </td>
-        <td class="<%= document_table_color(first_document) %> text-right">
+        <td class="text-right">
           <%= lower_show_link(@request_order.uuid, first_request_order.uuid, first_document) %>
         </td>
-        <td class="<%= document_table_color(first_document) %> text-right">
+        <td class="text-right">
           <%= link_to 'PDF', users_request_order_sub_request_order_document_path(@request_order.uuid, first_request_order.uuid, first_document, format: :pdf), target: :_blank, rel: "noopener noreferrer" %>
         </td>
       </tr>

--- a/app/views/users/request_orders/_current_user_lower_other_documents.html.erb
+++ b/app/views/users/request_orders/_current_user_lower_other_documents.html.erb
@@ -1,7 +1,6 @@
 <table class="table table-sm table-hover text-nowrap">
   <thead>
     <tr>
-      <th width="5%">No.</th>
       <th>書類名</th>
       <th width="10%"></th>
       <th width="10%"></th>
@@ -10,16 +9,13 @@
   <tbody>
     <% current_lower_other_documents_type(other_request_order).each do |other_document| %>
       <tr>
-        <td class="<%= document_table_color(other_document) %>">
-          <%= other_document.document_type_before_type_cast %>
-        </td>
-        <td class="<%= document_table_color(other_document) %>">
+        <td>
           <%= other_document.document_type_i18n %>
         </td>
-        <td class="<%= document_table_color(other_document) %> text-right">
+        <td class="text-right">
           <%= lower_show_link(@request_order.uuid, other_request_order.uuid, other_document) %>
         </td>
-        <td class="<%= document_table_color(other_document) %> text-right">
+        <td class="text-right">
           <%= link_to 'PDF', users_request_order_sub_request_order_document_path(@request_order.uuid, other_request_order.uuid, other_document, format: :pdf), target: :_blank, rel: "noopener noreferrer" %>
         </td>
       </tr>

--- a/app/views/users/request_orders/_current_user_lower_second_documents.html.erb
+++ b/app/views/users/request_orders/_current_user_lower_second_documents.html.erb
@@ -1,7 +1,6 @@
 <table class="table table-sm table-hover text-nowrap">
   <thead>
     <tr>
-      <th width="5%">No.</th>
       <th>書類名</th>
       <th width="10%"></th>
       <th width="10%"></th>
@@ -10,16 +9,13 @@
   <tbody>
     <% current_lower_second_documents_type(second_request_order).each do |second_document| %>
       <tr>
-        <td class="<%= document_table_color(second_document) %>">
-          <%= second_document.document_type_before_type_cast %>
-        </td>
-        <td class="<%= document_table_color(second_document) %>">
+        <td>
           <%= second_document.document_type_i18n %>
         </td>
-        <td class="<%= document_table_color(second_document) %> text-right">
+        <td class="text-right">
           <%= lower_show_link(@request_order.uuid, second_request_order.uuid, second_document) %>
         </td>
-        <td class="<%= document_table_color(second_document) %> text-right">
+        <td class="text-right">
           <%= link_to 'PDF', users_request_order_sub_request_order_document_path(@request_order.uuid, second_request_order.uuid, second_document, format: :pdf), target: :_blank, rel: "noopener noreferrer" %>
         </td>
       </tr>

--- a/app/views/users/request_orders/show.html.erb
+++ b/app/views/users/request_orders/show.html.erb
@@ -237,6 +237,40 @@
   </section>
 <% end %>
 
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card card-primary card-outline">
+          <div class="card-body">
+            <div class="row">
+              <div class="card-body table-responsive p-0">
+                <table class="table table-sm text-nowrap">
+                  <tbody>
+                    <% @system_chart_documents.each do |current_user_document| %>
+                      <tr>
+                        <td>
+                          <%= current_user_document.document_type_i18n %>
+                        </td>
+                        <td class="text-right">
+                          <%= link_to '詳細', users_request_order_document_path(@request_order.uuid, current_user_document.uuid) %>
+                        </td>
+                        <td class="text-right">
+                          <%= link_to 'PDF', users_request_order_document_path(@request_order.uuid, current_user_document.uuid, format: :pdf), target: :_blank, rel: "noopener noreferrer" %>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<section>
+
 <!-- 元請（自身の情報） -->
 <section class="content">
   <div class="container-fluid">
@@ -247,20 +281,21 @@
           <%= '下請け' if sc_hierarchy(@request_order) != '元請' %>
           （自身の情報）
         </h5>
+
         <div class="card card-primary card-outline">
           <div class="card-body">
             <div class="row">
-            <div class="col-md-4 mb-2">
-              <%= RequestOrder.human_attribute_name(:status) %>：<%= @request_order.status_i18n %>
-            </div>
-            <div class="col-md-8 mb-2">
-              <%= Business.human_attribute_name(:name) %>：<%= @request_order.business.name %>
-              <%= link_to "(書類一覧)", users_request_order_documents_path(@request_order) %>
-            </div>
-            <div class="card-body table-responsive p-0">
-              <!-- 自身の書類一覧 -->
-              <%= render 'current_user_documents', request_order: @request_order %>
-            </div>
+              <div class="col-md-4 mb-2">
+                <%= RequestOrder.human_attribute_name(:status) %>：<%= @request_order.status_i18n %>
+              </div>
+              <div class="col-md-8 mb-2">
+                <%= Business.human_attribute_name(:name) %>：<%= @request_order.business.name %>
+                <%= link_to "(書類一覧)", users_request_order_documents_path(@request_order) %>
+              </div>
+              <div class="card-body table-responsive p-0">
+                <!-- 自身の書類一覧 -->
+                <%= render 'current_user_documents', request_order: @request_order %>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### 概要
書類18,19の一覧表示修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- (18)工事作業所災害防止協議会兼施工体系図、(22)作業間連絡調整書を書類一覧部分から外し上側へ単独表示へ変更

### 実装画像などあれば添付する


![FireShot Capture 055 - App - localhost](https://user-images.githubusercontent.com/52871417/233753894-135abf68-2465-4685-a2ad-8220944ce1f5.png)
