### PR TITLE
作業員情報URLジェネレーションエラー修正

### DIFF
--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -22,7 +22,7 @@
     <%# キャリアアップシステムカードの写し %>
     <%= f.label :career_up_images %>
     <%= f.file_field :career_up_images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
-    <% if @worker.career_up_images.present? %>
+    <% if @worker.career_up_images.present? && @worker.id.present? %>
       <% @worker.career_up_images.each_with_index do |image, index| %>
         <%= image_tag(image.url) %>
         <%= link_to "削除", users_worker_update_career_up_images_path(@worker, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
@@ -105,7 +105,7 @@
     <%# 従業員証の写し %>
     <%= f.label :employee_cards %>
     <%= f.file_field :employee_cards, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
-    <% if @worker.employee_cards.present? %>
+    <% if @worker.employee_cards.present? && @worker.id.present? %>
       <% @worker.employee_cards.each_with_index do |image, index| %>
         <%= image_tag(image.url) %>
         <%= link_to "削除", users_worker_update_employee_cards_path(@worker, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
@@ -312,10 +312,10 @@
             <%= worker_insurance.label :health_insurance_image %>
             <div style="margin-bottom: 10px;">
               <%= worker_insurance.file_field :health_insurance_image, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
-              <% if @worker.worker_insurance.health_insurance_image.present? %>
+              <% if @worker.worker_insurance.health_insurance_image.present? && @worker.id.present? %>
                 <% @worker.worker_insurance.health_insurance_image.each_with_index do |image, index| %>
                   <%= image_tag(image.url) %>
-                  <%= link_to "削除", users_worker_update_health_insurance_image_path(@worker, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+                  <%= link_to "削除", users_worker_update_health_insurance_image_path(@worker.id, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
                 <% end %>
               <% end %>
             </div>
@@ -485,7 +485,7 @@
     <%# 認印 %>
     <%= f.label :seal %>
     <%= f.file_field :seal, accept: 'image/jpg, image/jpeg, image/png', class: "form-control" %>
-    <% if @worker.seal.present? %>
+    <% if @worker.seal.present? && @worker.id.present? %>
       <%= image_tag(@worker.seal.url) %>
       <%= link_to "削除", users_worker_delete_seal_path(@worker), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
     <% end %>
@@ -540,7 +540,7 @@
       <%= f.label :passports %>
       <div class="col-md-8" style="margin-bottom: 10px;">
         <%= f.file_field :passports, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
-        <% if @worker.passports.present? %>
+        <% if @worker.passports.present? && @worker.id.present? %>
           <% @worker.passports.each_with_index do |image, index| %>
             <%= image_tag(image.url) %>
             <%= link_to "削除", users_worker_update_passports_path(@worker, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
@@ -553,7 +553,7 @@
       <%= f.label :residence_cards %>
       <div class="col-md-8" style="margin-bottom: 10px;">
         <%= f.file_field :residence_cards, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
-        <% if @worker.residence_cards.present? %>
+        <% if @worker.residence_cards.present? && @worker.id.present? %>
           <% @worker.residence_cards.each_with_index do |image, index| %>
             <%= image_tag(image.url) %>
             <%= link_to "削除", users_worker_update_residence_cards_path(@worker, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
@@ -566,7 +566,7 @@
       <%= f.label :employment_conditions %>
       <div class="col-md-8" style="margin-bottom: 10px;">
         <%= f.file_field :employment_conditions, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
-        <% if @worker.employment_conditions.present? %>
+        <% if @worker.employment_conditions.present? && @worker.id.present? %>
           <% @worker.employment_conditions.each_with_index do |image, index| %>
             <%= image_tag(image.url) %>
             <%= link_to "削除", users_worker_update_employment_conditions_path(@worker, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
@@ -1078,8 +1078,14 @@
         "worker[employment_contract]": {
           required: "雇用契約書を取り交わしたかどうかを選択してください。"
         },
+        "worker[status_of_residence]": {
+          required: "在留資格を選択してください。"
+        },
+        "worker[confirmed_check]": {
+          required: "CCUS登録情報が最新であることの確認を選択してください。"
+        },
         "worker[maturity_date]": {
-          required: "CCUS登録情報が最新であることの確認を選択してください"
+          required: "在留期間満期日を入力してください"
         },
         "worker[confirmed_check_date]": {
           required: "キャリアアップシステム登録情報が最新であることの確認日を選択してください"

--- a/app/views/users/workers/_worker_license_fields.html.erb
+++ b/app/views/users/workers/_worker_license_fields.html.erb
@@ -9,9 +9,11 @@
       <%= f.file_field :images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
     </div>
     <div class="col-md-3" style="margin-bottom: 10px;">
-      <% f.object.images.each_with_index do |image, index| %>
-        <%= image_tag(image.url) %>
-        <%= link_to "削除", users_worker_update_workerlicense_images_path(@worker, index: index, worker_license_id: f.object.id), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+      <% if @worker.id.present? %>
+        <% f.object.images.each_with_index do |image, index| %>
+          <%= image_tag(image.url) %>
+          <%= link_to "削除", users_worker_update_workerlicense_images_path(@worker, index: index, worker_license_id: f.object.id), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+        <% end %>
       <% end %>
     </div>
     <div class="col-md-2" style="margin-top: 8px;">

--- a/app/views/users/workers/_worker_safety_health_education_fields.erb
+++ b/app/views/users/workers/_worker_safety_health_education_fields.erb
@@ -9,9 +9,11 @@
       <%= f.file_field :images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
     </div>
     <div class="col-md-3" style="margin-bottom: 10px;">
-      <% f.object.images.each_with_index do |image, index| %>
-        <%= image_tag(image.url) %>
-        <%= link_to "削除", users_worker_update_worker_safety_health_education_images_path(@worker, index: index, safety_health_education_id: f.object.id), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+      <% if @worker.id.present? %>
+        <% f.object.images.each_with_index do |image, index| %>
+          <%= image_tag(image.url) %>
+          <%= link_to "削除", users_worker_update_worker_safety_health_education_images_path(@worker, index: index, safety_health_education_id: f.object.id), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+        <% end %>
       <% end %>
     </div>
     <div class="col-md-2" style="margin-top: 8px;">

--- a/app/views/users/workers/_worker_skill_training_fields.html.erb
+++ b/app/views/users/workers/_worker_skill_training_fields.html.erb
@@ -9,9 +9,11 @@
       <%= f.file_field :images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
     </div>
     <div class="col-md-3" style="margin-bottom: 10px;">
-      <% f.object.images.each_with_index do |image, index| %>
-        <%= image_tag(image.url) %>
-        <%= link_to "削除", users_worker_update_workerskilltraining_images_path(@worker, index: index, worker_skill_training_id: f.object.id), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+      <% if @worker.id.present? %>
+        <% f.object.images.each_with_index do |image, index| %>
+          <%= image_tag(image.url) %>
+          <%= link_to "削除", users_worker_update_workerskilltraining_images_path(@worker, index: index, worker_skill_training_id: f.object.id), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+        <% end %>
       <% end %>
     </div>
     <div class="col-md-2" style="margin-top: 8px;">

--- a/app/views/users/workers/_worker_special_education_fields.html.erb
+++ b/app/views/users/workers/_worker_special_education_fields.html.erb
@@ -9,9 +9,11 @@
       <%= f.file_field :images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
     </div>
     <div class="col-md-3" style="margin-bottom: 10px;">
-      <% f.object.images.each_with_index do |image, index| %>
-        <%= image_tag(image.url) %>
-        <%= link_to "削除", users_worker_update_workerspecialeducation_images_path(@worker, index: index, worker_special_education_id: f.object.id), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+      <% if @worker.id.present? %>
+        <% f.object.images.each_with_index do |image, index| %>
+          <%= image_tag(image.url) %>
+          <%= link_to "削除", users_worker_update_workerspecialeducation_images_path(@worker, index: index, worker_special_education_id: f.object.id), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+        <% end %>
       <% end %>
     </div>
     <div class="col-md-2" style="margin-top: 8px;">


### PR DESCRIPTION
### 概要
作業員情報URLジェネレーションエラー修正
### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
作業員情報マスタ、新規登録画面で、画像を入力し、バリデーションではじかれて戻った時、エラー発生。
そのエラーを当該リンクを非表示にする条件分岐を使い対応

### 実装画像などあれば添付する


