### PR TITLE
ステージング環境の現場情報エラー対応、会社情報の非表示項目を空にして更新(伊藤)

### DIFF
--- a/app/controllers/users/businesses_controller.rb
+++ b/app/controllers/users/businesses_controller.rb
@@ -52,6 +52,7 @@ module Users
     end
 
     def update
+      clear_hidden_fields #ラジオボタンで非表示になった項目を強制的にnilにする
       if @business.update(business_params_with_converted)
         flash[:success] = '更新しました'
         redirect_to users_business_url
@@ -110,6 +111,25 @@ module Users
         converted_params[key] = converted_params[key].to_s.gsub(/[-ー]/, '')
       end
       converted_params
+    end
+
+    def clear_hidden_fields
+      if params[:business][:business_health_insurance_status] != "join"
+        params[:business][:business_health_insurance_association] = nil
+        params[:business][:business_health_insurance_office_number] = nil
+      end
+      if params[:business][:business_welfare_pension_insurance_join_status] != "join"
+        params[:business][:business_welfare_pension_insurance_office_number] = nil
+      end
+      if params[:business][:business_employment_insurance_join_status] != "join"
+        params[:business][:business_employment_insurance_number] = nil
+      end
+      if params[:business][:foreign_work_status_exist] != "available"
+        params[:business][:specific_skilled_foreigners_exist] = nil
+        params[:business][:foreign_construction_workers_exist] = nil
+        params[:business][:foreign_technical_intern_trainees_exist] = nil
+        params[:business][:foreigners_employment_manager] = nil
+      end
     end
 
     def business_params

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -545,6 +545,7 @@
         // "business[foreigners_employment_manager]": {
         //   required: true
         // },
+      },
       messages: {
         "business[uuid]": {
           required: "事業所IDを入力してください。"

--- a/app/views/users/request_orders/_form.html.erb
+++ b/app/views/users/request_orders/_form.html.erb
@@ -197,8 +197,8 @@
             <% industry = BusinessIndustry.find_by(id: id) %>
             <% if industry %>
               <div class="form-check">
-                <%= f.check_box :construction_license, { multiple: true, checked: (@request_order.construction_license.present? && @request_order.construction_license&.include?(id.to_s)) }, id, nil %>
-                <%= f.label industry.construction_license_number %>
+                <%= f.check_box :construction_license, { multiple: true, checked: (@request_order.construction_license.present? && @request_order.construction_license&.include?(id.to_s)), id: "construction_license_number_#{id}" }, id, nil %>
+                <label for='construction_license_number_<%= id %>'><%= industry.construction_license_number %></label>
               </div>
             <% end %>
           <% end %>

--- a/db/migrate/20220107150006_create_businesses.rb
+++ b/db/migrate/20220107150006_create_businesses.rb
@@ -19,9 +19,9 @@ class CreateBusinesses < ActiveRecord::Migration[6.1]
       t.json :tem_industry_ids
       t.string :employment_manager_name
       t.integer :foreign_work_status_exist
-      t.integer :specific_skilled_foreigners_exist,default: 1, null: false
-      t.integer :foreign_construction_workers_exist,default: 1, null: false
-      t.integer :foreign_technical_intern_trainees_exist,default: 1, null: false
+      t.integer :specific_skilled_foreigners_exist
+      t.integer :foreign_construction_workers_exist
+      t.integer :foreign_technical_intern_trainees_exist
       t.integer :construction_license_status, null: false, comment: "建設許可証(取得状況) enum"
       t.string :foreigners_employment_manager
       # t.string :employment_manager_post


### PR DESCRIPTION
### 概要
・ ステージング環境の現場情報作成押下時に発生しているエラーに対しての対応 
・ 会社情報において、非表示項目の値を空にして更新する

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
・ 下請け現場情報の建設許可証番号のセレクトボックのラベルの記述を修正
※ request_order側の対応が漏れていたため修正
・ 会社情報において、ラジオボタンの選択肢により非表示になる項目を空にして更新するように修正（健康保険、厚生年金保険、雇用保険、外国人就労の有無）※ 不具合・改善および対応履歴一覧No.30

### 実装画像などあれば添付する
画面自体の変更はなし