### PR TITLE
会社情報フォーム_エラー修正（森本）

### DIFF
--- a/app/controllers/users/businesses_controller.rb
+++ b/app/controllers/users/businesses_controller.rb
@@ -1,10 +1,10 @@
 # rubocop:disable all
 module Users
   class BusinessesController < Users::Base
-    before_action :set_business, except: %i[new create]
+    before_action :set_business, except: %i[new create occupation_select]
     before_action :set_business_workers_name, only: %i[edit update]
     before_action :business_present_access, only: %i[new create]
-    skip_before_action :business_nil_access, only: %i[new create]
+    skip_before_action :business_nil_access, only: %i[new create occupation_select]
 
     def new
       if Rails.env.development?
@@ -43,6 +43,7 @@ module Users
       if @business.save
         redirect_to users_orders_url
       else
+        session[:tem_industry_ids] = params[:business][:tem_industry_ids].map(&:to_i).reject(&:zero?)
         render :new
       end
     end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -215,12 +215,19 @@ module DocumentsHelper
     f_type == yes_no ? tag.span(yes_no, class: :circle) : yes_no
   end
 
-  def occupation_default(list)
-    if params[:action] == "edit" && @business.tem_industry_ids.present?
-      Occupation.where(industry_id: @business.tem_industry_ids.map(&:to_i).reject(&:zero?))
-    else
-      Occupation.all
-    end
+  def get_occupations_for_selected_industries
+    industry_ids =
+      if params.dig(:business, :tem_industry_ids)&.any? # 新規 - 業種のみ選択
+        params[:business][:tem_industry_ids].map(&:to_i).compact
+      elsif @business&.tem_industry_ids&.any? # 編集 - 既定選択
+        @business.tem_industry_ids.map(&:to_i).compact
+      elsif session[:tem_industry_ids]&.any? # 新規 - 業種＆職種を選択
+        session[:tem_industry_ids].map(&:to_i).compact
+      else # 一切未選択
+        []
+      end
+  
+    Occupation.where(industry_id: industry_ids)
   end
   
   def constr_license_info(ordinal_number, document_type, column)

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -82,7 +82,7 @@
     <br>
     <%= f.label :occupation_ids %><!-- 職種 -->
     <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-    <%= f.collection_select :occupation_ids, occupation_default(@business), :id, :short_name, { selected: @business.occupations.ids }, { class: 'form-control select2', id: 'child-select', multiple: true, style: "width: 100%" } %>
+    <%= f.collection_select :occupation_ids, get_occupations_for_selected_industries, :id, :short_name, { selected: @business.occupations.ids }, { class: 'form-control select2', id: 'child-select', multiple: true, style: "width: 100%" } %>
     <br>
     <br>
     <%= f.label :employment_manager_name %> <!-- 雇用管理責任者 -->
@@ -213,8 +213,10 @@
     <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
     <div class="list-group-item">
       <div id="available-form-foreign-work">
-        <%= f.collection_radio_buttons(:foreign_work_status_exist, Business.foreign_work_status_exists_i18n, :first, :last, item_wrapper_class: 'radio-button-item') do |b| %>
-          <%= b.label(class: 'radio-button-label') { b.radio_button + ' ' + b.text } %><br>
+        <% Business.foreign_work_status_exists_i18n.each do |key, value| %>
+          <%= f.radio_button :foreign_work_status_exist, key, id: "foreign_work_status_exist_#{key}" %>
+          <%= label_tag "foreign_work_status_exist_#{key}", value %>
+          <span class="radio-spacing"></span>
         <% end %>
       </div>
     </div>
@@ -223,24 +225,30 @@
       <%= f.label :specific_skilled_foreigners_exist %><!-- 一号特定技能外国人従事状況 -->
       <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
       <div class="list-group-item">
-        <%= f.collection_radio_buttons(:specific_skilled_foreigners_exist, Business.specific_skilled_foreigners_exists_i18n, :first, :last, item_wrapper_class: 'radio-button-item') do |b| %>
-            <%= b.label(class: 'radio-button-label') { b.radio_button + ' ' + b.text } %><br>
+        <% Business.specific_skilled_foreigners_exists_i18n.each do |key, value| %>
+          <%= f.radio_button :specific_skilled_foreigners_exist, key, id: "specific_skilled_foreigners_exist_#{key}" %>
+          <%= label_tag "specific_skilled_foreigners_exist_#{key}", value %>
+          <span class="radio-spacing"></span>
         <% end %>
       </div>
       <br>
       <%= f.label :foreign_construction_workers_exist %><!-- 外国人建設就労者従事状況 -->
       <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
       <div class="list-group-item">
-        <%= f.collection_radio_buttons(:foreign_construction_workers_exist, Business.foreign_construction_workers_exists_i18n, :first, :last, item_wrapper_class: 'radio-button-item') do |b| %>
-          <%= b.label(class: 'radio-button-label') { b.radio_button + ' ' + b.text } %><br>
+        <% Business.foreign_construction_workers_exists_i18n.each do |key, value| %>
+          <%= f.radio_button :foreign_construction_workers_exist, key, id: "foreign_construction_workers_exist_#{key}" %>
+          <%= label_tag "foreign_construction_workers_exist_#{key}", value %>
+          <span class="radio-spacing"></span>
         <% end %>
       </div>
       <br>
       <%= f.label :foreign_technical_intern_trainees_exist %><!-- 外国人技能実習生従事状況 -->
       <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
       <div class="list-group-item">
-        <%= f.collection_radio_buttons(:foreign_technical_intern_trainees_exist, Business.foreign_technical_intern_trainees_exists_i18n, :first, :last, item_wrapper_class: 'radio-button-item') do |b| %>
-          <%= b.label(class: 'radio-button-label') { b.radio_button + ' ' + b.text } %><br>
+        <% Business.foreign_technical_intern_trainees_exists_i18n.each do |key, value| %>
+          <%= f.radio_button :foreign_technical_intern_trainees_exist, key, id: "foreign_technical_intern_trainees_exist_#{key}" %>
+          <%= label_tag "foreign_technical_intern_trainees_exist_#{key}", value %>
+          <span class="radio-spacing"></span>
         <% end %>
       </div>
       <br>
@@ -436,7 +444,7 @@
         "business[tem_industry_ids][]": {
           required: true
         },
-        "business_occupations[occupation_id][]": {
+        "business[occupation_ids][]": {
           required: true
         },
         // "business[employment_manager_name]": {
@@ -468,9 +476,6 @@
           required: true
         },
         "business[construction_license_status]": {
-          required: true
-        },
-        "business[tem_industry_ids][]": {
           required: true
         },
         "business[business_industries_attributes][construction_license_permission_type_minister_governor]": {
@@ -576,6 +581,9 @@
         "business[tem_industry_ids][]": {
           required: "業種を選択してください。"
         },
+        "business[occupation_ids][]": {
+          required: "職種を選択してください。"
+        },
         "business[business_industries_attributes][construction_license_permission_type_minister_governor]": {
           required: "どちらかを選択してください。"
         },
@@ -598,19 +606,27 @@
           required: "どちらかを選択してください。"
         },
         "business[specific_skilled_foreigners_exist]": {
-          required: "どれか一つを選択してください。"
+          required: "どちらかを選択してください。"
         },
         "business[foreign_construction_workers_exist]": {
-          required: "どれか一つを選択してください。"
+          required: "どちらかを選択してください。"
         },
         "business[foreign_technical_intern_trainees_exist]": {
-          required: "どれか一つを選択してください。"
+          required: "どちらかを選択してください。"
         },
         // "business[foreigners_employment_manager]": {
         //   required: "外国人雇用管理責任者名を選択してください。"
         // },
       },
-      errorClass: "input_form_error"
+      errorClass: "input_form_error",
+      
+      errorPlacement: function(error, element) {
+        if (element.is(":radio")) {
+          error.insertBefore(element.parent());
+        } else {
+          error.insertBefore(element);
+        }     
+      }
     });
 
 


### PR DESCRIPTION
### 概要
会社情報フォーム内の下記不具合を修正
- 業種/職種にて、英字メッセージを日本語表示
- 新規登録時に、業種/職種が紐づいた状態で表示
- 外国人関連のエラーメッセージ表示位置を修正

### タスク
- [x] なし

### 実装内容・手法
Javascript/コントローラー側の挙動を見直すことで修正

### 実装画像などあれば添付する
・英字メッセージの日本語化
![業種・職種未選択時にエラーメッセージ](https://user-images.githubusercontent.com/77308890/235095147-03f435c7-8b3b-4162-b1bc-a802de9296d0.png)

・業種/職種の連動表示
![業種選択時に職種絞り込み](https://user-images.githubusercontent.com/77308890/235095225-f18803ce-3892-435d-8c50-aeacb0e3b7e9.png)

・エラーメッセージの表示位置
![会社情報-外国人建設就労者](https://user-images.githubusercontent.com/77308890/235095312-5649b75b-e01e-4e38-8b58-b2574832c9d4.png)
