### PR TITLE
不具合・問題表No.41、No.42の対応＆作業員情報のレイアウト修正（奥野）

### DIFF
--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -20,6 +20,9 @@ module Users
     def create
       @worker = current_business.workers.build(worker_params_with_converted)
       if @worker.save
+        unless @worker.worker_medical.is_special_med_exam == 'y' && @worker.worker_medical.worker_exams.blank?
+          @worker.worker_medical.worker_exams.destroy_all
+        end
         flash[:success] = '作業員情報を作成しました'
         redirect_to users_worker_path(@worker)
       else
@@ -47,6 +50,7 @@ module Users
 
     def update
       if @worker.update(worker_params_with_converted)
+        @worker.worker_medical.worker_exams.destroy_all unless @worker.worker_medical.is_special_med_exam == 'y'
         flash[:success] = '更新しました'
         redirect_to users_worker_path(@worker)
       else

--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -39,6 +39,7 @@ module Users
       @worker.worker_licenses.build if @worker.licenses.blank?
       @worker.worker_skill_trainings.build if @worker.skill_trainings.blank?
       @worker.worker_special_educations.build if @worker.special_educations.blank?
+      @worker.worker_safety_health_educations.build if @worker.worker_safety_health_educations.blank?
       worker_add_hyhpen(@worker)
       if @worker.status_of_residence.blank?
         @worker.status_of_residence = :construction_employment

--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -10,8 +10,7 @@ module Users
 
     def new
       if Rails.env.development?
-        # test_data_new
-        production_data_new
+        test_data_new
         worker_add_hyhpen(@worker)
       else
         production_data_new

--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -10,7 +10,8 @@ module Users
 
     def new
       if Rails.env.development?
-        test_data_new
+        # test_data_new
+        production_data_new
         worker_add_hyhpen(@worker)
       else
         production_data_new
@@ -372,11 +373,13 @@ module Users
 
     # 作業員情報のハイフン差し込み
     def worker_add_hyhpen(worker)
-      @my_phone_number = phone_number_add_hyphen(worker.my_phone_number)
-      @family_phone_number = phone_number_add_hyphen(worker.family_phone_number)
-      @post_code = post_code_add_hyphen(worker)
-      @career_up_id = career_up_id_add_hyphen(worker)
-      @driver_licence_number = driver_licence_number_add_hyphen(worker)
+      if worker.present?
+        @my_phone_number = phone_number_add_hyphen(worker.my_phone_number)
+        @family_phone_number = phone_number_add_hyphen(worker.family_phone_number)
+        @post_code = post_code_add_hyphen(worker.post_code)
+        @career_up_id = career_up_id_add_hyphen(worker.career_up_id)
+        @driver_licence_number = driver_licence_number_add_hyphen(worker.driver_licence_number)
+      end
     end
 
     def worker_params

--- a/app/controllers/users/workers_controller.rb
+++ b/app/controllers/users/workers_controller.rb
@@ -47,7 +47,6 @@ module Users
 
     def update
       if @worker.update(worker_params_with_converted)
-        @worker.disabled_convert(worker_params[:confirmed_check_date], :confirmed_check_date)
         flash[:success] = '更新しました'
         redirect_to users_worker_path(@worker)
       else
@@ -234,6 +233,20 @@ module Users
         next unless converted_params[key].present?
 
         converted_params[key] = full_width_to_half_width(converted_params[key])
+      end
+
+      # 作業員健康情報のパラメーター整理
+      # 健康診断項目の受診の有無が無の時、診断日と血圧をnilにする
+      worker_medical_attributes = converted_params[:worker_medical_attributes]
+      if worker_medical_attributes[:is_med_exam] == 'n'
+        worker_medical_attributes[:med_exam_on] = nil
+        worker_medical_attributes[:max_blood_pressure] = nil
+        worker_medical_attributes[:min_blood_pressure] = nil
+      end
+
+      # 健康診断項目の受診の有無が無の時、診断日と診断種類をnilにする
+      if worker_medical_attributes[:is_special_med_exam] == 'n'
+        worker_medical_attributes[:special_med_exam_on] = nil
       end
 
       # 保険名、被保険者番号、建設業退職金共済手帳その他、労働保険特別加入が必須でない場合パラメータを空文字にする

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,45 +106,47 @@ module ApplicationHelper
 
   # 電話番号のハイフン差し込み
   def phone_number_add_hyphen(phone_number)
-    case phone_number.size
-    when 10
-      add_hyphen([4, 2], phone_number)
-    when 11
-      add_hyphen([3, 4], phone_number)
-    else
-      phone_number
+    if phone_number.present?
+      case phone_number.size
+      when 10
+        add_hyphen([4, 2], phone_number)
+      when 11
+        add_hyphen([3, 4], phone_number)
+      else
+        phone_number
+      end
     end
   end
 
   # 郵便番号のハイフン追加
-  def post_code_add_hyphen(worker)
-    if worker.post_code.present?
-      if worker.post_code.size == 7
-        add_hyphen([3], worker.post_code)
+  def post_code_add_hyphen(post_code)
+    if post_code.present?
+      if post_code.size == 7
+        add_hyphen([3], post_code)
       else
-        worker.post_code
+        post_code
       end
     end
   end
 
   # キャリアアップidのハイフン追加
-  def career_up_id_add_hyphen(worker)
-    if worker.career_up_id.present?
-      if worker.career_up_id.size == 14
-        add_hyphen([4, 4, 4], worker.career_up_id)
+  def career_up_id_add_hyphen(career_up_id)
+    if career_up_id.present?
+      if career_up_id.size == 14
+        add_hyphen([4, 4, 4], career_up_id)
       else
-        worker.career_up_id
+        career_up_id
       end
     end
   end
 
   # 運転免許証のハイフン追加
-  def driver_licence_number_add_hyphen(worker)
-    if worker.driver_licence_number.present?
-      if worker.driver_licence_number.size == 12
-        add_hyphen([4, 4], worker.driver_licence_number)
+  def driver_licence_number_add_hyphen(driver_licence_number)
+    if driver_licence_number.present?
+      if driver_licence_number.size == 12
+        add_hyphen([4, 4], driver_licence_number)
       else
-        worker.driver_licence_number
+        driver_licence_number
       end
     end
   end

--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -94,6 +94,7 @@ module WorkersHelper
       health_condition: :good
       # ============================================
     )
+    @worker.worker_safety_health_educations.build
     worker_medical.worker_exams.build
     @worker.build_worker_insurance(
       # 本番環境用デフォルト値 ==========================

--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -55,6 +55,7 @@ module WorkersHelper
       med_exam_on:         '2022-03-01',
       max_blood_pressure:  120,
       min_blood_pressure:  70,
+      is_special_med_exam: :y,
       special_med_exam_on: '2022-03-01'
       # ============================================
     )
@@ -93,8 +94,9 @@ module WorkersHelper
     @worker.worker_special_educations.build
     worker_medical = @worker.build_worker_medical(
       # 本番環境用デフォルト値 ==========================
-      is_med_exam:      :y,
-      health_condition: :good
+      is_med_exam:         :y,
+      is_special_med_exam: :y,
+      health_condition:    :good
       # ============================================
     )
     @worker.worker_safety_health_educations.build

--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -71,7 +71,8 @@ module WorkersHelper
       employment_insurance_type:     :insured,
       employment_insurance_number:   '12345678901',
       severance_pay_mutual_aid_type: :kentaikyo,
-      severance_pay_mutual_aid_name: 'テスト共済制度'
+      severance_pay_mutual_aid_name: 'テスト共済制度',
+      has_labor_insurance:           :join
       # ============================================
     )
   end
@@ -79,10 +80,12 @@ module WorkersHelper
   def production_data_new
     @worker = current_business.workers.new(
       # 本番環境用デフォルト値 ==========================
-      country:        'JP',
-      abo_blood_type: :a,
-      rh_blood_type:  :plus,
-      sex:            :man
+      country:             'JP',
+      abo_blood_type:      :a,
+      rh_blood_type:       :plus,
+      sex:                 :man,
+      status_of_residence: :permanent_resident,
+      confirmed_check:     :checked
       # ============================================
     )
     @worker.worker_licenses.build
@@ -101,7 +104,8 @@ module WorkersHelper
       health_insurance_type:         :health_insurance_association,
       pension_insurance_type:        :welfare,
       employment_insurance_type:     :insured,
-      severance_pay_mutual_aid_type: :kentaikyo
+      severance_pay_mutual_aid_type: :kentaikyo,
+      has_labor_insurance:           :join
       # ============================================
     )
   end

--- a/app/models/worker.rb
+++ b/app/models/worker.rb
@@ -84,6 +84,8 @@ class Worker < ApplicationRecord
     uuid
   end
 
+  private
+
   def driver_licence_present?
     driver_licences.present?
   end
@@ -98,9 +100,5 @@ class Worker < ApplicationRecord
 
   def confirmed_check_checked?
     specified_skill_or_construction_employment? && confirmed_check == 'checked'
-  end
-
-  def disabled_convert(params, key)
-    self.update(key => '') if params.blank?
   end
 end

--- a/app/models/worker_medical.rb
+++ b/app/models/worker_medical.rb
@@ -14,9 +14,25 @@ class WorkerMedical < ApplicationRecord
   enum is_med_exam: { y: 0, n: 1 }, _prefix: true         # 健康診断受診の有無
   enum is_special_med_exam: { y: 0, n: 1 }, _prefix: true # 特別健康診断受診の有無
 
-  validates :med_exam_on, presence: true
-  validates :max_blood_pressure, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 999 }
-  validates :min_blood_pressure, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 999 }
+  validates :med_exam_on, presence: true, if: :med_exam_y?
+  validates :med_exam_on, absence: true, unless: :med_exam_y?
+  validates :max_blood_pressure, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 999 }, if: :med_exam_y?
+  validates :max_blood_pressure, absence: true, unless: :med_exam_y?
+  validates :min_blood_pressure, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 999 }, if: :med_exam_y?
+  validates :min_blood_pressure, absence: true, unless: :med_exam_y?
+  validates :is_special_med_exam, presence: true
+  validates :special_med_exam_on, presence: true, if: :special_med_exam_y?
+  validates :special_med_exam_on, absence: true, unless: :special_med_exam_y?
   validates :health_condition, presence: true
   validates :is_med_exam, presence: true
+
+  private
+
+  def special_med_exam_y?
+    is_special_med_exam == 'y'
+  end
+
+  def med_exam_y?
+    self.is_med_exam == 'y'
+  end
 end

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -226,7 +226,7 @@
 
       <%# 特別健康診断項目 %>
       <label><%= yield(:special_med_exam_info) %></label><span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-      <div class="list-group-item">
+      <div class="list-group-item mb-3">
         <%# 特別健康診断の受診状況 %>
         <div class="mb-1">
           <%= worker_medical.label :is_special_med_exam %><br>
@@ -248,7 +248,7 @@
 
           <%# 特別健康診断 %>
           <label><%= yield(:special_med_exam_id_info) %></label>
-          <div class="list-group-item">
+          <div class="list-group-item mb-2">
             <%= worker_medical.fields_for :worker_exams do |worker_exam| %>
               <%= render "worker_exam_fields", f: worker_exam %>
             <% end %>

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -1,6 +1,9 @@
 <% provide(:worker_info, "【作業員情報】") %>
 <% provide(:worker_emergency_contact_info, "【緊急連絡先】") %>
 <% provide(:worker_health_info, "【健康情報】") %>
+<% provide(:is_med_exam_info, "健康診断") %>
+<% provide(:special_med_exam_info, "特別健康診断") %>
+<% provide(:special_med_exam_id_info, "診断種類") %>
 <% provide(:worker_health_info_blood_pressure, "血圧") %>
 <% provide(:worker_insurances_info, "【保険情報】") %>
 <% provide(:worker_licenses_info, "【資格情報】") %>
@@ -184,68 +187,82 @@
 
     <!-- WorkerMedicalテーブル情報ここから -->
     <%= f.fields_for :worker_medical do |worker_medical| %>
-      <%# 健康診断の受診状況 %>
-      <div class="mb-3">
-        <%= worker_medical.label :is_med_exam %>
-        <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
-        <div class="list-group-item">
-          <%= worker_medical.collection_radio_buttons(:is_med_exam, WorkerMedical.is_med_exams_i18n, :first, :last, class: "radio") do |b| %>
-            <div class="radio">
-              <%= b.label { b.radio_button + b.text } %>
+      <label><%= yield(:is_med_exam_info) %></label><span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+      <div class="list-group-item mb-3">
+        <%# 健康診断の受診状況 %>
+        <div class="mb-1">
+          <%= worker_medical.label :is_med_exam %><br>
+          <div class="list-group-item">
+            <%= worker_medical.collection_radio_buttons(:is_med_exam, WorkerMedical.is_med_exams_i18n, :first, :last, class: "radio") do |b| %>
+              <div class="radio">
+                <%= b.label { b.radio_button + b.text } %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <%# 健康保険が適用除外もしくは、未加入の場合、非表示にする要素 %>
+        <div id="is_med_exam_n_hide">
+          <%# 健康診断日 %>
+          <div class="mb-1">
+            <%= worker_medical.label :med_exam_on %>
+            <%= worker_medical.date_field :med_exam_on, class: "form-control", style: "width: 25%;" %>
+          </div>
+
+          <!-- 作業員健康保険情報血圧 -->
+          <div class="mb-1">
+            <%= f.label yield(:worker_health_info_blood_pressure) %>
+            <div class="list-group-item" style="border: none;">
+              <%# 最高血圧 (mmHg) %>
+              <%= worker_medical.label :max_blood_pressure %>
+              <%= worker_medical.number_field :max_blood_pressure, class: "form-control" %>
+              <%# 最低血圧 (mmHg) %>
+              <%= worker_medical.label :min_blood_pressure %>
+              <%= worker_medical.number_field :min_blood_pressure, class: "form-control" %>
             </div>
-          <% end %>
-        </div>
-      </div>
-      <%# 健康診断日 %>
-      <div class="mb-3">
-        <%= worker_medical.label :med_exam_on %>
-        <%= worker_medical.date_field :med_exam_on, class: "form-control", style: "width: 25%;" %>
-      </div>
-
-      <!-- 作業員健康保険情報血圧 -->
-      <div class="mb-3">
-        <%= f.label yield(:worker_health_info_blood_pressure) %><span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-        <div class="list-group-item" style="border: none;">
-          <%# 最高血圧 (mmHg) %>
-          <%= worker_medical.label :max_blood_pressure %>
-          <%= worker_medical.number_field :max_blood_pressure, class: "form-control" %>
-          <%# 最低血圧 (mmHg) %>
-          <%= worker_medical.label :min_blood_pressure %>
-          <%= worker_medical.number_field :min_blood_pressure, class: "form-control" %>
+          </div>
         </div>
       </div>
 
-      <%# 特別健康診断の受診状況 %>
-      <div class="mb-3">
-        <%= worker_medical.label :is_special_med_exam %>
-        <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
-        <div class="list-group-item">
-          <%= worker_medical.collection_radio_buttons(:is_special_med_exam, WorkerMedical.is_special_med_exams_i18n, :first, :last, class: "radio") do |b| %>
-            <div class="radio">
-              <%= b.label { b.radio_button + b.text } %>
-            </div>
-          <% end %>
+      <%# 特別健康診断項目 %>
+      <label><%= yield(:special_med_exam_info) %></label><span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
+      <div class="list-group-item">
+        <%# 特別健康診断の受診状況 %>
+        <div class="mb-1">
+          <%= worker_medical.label :is_special_med_exam %><br>
+          <div class="list-group-item">
+            <%= worker_medical.collection_radio_buttons(:is_special_med_exam, WorkerMedical.is_special_med_exams_i18n, :first, :last, class: "radio") do |b| %>
+              <div class="radio">
+                <%= b.label { b.radio_button + b.text } %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <div id="is_special_med_exam_n_hide">
+          <%# 特別健康診断日%>
+          <div class="mb-1">
+            <%= worker_medical.label :special_med_exam_on %>
+            <%= worker_medical.date_field :special_med_exam_on, class: "form-control", style: "width: 25%;" %>
+          </div>
+
+          <%# 特別健康診断 %>
+          <label><%= yield(:special_med_exam_id_info) %></label>
+          <div class="list-group-item">
+            <%= worker_medical.fields_for :worker_exams do |worker_exam| %>
+              <%= render "worker_exam_fields", f: worker_exam %>
+            <% end %>
+            <div id='worker-exam-insertion-point'></div>
+            <span>　　</span><%= link_to_add_association "＋フォーム追加", worker_medical, :worker_exams,
+              data: {
+                association_insertion_node: '#worker-exam-insertion-point',
+                association_insertion_method: 'append'
+              },
+              class: "btn btn-sm btn-primary mb-3"
+            %>
+          </div>
         </div>
       </div>
-
-      <%# 特別健康診断日   %>
-      <div class="mb-3">
-        <%= worker_medical.label :special_med_exam_on %>
-        <%= worker_medical.date_field :special_med_exam_on, class: "form-control", style: "width: 25%;" %>
-      </div>
-
-      <%# 特別健康診断 %>
-      <%= worker_medical.fields_for :worker_exams do |worker_exam| %>
-        <%= render "worker_exam_fields", f: worker_exam %>
-      <% end %>
-      <div id='worker-exam-insertion-point'></div>
-      <%= link_to_add_association "＋フォーム追加", worker_medical, :worker_exams,
-        data: {
-          association_insertion_node: '#worker-exam-insertion-point',
-          association_insertion_method: 'append'
-        },
-        class: "btn btn-sm btn-primary mb-3"
-      %>
 
       <%# 最近の健康状態 %>
       <div class="mb-3">
@@ -557,6 +574,64 @@
 <!-- 作業員外国人建設就労者情報ここから -->
 
 <script>
+  // 保険情報：健康診断の受診の有無が無であれば診断日、血圧を非表示にする処理
+  $(document).ready(function() {
+    const radioIsMedExam = document.getElementsByName('worker[worker_medical_attributes][is_med_exam]')
+    function HealthInsuranceNameShowOrHide(radioIsMedExam) {
+      let checkedValue;
+      for (const radio of radioIsMedExam) {
+        if (radio.checked) {
+          checkedValue = radio.value;
+          break;
+        }
+      }
+
+      if (checkedValue == 'n'){
+        document.getElementById('is_med_exam_n_hide').style.display = "none";
+      } else {
+        document.getElementById('is_med_exam_n_hide').style.display = "block";
+      }
+    }
+
+    // 健康診断の受診の有無の変更時、非表示処理を実行する
+    for(let i = 0; i < radioIsMedExam.length; i++) {
+      radioIsMedExam[i].addEventListener('change', function() {HealthInsuranceNameShowOrHide(radioIsMedExam);});
+    }
+
+    HealthInsuranceNameShowOrHide(radioIsMedExam); //画面が読み込まれたとき非表示処理を実行する
+  })
+</script>
+
+<script>
+  // 保険情報：特別健康診断の受診の有無が無であれば診断日、診断種類を非表示にする処理
+  $(document).ready(function() {
+    const radioIsSpecialMedExam = document.getElementsByName('worker[worker_medical_attributes][is_special_med_exam]')
+    function IsSpecialMedExamNHideShowOrHide(radioIsSpecialMedExam) {
+      let checkedValue;
+      for (const radio of radioIsSpecialMedExam) {
+        if (radio.checked) {
+          checkedValue = radio.value;
+          break;
+        }
+      }
+
+      if (checkedValue == 'n'){
+        document.getElementById('is_special_med_exam_n_hide').style.display = "none";
+      } else {
+        document.getElementById('is_special_med_exam_n_hide').style.display = "block";
+      }
+    }
+
+    // 健康診断の受診の有無の変更時、非表示処理を実行する
+    for(let i = 0; i < radioIsSpecialMedExam.length; i++) {
+      radioIsSpecialMedExam[i].addEventListener('change', function() {IsSpecialMedExamNHideShowOrHide(radioIsSpecialMedExam);});
+    }
+
+    IsSpecialMedExamNHideShowOrHide(radioIsSpecialMedExam); //画面が読み込まれたとき非表示処理を実行する
+  })
+</script>
+
+<script>
   // 国籍が日本以外の選択時に外国人就労者情報のフォームを表示させる
   $(document).ready(function() {
     // 国の選択肢が変更されたときに呼び出される関数を定義する
@@ -647,6 +722,7 @@
     }
   }
 
+  // 健康保険が適用除外もしくは、未加入の場合、健康保険証の写しを非表示にする
   function HealthInsuranceImage(radioHealthInsuranceTypes) {
     let checkedValue;
     for (const radio of radioHealthInsuranceTypes) {

--- a/app/views/users/workers/_worker_exam_fields.html.erb
+++ b/app/views/users/workers/_worker_exam_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="nested-fields">
-  <div class="row mt-3">
+  <div class="row mt-1">
     <div class="col-md-3">
       <%= f.label :special_med_exam_id %>
       <%= f.collection_select :special_med_exam_id, SpecialMedExam.all, :id, :name, { prompt: '特別健康診断の種類を選択してください' }, { class: "form-control" } %>

--- a/app/views/users/workers/show.html.erb
+++ b/app/views/users/workers/show.html.erb
@@ -396,7 +396,6 @@
           <td></td>
           <td></td>
         </tr>
-        <!-- worker_insuranceここまで -->
         <!-- 資格情報ここから -->
         <tr>
           <td><div style="font-size: 22px; font-weight: bold;"><%=  yield(:worker_licenses_info) %></div><!-- 作業員資格情報 --></td>
@@ -411,21 +410,30 @@
           <th><%= WorkerSpecialEducation.human_attribute_name(:images) %></th>
           <th></th>
         </tr>
-        <% @worker.worker_special_educations.each do |worker_special_education| %>
-          <tr>
-            <% if @worker.special_educations.first.id == worker_special_education.special_education_id %>
-              <th>&emsp;&emsp;<%= WorkerSpecialEducation.human_attribute_name(:special_education_id) %></th>
-            <% else %>
-              <th></th>
-            <% end %>
-            <%# 名称 %>
-            <td><%= worker_special_education.special_education.name %></td>
-            <td>
-              <% worker_special_education.images.each do |image| %>
-                <%# 特別教育修了証明書の写し %>
-                <%= image_tag(image.url) %>
+        <% if @worker.worker_special_educations.present? %>
+          <% @worker.worker_special_educations.each do |worker_special_education| %>
+            <tr>
+              <% if @worker.special_educations.first.id == worker_special_education.special_education_id %>
+                <th>&emsp;&emsp;<%= WorkerSpecialEducation.human_attribute_name(:special_education_id) %></th>
+              <% else %>
+                <th></th>
               <% end %>
-            </td>
+            <%# 名称 %>
+              <td></td>
+              <td>
+                <% worker_special_education.images.each do |image| %>
+                  <%# 特別教育修了証明書の写し %>
+                  <%= image_tag(image.url) %>
+                <% end %>
+              </td>
+              <td></td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <th>&emsp;&emsp;<%= WorkerSpecialEducation.human_attribute_name(:special_education_id) %></th>
+            <td></td>
+            <td></td>
             <td></td>
           </tr>
         <% end %>
@@ -436,13 +444,14 @@
           <th><%= WorkerSkillTraining.human_attribute_name(:images) %></th>
           <th></th>
         </tr>
-        <% @worker.worker_skill_trainings.each do |worker_skill_training| %>
-          <tr>
-            <% if @worker.skill_trainings.first.id == worker_skill_training.skill_training_id %>
-              <th>&emsp;&emsp;<%= WorkerSkillTraining.human_attribute_name(:skill_training_id) %></th>
-            <% else %>
-              <th></th>
-            <% end %>
+        <% if @worker.worker_special_educations.present? %>
+          <% @worker.worker_skill_trainings.each do |worker_skill_training| %>
+            <tr>
+              <% if @worker.skill_trainings.first.id == worker_skill_training.skill_training_id %>
+                <th>&emsp;&emsp;<%= WorkerSkillTraining.human_attribute_name(:skill_training_id) %></th>
+              <% else %>
+                <th></th>
+              <% end %>
             <%# 名称 %>
             <td><%= worker_skill_training.skill_training.name %></td>
             <td>
@@ -453,23 +462,32 @@
             </td>
             <td></td>
           </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <th>&emsp;&emsp;<%= WorkerSkillTraining.human_attribute_name(:skill_training_id) %></th>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
         <% end %>
         <!-- worker_liceseここから -->
+        <%# 技能検定 %>
         <tr bgcolor="#dee2e6">
           <th></th>
           <th>&emsp;&emsp;<%= License.human_attribute_name(:name) %></th>
           <th><%= WorkerLicense.human_attribute_name(:images) %></th>
           <th></th>
         </tr>
-        <%# 技能検定 %>
-        <% @worker.worker_licenses.each do |worker_license| %>
-          <tr>
-            <% if @worker.licenses.first.id == worker_license.license_id %>
-              <%# 技能検定 %>
+        <% if @worker.worker_licenses.present? %>
+          <% @worker.worker_licenses.each do |worker_license| %>
+            <tr>
+              <% if @worker.licenses.first.id == worker_license.license_id %>
+                <%# 技能検定 %>
               <th>&emsp;&emsp;<%= WorkerLicense.human_attribute_name(:license_id) %></th>
-            <% else %>
-              <th></th>
-            <% end %>
+              <% else %>
+                <th></th>
+              <% end %>
             <%# 名称 %>
             <td><%= worker_license.license.name %></td>
             <td>
@@ -479,18 +497,27 @@
               <% end %>
             </td>
             <td></td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <th>&emsp;&emsp;<%= WorkerLicense.human_attribute_name(:license_id) %></th>
+            <td></td>
+            <td></td>
+            <td></td>
           </tr>
         <% end %>
         <!-- worker_liceseここまで -->
         <!-- worker_skill_trainingここまで -->
         <%# worker_safety_health_educationここから %>
-          <tr bgcolor="#dee2e6">
-            <th></th>
-            <th>&emsp;&emsp;<%= SpecialEducation.human_attribute_name(:name) %></th>
-            <%# 安全衛生教育の写し %>
-            <th><%= WorkerSafetyHealthEducation.human_attribute_name(:images) %></th>
-            <th></th>
-          </tr>
+        <tr bgcolor="#dee2e6">
+          <th></th>
+          <th>&emsp;&emsp;<%= SpecialEducation.human_attribute_name(:name) %></th>
+          <%# 安全衛生教育の写し %>
+          <th><%= WorkerSafetyHealthEducation.human_attribute_name(:images) %></th>
+          <th></th>
+        </tr>
+        <% if @worker.worker_safety_health_educations.present? %>
           <% @worker.worker_safety_health_educations.each do |worker_safety_health_education| %>
             <tr>
               <% if @worker.safety_health_educations.first.id == worker_safety_health_education.safety_health_education_id %>
@@ -507,7 +534,15 @@
               </td>
               <td></td>
             </tr>
-          <% end %>       
+          <% end %>
+        <% else %>
+          <tr>
+            <th>&emsp;&emsp;<%= WorkerSafetyHealthEducation.human_attribute_name(:safety_health_education_id) %></th>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+        <% end %>
         <%# worker_safety_health_educationここまで %>
         <%# 自動車運転免許証 %>
           <tr>

--- a/app/views/users/workers/show.html.erb
+++ b/app/views/users/workers/show.html.erb
@@ -419,7 +419,7 @@
                 <th></th>
               <% end %>
             <%# 名称 %>
-              <td></td>
+              <td><%= worker_special_education.special_education.name %></td>
               <td>
                 <% worker_special_education.images.each do |image| %>
                   <%# 特別教育修了証明書の写し %>

--- a/app/views/users/workers/show.html.erb
+++ b/app/views/users/workers/show.html.erb
@@ -2,7 +2,9 @@
 <% provide(:worker_info, "【作業員情報】") %>
 <% provide(:worker_emergency_contact_info, "【緊急連絡先】") %>
 <% provide(:worker_health_info, "【健康情報】") %>
+<% provide(:is_med_exam_info, "健康診断") %>
 <% provide(:worker_health_info_blood_pressure, "血圧") %>
+<% provide(:special_med_exam_info, "特別健康診断") %>
 <% provide(:worker_insurances_info, "【保険情報】") %>
 <% provide(:worker_licenses_info, "【資格情報】") %>
 <% provide(:worker_foreign_construction_workers_info, "【外国人建設就労者情報】") %>
@@ -205,68 +207,84 @@
           <td></td>
         </tr>
         <!-- worker_medicalここから -->
-        <%# 健康診断 %>
-          <th>&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:is_med_exam) %></th>
+
+        <%# 健康診断項目 %>
+        <tr>
+          <td><label>&emsp;&emsp;<%= yield(:is_med_exam_info) %></label></td>
+        </tr>
+        <%# 受診の有無 %>
+        <tr>
+          <th>&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:is_med_exam) %></th>
           <td><%= @worker.worker_medical.is_med_exam_i18n %><td>
           <td></td>
         </tr>
-        <%# 健康診断日 %>
-        <tr>
-          <th>&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:med_exam_on) %></th>
-          <td><%= @worker.worker_medical.med_exam_on %><td>
-          <td></td>
-        </tr>
-        <%# 血圧 %>
-        <tr>
-          <th>&emsp;&emsp;<%= yield(:worker_health_info_blood_pressure) %></th>
-        </tr>
-        <%# 最高 %>
-        <tr>
-          <th>&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:max_blood_pressure) %></th>
-          <td><%= @worker.worker_medical.max_blood_pressure %><td>
-          <td></td>
-        </tr>
-        <%# 最低 %>
-        <tr>
-          <th>&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:min_blood_pressure) %></th>
-          <td><%= @worker.worker_medical.min_blood_pressure %><td>
-          <td></td>
-        </tr>
-        <%# 診断日 %>
-        <tr>
-          <th>&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:special_med_exam_on) %></th>
-          <td><%= @worker.worker_medical.special_med_exam_on %><td>
-          <td></td>
-        </tr>
-        <!-- worker_medicalここまで -->
-        <!-- worker_examここから -->
-        <%# 特別健康診断 %>
-        <th>&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:is_special_med_exam) %></th>
-        <td><%= @worker.worker_medical.is_special_med_exam_i18n %><td>
-        <tr bgcolor="#dee2e6">
-          <th></th>
-          <th>&emsp;&emsp;<%= SpecialMedExam.human_attribute_name(:name) %></th>
-          <th></th>
-          <th></th>
-        </tr>
-        
-        <% @worker.worker_medical.worker_exams.each do |worker_exam| %>
+        <% if @worker.worker_medical.is_med_exam_i18n == '有' %>
+          <%# 健康診断日 %>
           <tr>
-            <% if @worker.worker_medical.special_med_exams.first.id == worker_exam.special_med_exam_id %>
-              <%# 診断種類 %>
-              <th>&emsp;&emsp;<%= WorkerExam.human_attribute_name(:special_med_exam_id) %></th>
-            <% else %>
-              <th></th>
-            <% end %>
-            <td colspan="4">
-              <%= worker_exam.special_med_exam.name %>
-              <% if worker_exam.special_med_exam.name == 'その他' %>
-                （<%= worker_exam.others %>）
-              <% end %>
-            </td>
+            <th>&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:med_exam_on) %></th>
+            <td><%= @worker.worker_medical.med_exam_on %><td>
+            <td></td>
+          </tr>
+          <%# 血圧 %>
+          <tr>
+            <th>&emsp;&emsp;&emsp;&emsp;<%= yield(:worker_health_info_blood_pressure) %></th>
+          </tr>
+          <%# 最高 %>
+          <tr>
+            <th>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:max_blood_pressure) %></th>
+            <td><%= @worker.worker_medical.max_blood_pressure %><td>
+            <td></td>
+          </tr>
+          <%# 最低 %>
+          <tr>
+            <th>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:min_blood_pressure) %></th>
+            <td><%= @worker.worker_medical.min_blood_pressure %><td>
+            <td></td>
           </tr>
         <% end %>
+        <!-- worker_medicalここまで -->
+        <!-- worker_examここから -->
+        <%# 特別健康診断項目 %>
+        <tr>
+          <td><label>&emsp;&emsp;<%= yield(:special_med_exam_info) %></label></td>
+        </tr>
+        <%# 受診の有無 %>
+        <tr>
+          <th>&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:is_special_med_exam) %></th>
+          <td><%= @worker.worker_medical.is_special_med_exam_i18n %><td>
+        </td>
+        <% if @worker.worker_medical.is_special_med_exam_i18n == '有' %>
+          <%# 診断日 %>
+          <tr>
+            <th>&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:special_med_exam_on) %></th>
+            <td><%= @worker.worker_medical.special_med_exam_on %><td>
+            <td></td>
+          </tr>
+
+          <tr bgcolor="#dee2e6">
+            <th></th>
+            <th>&emsp;&emsp;&emsp;&emsp;<%= SpecialMedExam.human_attribute_name(:name) %></th>
+            <th></th>
+            <th></th>
+          </tr>
         
+          <% @worker.worker_medical.worker_exams.each do |worker_exam| %>
+            <tr>
+              <% if @worker.worker_medical.special_med_exams.first.id == worker_exam.special_med_exam_id %>
+                <%# 診断種類 %>
+                <th>&emsp;&emsp;&emsp;&emsp;<%= WorkerExam.human_attribute_name(:special_med_exam_id) %></th>
+              <% else %>
+                <th></th>
+              <% end %>
+              <td colspan="4">
+                <%= worker_exam.special_med_exam.name %>
+                <% if worker_exam.special_med_exam.name == 'その他' %>
+                  （<%= worker_exam.others %>）
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
 
         <!-- worker_examここまで -->
         <%# 最近の健康状態 %>

--- a/app/views/users/workers/show.html.erb
+++ b/app/views/users/workers/show.html.erb
@@ -15,6 +15,9 @@
       <tbody>
         <tr>
           <td><div style="font-size: 22px; font-weight: bold;"><%= yield(:worker_info) %></div><!-- 作業員情報 --></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <%# 技能者ID(キャリアアップシステム) %>
         <tr>
@@ -33,6 +36,8 @@
                 <%= image_tag(image.url) %>
               <% end %>
             </td>
+            <td></td>
+            <td></td>
         </tr>
         <%# 名前 %>
         <tr>
@@ -133,18 +138,23 @@
         <%# 従業員証の写し %>
         <tr>
           <th>&emsp;&emsp;<%= Worker.human_attribute_name(:employee_cards) %></th>
-            <td>
-              <% if @worker.employee_cards.present? %>
-                <% @worker.employee_cards.each do |image| %>
-                  <%# 技能講習修了証明書の写し %>
-                  <%= image_tag(image.url) %>
-                <% end %>
+          <td>
+            <% if @worker.employee_cards.present? %>
+              <% @worker.employee_cards.each do |image| %>
+                <%# 技能講習修了証明書の写し %>
+                <%= image_tag(image.url) %>
               <% end %>
-            </td>
+            <% end %>
+          </td>
+          <td></td>
+          <td></td>
         </tr>
 
         <tr>
           <td><div style="font-size: 22px; font-weight: bold;"><%=  yield(:worker_emergency_contact_info) %></div><!-- 作業員緊急連絡先 --></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <%# 緊急連絡先：氏名 %>
         <tr>
@@ -177,6 +187,9 @@
 
         <tr>
           <td><div style="font-size: 22px; font-weight: bold;"><%=  yield(:worker_health_info) %></div><!-- 作業員健康情報 --></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <%# 生年月日 %>
         <tr>
@@ -211,6 +224,9 @@
         <%# 健康診断項目 %>
         <tr>
           <td><label>&emsp;&emsp;<%= yield(:is_med_exam_info) %></label></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <%# 受診の有無 %>
         <tr>
@@ -228,6 +244,9 @@
           <%# 血圧 %>
           <tr>
             <th>&emsp;&emsp;&emsp;&emsp;<%= yield(:worker_health_info_blood_pressure) %></th>
+            <td></td>
+            <td></td>
+            <td></td>
           </tr>
           <%# 最高 %>
           <tr>
@@ -247,11 +266,15 @@
         <%# 特別健康診断項目 %>
         <tr>
           <td><label>&emsp;&emsp;<%= yield(:special_med_exam_info) %></label></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <%# 受診の有無 %>
         <tr>
           <th>&emsp;&emsp;&emsp;&emsp;<%= WorkerMedical.human_attribute_name(:is_special_med_exam) %></th>
           <td><%= @worker.worker_medical.is_special_med_exam_i18n %><td>
+          <td></td>
         </td>
         <% if @worker.worker_medical.is_special_med_exam_i18n == '有' %>
           <%# 診断日 %>
@@ -297,6 +320,9 @@
         <tr >
           <%# 保険情報 %>
           <td><div style="font-size: 22px; font-weight: bold;"><%=  yield(:worker_insurances_info) %></div></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <%# 健康保険 %>
         <tr>
@@ -317,11 +343,13 @@
         <%# 健康保険証の写し %>
         <tr>
           <th>&emsp;&emsp;<%= WorkerInsurance.human_attribute_name(:health_insurance_image) %></th>
-            <td>
-              <% @worker.worker_insurance.health_insurance_image.each do |image| %>
-                <%= image_tag(image.url) %>
-              <% end %>
-            </td>
+          <td>
+            <% @worker.worker_insurance.health_insurance_image.each do |image| %>
+              <%= image_tag(image.url) %>
+            <% end %>
+          </td>
+          <td></td>
+          <td></td>
         </tr>
         <%# 年金保険 %>
         <tr>
@@ -372,6 +400,9 @@
         <!-- 資格情報ここから -->
         <tr>
           <td><div style="font-size: 22px; font-weight: bold;"><%=  yield(:worker_licenses_info) %></div><!-- 作業員資格情報 --></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <!-- worker_special_educationここから -->
         <tr bgcolor="#dee2e6">
@@ -395,6 +426,7 @@
                 <%= image_tag(image.url) %>
               <% end %>
             </td>
+            <td></td>
           </tr>
         <% end %>
         <!-- worker_skill_trainingここから -->
@@ -419,6 +451,7 @@
                 <%= image_tag(image.url) %>
               <% end %>
             </td>
+            <td></td>
           </tr>
         <% end %>
         <!-- worker_liceseここから -->
@@ -445,6 +478,7 @@
                 <%= image_tag(image.url) %>
               <% end %>
             </td>
+            <td></td>
           </tr>
         <% end %>
         <!-- worker_liceseここまで -->
@@ -471,6 +505,7 @@
                   <%= image_tag(image.url) %>
                 <% end %>
               </td>
+              <td></td>
             </tr>
           <% end %>       
         <%# worker_safety_health_educationここまで %>
@@ -505,6 +540,9 @@
           <!-- 外国人建設就労者情報ここから -->
           <tr>
             <td><div style="font-size: 22px; font-weight: bold;"><%=  yield(:worker_foreign_construction_workers_info) %></div></td>
+            <td></td>
+            <td></td>
+            <td></td>
           </tr>
           <%# 在留資格 %>
           <tr>

--- a/config/locales/model_ja.yml
+++ b/config/locales/model_ja.yml
@@ -434,10 +434,10 @@ ja:
         med_exam_on: 健康診断日
         max_blood_pressure: 最高
         min_blood_pressure: 最低
-        is_special_med_exam: 特別健康診断
+        is_special_med_exam: 受診の有無
         special_med_exam_on: 診断日
         health_condition: 最近の健康状態
-        is_med_exam: 健康診断の受診
+        is_med_exam: 受診の有無
       worker_exam:
         special_med_exam_id: 診断種類
         others: その他

--- a/config/locales/model_ja.yml
+++ b/config/locales/model_ja.yml
@@ -24,11 +24,12 @@ ja:
       request_order: 下請発注情報
       worker: 作業員情報
       license: 免許マスタ
-      worker_license: 中間テーブル(免許マスタ)
+      worker_license: 技能検定
       skill_training: 技能講習マスタ
-      worker_skill_training: 中間テーブル(技能講習マスタ)
+      worker_skill_training: 技能講習
       special_education: 特別教育マスタ
-      worker_special_education: 中間テーブル(特別教育マスタ)
+      worker_special_education: 特別教育
+      worker_safety_health_education: 安全衛生教育
       worker_insurance: 保険情報
       news: お知らせ
       document: 書類

--- a/db/migrate/20220316123818_create_worker_medicals.rb
+++ b/db/migrate/20220316123818_create_worker_medicals.rb
@@ -3,9 +3,9 @@ class CreateWorkerMedicals < ActiveRecord::Migration[6.1]
     create_table :worker_medicals do |t|
       t.references :worker, null: false, foreign_key: true
       t.integer :is_med_exam, null: false, default: 0         # 健康診断の受診有無 enum
-      t.date :med_exam_on, null: false                        # 健康診断日
-      t.integer :max_blood_pressure, null: false              # 最高血圧
-      t.integer :min_blood_pressure, null: false              # 最低血圧
+      t.date :med_exam_on                                     # 健康診断日
+      t.integer :max_blood_pressure                           # 最高血圧
+      t.integer :min_blood_pressure                           # 最低血圧
       t.integer :is_special_med_exam, null: false, default: 1 # 特別健康診断の受診有無 enum
       t.date :special_med_exam_on                             # 特別健康診断日
       t.integer :health_condition, null: false, default: 0    # 最近の健康状態 enum

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,9 +106,9 @@ ActiveRecord::Schema.define(version: 2023_03_13_135036) do
     t.json "tem_industry_ids"
     t.string "employment_manager_name"
     t.integer "foreign_work_status_exist"
-    t.integer "specific_skilled_foreigners_exist", default: 1, null: false
-    t.integer "foreign_construction_workers_exist", default: 1, null: false
-    t.integer "foreign_technical_intern_trainees_exist", default: 1, null: false
+    t.integer "specific_skilled_foreigners_exist"
+    t.integer "foreign_construction_workers_exist"
+    t.integer "foreign_technical_intern_trainees_exist"
     t.integer "construction_license_status", null: false, comment: "建設許可証(取得状況) enum"
     t.string "foreigners_employment_manager"
     t.bigint "user_id", null: false
@@ -725,9 +725,9 @@ ActiveRecord::Schema.define(version: 2023_03_13_135036) do
   create_table "worker_medicals", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "worker_id", null: false
     t.integer "is_med_exam", default: 0, null: false
-    t.date "med_exam_on", null: false
-    t.integer "max_blood_pressure", null: false
-    t.integer "min_blood_pressure", null: false
+    t.date "med_exam_on"
+    t.integer "max_blood_pressure"
+    t.integer "min_blood_pressure"
     t.integer "is_special_med_exam", default: 1, null: false
     t.date "special_med_exam_on"
     t.integer "health_condition", default: 0, null: false


### PR DESCRIPTION
### 概要
・不具合・問題表No.41の対応
・不具合・問題表No.42の対応
・作業員情報詳細画面レイアウト修正
・作業員情報編集画面レイアウト修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
〇作業員情報No.41
　・フォームの非表示をJSで行い、パラメーターのnil化
〇作業員情報No.42
　・詳細画面のerb文で表示を条件分岐させた
〇レイアウト修正
　・詳細画面と編集画面の大項目を【】で囲む
　・編集画面の健康保険項目をひとまとめにした。
　・編集情報の特別健康保険をひとまとめにした。

### 実装画像などあれば添付する
不具合・問題表No.41：https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=797611446

不具合・問題表No.42：https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=1913359850

修正後の画面：https://drive.google.com/drive/folders/1Ns1Q7iQAPkdOqtNsahs4vysWEkXegLeX
