### PR TITLE
建設許可証番号保存処理等（原）

### DIFF
--- a/app/models/business_industry.rb
+++ b/app/models/business_industry.rb
@@ -1,6 +1,7 @@
 class BusinessIndustry < ApplicationRecord
   belongs_to :business
   belongs_to :industry
+  before_save :set_construction_license_number
 
   enum construction_license_permission_type_minister_governor: { minister_permission: 0, governor_permission: 1 }, _prefix: true # 建設許可証(許可種別)
   enum construction_license_governor_permission_prefecture: { hokkaido: 0, aomori: 1, iwate: 2, miyagi: 3, akita: 4, yamagata: 5, fukushima: 6, ibaraki: 7, tochigi: 8, gunma: 9, saitama: 10, chiba: 11, tokyo: 12, kanagawa: 13, niigata: 14, toyama: 15, ishikawa: 16, fukui: 17, yamanashi: 18, nagano: 19, gifu: 20, shizuoka: 21, aichi: 22, mie: 23, shiga: 24, kyoto: 25, osaka: 26, hyogo: 27, nara: 28, wakayama: 29, tottori: 30, shimane: 31, okayama: 32, hiroshima: 33, yamaguchi: 34, tokushima: 35, kagawa: 36, ehime: 37, kochi: 38, fukuoka: 39, saga: 40, nagasaki: 41, kumamoto: 42, oita: 43, miyazaki: 44, kagoshima: 45, okinawa: 46 } # 建設許可証(都道府県)
@@ -12,6 +13,10 @@ class BusinessIndustry < ApplicationRecord
   validates :construction_license_number_double_digit, format: { with: /\A\d{2}\z/, message: 'は数字2桁で入力してください' }, presence: true, if: -> { business.construction_license_status == 'available' }
   validates :construction_license_number_six_digits, format: { with: /\A\d{1,6}\z/, message: 'は数字6桁以下で入力してください' }, presence: true, if: -> { business.construction_license_status == 'available' }
   validates :construction_license_updated_at, presence: true, if: -> { business.construction_license_status == 'available' }
+
+  def set_construction_license_number
+    self.construction_license_number = construction_license_number_string
+  end
 
   # 建設許可証番号の組み合わせ表示
   def construction_license_number_string

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -509,6 +509,7 @@
         // "business[foreigners_employment_manager]": {
         //   required: true
         // },
+      },
       messages: {
         "business[uuid]": {
           required: "事業所IDを入力してください。"

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -269,8 +269,6 @@
       list_group_health_insurance.classList.remove('hidden');
     } else {
       list_group_health_insurance.classList.add('hidden');
-      if ($("#nest-field").length) {
-      }
     }
   };
   getRadioBusinessHealthInsuranceStatus(available_form_health_insurance); //ページの読み込み時に判定
@@ -279,8 +277,6 @@
       list_group_health_insurance.classList.remove('hidden');
     } else {
       list_group_health_insurance.classList.add('hidden');
-      if ($("#nest-field").length) {
-      }
     }
   });
 
@@ -293,8 +289,6 @@
       list_group_welfare_pension_insurance.classList.remove('hidden');
     } else {
       list_group_welfare_pension_insurance.classList.add('hidden');
-      if ($("#nest-field").length) {
-      }
     }
   };
   getRadioBusinessWelfarePensionInsuranceJoinStatus(available_form_welfare_pension_insurance); //ページの読み込み時に判定
@@ -303,8 +297,6 @@
       list_group_welfare_pension_insurance.classList.remove('hidden');
     } else {
       list_group_welfare_pension_insurance.classList.add('hidden');
-      if ($("#nest-field").length) {
-      }
     }
   });
 
@@ -317,8 +309,6 @@
       list_group_employment_insurance.classList.remove('hidden');
     } else {
       list_group_employment_insurance.classList.add('hidden');
-      if ($("#nest-field").length) {
-      }
     }
   };
   getRadioBusinessEmploymentInsuranceJoinStatus(available_form_employment_insurance); //ページの読み込み時に判定
@@ -327,8 +317,6 @@
       list_group_employment_insurance.classList.remove('hidden');
     } else {
       list_group_employment_insurance.classList.add('hidden');
-      if ($("#nest-field").length) {
-      }
     }
   });
 
@@ -341,8 +329,6 @@
       list_group_foreign_work.classList.remove('hidden');
     } else {
       list_group_foreign_work.classList.add('hidden');
-      if ($("#nest-field").length) {
-      }
     }
   };
   getRadioForeignWorkStatusExist(available_form_foreign_work); //ページの読み込み時に判定
@@ -351,8 +337,6 @@
       list_group_foreign_work.classList.remove('hidden');
     } else {
       list_group_foreign_work.classList.add('hidden');
-      if ($("#nest-field").length) {
-      }
     }
   });
 </script>

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -263,16 +263,13 @@
 //健康保険の加入状況によってフォームの表示・非表示の切り替え
   const available_form_health_insurance = document.getElementById('available-form-health-insurance')
   const list_group_health_insurance = document.getElementById('hidden-form-health-insurance')
-  const error_health_insurance = document.getElementById('error')
   function getRadioBusinessHealthInsuranceStatus(object) {
     const value = $('input[name="business[business_health_insurance_status]"]:checked').val();
     if (value == 'join'){
       list_group_health_insurance.classList.remove('hidden');
-      error_health_insurance.classList.add('hidden');
     } else {
       list_group_health_insurance.classList.add('hidden');
       if ($("#nest-field").length) {
-        error_health_insurance.classList.remove('hidden');
       }
     }
   };
@@ -280,11 +277,9 @@
   $('input[name="business[business_health_insurance_status]"]').change(function() {
     if ($(this).val() == 'join') {
       list_group_health_insurance.classList.remove('hidden');
-      error_health_insurance.classList.add('hidden');
     } else {
       list_group_health_insurance.classList.add('hidden');
       if ($("#nest-field").length) {
-        error_health_insurance.classList.remove('hidden');
       }
     }
   });
@@ -292,16 +287,13 @@
 //厚生年金保険の加入状況によってフォームの表示・非表示の切り替え
   const available_form_welfare_pension_insurance = document.getElementById('available-form-welfare-pension-insurance')
   const list_group_welfare_pension_insurance = document.getElementById('hidden-form-welfare-pension-insurance')
-  const error_welfare_pension_insurance = document.getElementById('error')
   function getRadioBusinessWelfarePensionInsuranceJoinStatus(object) {
     const value = $('input[name="business[business_welfare_pension_insurance_join_status]"]:checked').val();
     if (value == 'join'){
       list_group_welfare_pension_insurance.classList.remove('hidden');
-      error_welfare_pension_insurance.classList.add('hidden');
     } else {
       list_group_welfare_pension_insurance.classList.add('hidden');
       if ($("#nest-field").length) {
-        error_welfare_pension_insurance.classList.remove('hidden');
       }
     }
   };
@@ -309,11 +301,9 @@
   $('input[name="business[business_welfare_pension_insurance_join_status]"]').change(function() {
     if ($(this).val() == 'join') {
       list_group_welfare_pension_insurance.classList.remove('hidden');
-      error_welfare_pension_insurance.classList.add('hidden');
     } else {
       list_group_welfare_pension_insurance.classList.add('hidden');
       if ($("#nest-field").length) {
-        error_welfare_pension_insurance.classList.remove('hidden');
       }
     }
   });
@@ -321,16 +311,13 @@
 //雇用保険の加入状況によってフォームの表示・非表示の切り替え
   const available_form_employment_insurance = document.getElementById('available-form-employmentーinsurance')
   const list_group_employment_insurance = document.getElementById('hidden-form-employmentーinsurance')
-  const error_employment_insurance = document.getElementById('error')
   function getRadioBusinessEmploymentInsuranceJoinStatus(object) {
     const value = $('input[name="business[business_employment_insurance_join_status]"]:checked').val();
     if (value == 'join'){
       list_group_employment_insurance.classList.remove('hidden');
-      error_employment_insurance.classList.add('hidden');
     } else {
       list_group_employment_insurance.classList.add('hidden');
       if ($("#nest-field").length) {
-        error_employment_insurance.classList.remove('hidden');
       }
     }
   };
@@ -338,11 +325,9 @@
   $('input[name="business[business_employment_insurance_join_status]"]').change(function() {
     if ($(this).val() == 'join') {
       list_group_employment_insurance.classList.remove('hidden');
-      error_employment_insurance.classList.add('hidden');
     } else {
       list_group_employment_insurance.classList.add('hidden');
       if ($("#nest-field").length) {
-        error_employment_insurance.classList.remove('hidden');
       }
     }
   });
@@ -350,16 +335,13 @@
 //外国人就労者の有無によってフォームの表示・非表示の切り替え
   const available_form_foreign_work = document.getElementById('available-form-foreign-work')
   const list_group_foreign_work = document.getElementById('hidden-form-foreign-work')
-  const error_foreign_work = document.getElementById('error')
   function getRadioForeignWorkStatusExist(object) {
     const value = $('input[name="business[foreign_work_status_exist]"]:checked').val();
     if (value == 'available'){
       list_group_foreign_work.classList.remove('hidden');
-      error_foreign_work.classList.add('hidden');
     } else {
       list_group_foreign_work.classList.add('hidden');
       if ($("#nest-field").length) {
-        error_foreign_work.classList.remove('hidden');
       }
     }
   };
@@ -367,11 +349,9 @@
   $('input[name="business[foreign_work_status_exist]"]').change(function() {
     if ($(this).val() == 'available') {
       list_group_foreign_work.classList.remove('hidden');
-      error_foreign_work.classList.add('hidden');
     } else {
       list_group_foreign_work.classList.add('hidden');
       if ($("#nest-field").length) {
-        error_foreign_work.classList.remove('hidden');
       }
     }
   });

--- a/app/views/users/businesses/show.html.erb
+++ b/app/views/users/businesses/show.html.erb
@@ -7,26 +7,32 @@
         <tr>
           <th style='font-size:22px'><%= Business.human_attribute_name(:business_info) %></th> <!--会社情報-->
           <td></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:business_type) %></th>
           <td><%= @business.business_type_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:name) %></th>
           <td><%= @business.name %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:name_kana) %></th>
           <td><%= @business.name_kana %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:branch_name) %></th>
           <td><%= @business.branch_name %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:career_up_id) %></th>
           <td><%= @business.career_up_id %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:career_up_card_copy) %></th>
@@ -35,30 +41,37 @@
               <%= image_tag(image.url) %>
             <% end %>
           </td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:representative_name) %></th>
           <td><%= @business.representative_name %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:post_code) %></th>
           <td><%= @business.post_code[0,3] + '-' + @business.post_code[3,4] %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:address) %></th>
           <td><%= @business.address %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:phone_number) %></th>
           <td><%= @business.phone_number %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:fax_number) %></th>
           <td><%= @business.fax_number %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:email) %></th>
           <td><%= @business.email %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:stamp_images) %></th>
@@ -67,21 +80,26 @@
               <%= image_tag(image.url) %>
             <% end %>
           </td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:industry_ids) %></th>
           <td><%= Industry.where(id: @business.tem_industry_ids).pluck(:name).join(', ') %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:occupation_ids) %></th>
           <td><%= @business.occupations.pluck(:name).join(', ') %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:employment_manager_name) %></th>
           <td><%= @business.employment_manager_name %></td>
+          <td></td>
         </tr>
         <tr>
           <th style='font-size:22px'><%= Business.human_attribute_name(:social_insurance_info) %></th> <!--社会保険情報-->
+          <td></td>
           <td></td>
         </tr>
         <tr>
@@ -90,38 +108,47 @@
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:business_health_insurance_status) %></th>
           <td><%= @business.business_health_insurance_status_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:business_health_insurance_association) %></th>
           <td><%= @business.business_health_insurance_association %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:business_health_insurance_office_number) %></th>
           <td><%= @business.business_health_insurance_office_number %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:business_welfare_pension_insurance) %></th> <!--厚生年金保険-->
+          <td></td>
           <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:business_welfare_pension_insurance_join_status) %></th>
           <td><%= @business.business_welfare_pension_insurance_join_status_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:business_welfare_pension_insurance_office_number) %></th>
           <td><%= @business.business_welfare_pension_insurance_office_number %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:business_employment_insurance) %></th> <!--雇用保険-->
+          <td></td>
           <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:business_employment_insurance_join_status) %></th>
           <td><%= @business.business_employment_insurance_join_status_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:business_employment_insurance_number) %></th>
           <td><%= @business.business_employment_insurance_number %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:business_retirement_benefit_mutual_aid) %></th> <!--退職金共済制度-->
@@ -129,10 +156,12 @@
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= Business.human_attribute_name(:business_retirement_benefit_mutual_aid_status) %></th>
           <td><%= @business.business_retirement_benefit_mutual_aid_status_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:construction_license_status) %></th>
           <td><%= @business.construction_license_status_i18n %></td>
+          <td></td>
         </tr>
         <!-- business_industryここから（建設許可証「有」の場合のみ下記表示 -->
         <% if @business.construction_license_status_available? %>
@@ -144,7 +173,7 @@
           <% @business.business_industries.each do |business_industry| %>
             <tr>
               <td>&emsp;&emsp;&emsp;&emsp;<%= business_industry.industry.name %></td>
-              <td><%= business_industry.construction_license_number_string %></td>
+              <td><%= business_industry.construction_license_number %></td>
               <td><%= business_industry.construction_license_updated_at %></td>
             </tr>
           <% end %>
@@ -153,26 +182,32 @@
         <tr>
           <th style='font-size:22px'><%= Business.human_attribute_name(:foreign_construction_workers) %></th> <!--外国人建設就労者-->
           <td></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:foreign_work_status_exist) %></th>
           <td><%= @business.foreign_work_status_exist_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:specific_skilled_foreigners_exist) %></th>
           <td><%= @business.specific_skilled_foreigners_exist_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:foreign_construction_workers_exist) %></th>
           <td><%= @business.foreign_construction_workers_exist_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:foreign_technical_intern_trainees_exist) %></th>
           <td><%= @business.foreign_technical_intern_trainees_exist_i18n %></td>
+          <td></td>
         </tr>
         <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:foreigners_employment_manager) %></th>
           <td><%= @business.foreigners_employment_manager %></td>
+          <td></td>
         </tr>
       </tbody>
     </table>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,9 +106,9 @@ ActiveRecord::Schema.define(version: 2023_03_13_135036) do
     t.json "tem_industry_ids"
     t.string "employment_manager_name"
     t.integer "foreign_work_status_exist"
-    t.integer "specific_skilled_foreigners_exist"
-    t.integer "foreign_construction_workers_exist"
-    t.integer "foreign_technical_intern_trainees_exist"
+    t.integer "specific_skilled_foreigners_exist", default: 1, null: false
+    t.integer "foreign_construction_workers_exist", default: 1, null: false
+    t.integer "foreign_technical_intern_trainees_exist", default: 1, null: false
     t.integer "construction_license_status", null: false, comment: "建設許可証(取得状況) enum"
     t.string "foreigners_employment_manager"
     t.bigint "user_id", null: false


### PR DESCRIPTION
### 概要
_建設許可証番号保存処理等_

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
○会社情報のフォームにて、更新時に建設許可証番号を組み合わせたものをconstruction_license_numberに保存する実装
○会社情報フォーム内のJSの不要コード削除
○show画面微修正等

### 実装画像などあれば添付する

https://user-images.githubusercontent.com/63439936/233783456-57a7877b-4512-4187-9b7c-1cfabbd07a73.mov


