### PR TITLE
会社情報_ボタン削除/不具合解消（森本）

### DIFF
--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -14,9 +14,11 @@
     <%= f.label :business_type %><!--会社形態-->
     <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
     <div class="list-group-item">
+      <div id="available-form-business-type">
       <%= f.collection_radio_buttons(:business_type, Business.business_types_i18n, :first, :last, item_wrapper_class: 'radio-button-item') do |b| %>
         <%= b.label(class: 'radio-button-label') { b.radio_button + ' ' + b.text } %><br>
       <% end %>
+      </div>
     </div>
     <br>
     <%= f.label :name %><!-- 会社名 -->
@@ -82,11 +84,13 @@
     <%= f.collection_select :occupation_ids, get_occupations_for_selected_industries, :id, :short_name, { selected: @business.occupations.ids }, { class: 'form-control select2', id: 'child-select', multiple: true, style: "width: 100%" } %>
     <br>
     <br>
+    <div id="hidden-form-business-type">
     <%= f.label :employment_manager_name %> <!-- 雇用管理責任者 -->
     <%= f.select :employment_manager_name, (@business_workers_name&.uniq || []),
                   { include_blank: true },
                   { class: "form-select form-select-sm", style: "width: 100%" }
     %><br>
+    </div>
   </div>
 </div>
 
@@ -250,6 +254,25 @@
 <%= f.hidden_field :email, value: current_user.email %>
 
 <script>
+//一人親方かどうかによってフォームの表示・非表示の切り替え
+  const available_form_business_type = document.getElementById('available-form-business-type')
+  const list_group_business_type = document.getElementById('hidden-form-business-type')
+  function getRadioBusinessType(object) {
+    const value = $('input[name="business[business_type]"]:checked').val();
+    if (value != 'freelance'){
+      list_group_business_type.classList.remove('hidden');
+    } else {
+      list_group_business_type.classList.add('hidden');
+    }
+  };
+  getRadioBusinessType(available_form_business_type); //ページの読み込み時に判定
+  $('input[name="business[business_type]"]').change(function() {
+    if ($(this).val() != 'freelance') {
+      list_group_business_type.classList.remove('hidden');
+    } else {
+      list_group_business_type.classList.add('hidden');
+    }
+  });
 //健康保険の加入状況によってフォームの表示・非表示の切り替え
   const available_form_health_insurance = document.getElementById('available-form-health-insurance')
   const list_group_health_insurance = document.getElementById('hidden-form-health-insurance')
@@ -601,13 +624,13 @@
         // },
       },
       errorClass: "input_form_error",
-      
+
       errorPlacement: function(error, element) {
         if (element.is(":radio")) {
           error.insertBefore(element.parent());
         } else {
           error.insertBefore(element);
-        }     
+        }
       }
     });
 

--- a/app/views/users/businesses/show.html.erb
+++ b/app/views/users/businesses/show.html.erb
@@ -214,7 +214,6 @@
   </div>
   <div class="card-footer">
     <%= link_to "編集", edit_users_business_path, class: "btn btn-md btn-block btn-success" %>
-    <button id="page_go_back" class="btn btn-md btn-block btn-default">戻る</button>
   </div>
 
   <script>


### PR DESCRIPTION
### 概要
会社情報詳細ページにて「戻る」ボタンの削除
不具合（No.19）の解消
No.19：一人親方の場合、「雇用管理責任者名」は非表示

### タスク
- [x] なし

### 実装内容・手法
Javascriptにてフォーム表示/非表示を実装

### 実装画像などあれば添付する
会社情報ー詳細にて「戻る」ボタンを削除
![スクリーンショット 2023-05-01 0 21 17](https://user-images.githubusercontent.com/77308890/235361349-890d22cd-51e3-4c0b-96fe-6e2258c055e3.png)

一人親方の場合、「雇用管理責任者名」の非表示（下記は一人親方選択時）
![スクリーンショット 2023-05-01 0 20 39](https://user-images.githubusercontent.com/77308890/235361399-612fe56a-992a-444b-9e36-77161d6c0c6d.png)
