### PR TITLE
会社情報で削除された建設許可証番号関連のデータを現場情報で保持する(伊藤)

### DIFF
--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 module Users
   class OrdersController < Users::Base
     before_action :prime_contractor_access, except: :index
@@ -153,7 +154,218 @@ module Users
       redirect_to users_request_order_path(uuid: request_order)
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
+    # 業種1(建設許可証番号)がbusiness_industryにない時も取得する
+    def occupation_1st
+      occupation_info_1st = params.dig(:order, :content, :construction_license_number)&.slice(0)
+      if occupation_info_1st.present?
+        business_industry_occupation_1st = BusinessIndustry.find_by(id: occupation_info_1st)
+        industry_id_1st = BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.industry_id
+        if business_industry_occupation_1st.nil? && (occupation_info_1st == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_occupation_1st')
+        elsif business_industry_occupation_1st.nil? && (occupation_info_1st == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_occupation_2nd')
+        else
+          Industry.find_by(id: industry_id_1st)&.name
+        end
+      end
+    end
+
+    # 業種2(建設許可証番号)がbusiness_industryにない時も取得する
+    def occupation_2nd
+      occupation_info_2nd = params.dig(:order, :content, :construction_license_number)&.slice(1)
+      if occupation_info_2nd.present?
+        business_industry_occupation_2nd = BusinessIndustry.find_by(id: occupation_info_2nd)
+        industry_id_2nd = BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.industry_id
+        if business_industry_occupation_2nd.nil? && (occupation_info_2nd == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_occupation_1st')
+        elsif business_industry_occupation_2nd.nil? && (occupation_info_2nd == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_occupation_2nd')
+        else
+          Industry.find_by(id: industry_id_2nd)&.name
+        end
+      end
+    end
+
+    # 建設業許可種別(大臣,知事)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_permission_type_minister_governor_1st
+      construction_license_permission_type_minister_governor_info_1st = params.dig(:order, :content, :construction_license_number)&.slice(0)
+      if construction_license_permission_type_minister_governor_info_1st.present?
+        business_industry_minister_governor_1st = BusinessIndustry.find_by(id: construction_license_permission_type_minister_governor_info_1st)
+        if business_industry_minister_governor_1st.nil? && (construction_license_permission_type_minister_governor_info_1st == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_permission_type_minister_governor_1st')
+        elsif business_industry_minister_governor_1st.nil? && (construction_license_permission_type_minister_governor_info_1st == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_permission_type_minister_governor_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_permission_type_minister_governor_i18n
+        end
+      end
+    end
+
+    # 建設業許可種別(大臣,知事)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_permission_type_minister_governor_2nd
+      construction_license_permission_type_minister_governor_info_2nd = params.dig(:order, :content, :construction_license_number)&.slice(1)
+      if construction_license_permission_type_minister_governor_info_2nd.present?
+        business_industry_minister_governor_2nd = BusinessIndustry.find_by(id: construction_license_permission_type_minister_governor_info_2nd)
+        if business_industry_minister_governor_2nd.nil? && (construction_license_permission_type_minister_governor_info_2nd == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_permission_type_minister_governor_1st')
+        elsif business_industry_minister_governor_2nd.nil? && (construction_license_permission_type_minister_governor_info_2nd == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_permission_type_minister_governor_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_permission_type_minister_governor_i18n
+        end
+      end
+    end
+
+    # 建設業許可種別(特定,一般)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_permission_type_identification_general_1st
+      construction_license_permission_type_identification_general_info_1st = params.dig(:order, :content, :construction_license_number)&.slice(0)
+      if construction_license_permission_type_identification_general_info_1st.present?
+        business_industry_identification_general_1st = BusinessIndustry.find_by(id: construction_license_permission_type_identification_general_info_1st)
+        if business_industry_identification_general_1st.nil? && (construction_license_permission_type_identification_general_info_1st == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_permission_type_identification_general_1st')
+        elsif business_industry_identification_general_1st.nil? && (construction_license_permission_type_identification_general_info_1st == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_permission_type_identification_general_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_permission_type_identification_general_i18n
+        end
+      end
+    end
+
+    # 建設業許可種別(特定,一般)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_permission_type_identification_general_2nd
+      construction_license_permission_type_identification_general_info_2nd = params.dig(:order, :content, :construction_license_number)&.slice(1)
+      if construction_license_permission_type_identification_general_info_2nd.present?
+        business_industry_identification_general_2nd = BusinessIndustry.find_by(id: construction_license_permission_type_identification_general_info_2nd)
+        if business_industry_identification_general_2nd.nil? && (construction_license_permission_type_identification_general_info_2nd == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_permission_type_identification_general_1st')
+        elsif business_industry_identification_general_2nd.nil? && (construction_license_permission_type_identification_general_info_2nd == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_permission_type_identification_general_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_permission_type_identification_general_i18n
+        end
+      end
+    end
+
+    # 建設業許可番号(2桁)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_number_double_digit_1st
+      construction_license_number_double_digit_info_1st = params.dig(:order, :content, :construction_license_number)&.slice(0)
+      if construction_license_number_double_digit_info_1st.present?
+        business_industry_double_digit_1st = BusinessIndustry.find_by(id: construction_license_number_double_digit_info_1st)
+        if business_industry_double_digit_1st.nil? && (construction_license_number_double_digit_info_1st == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_number_double_digit_1st')
+        elsif business_industry_double_digit_1st.nil? && (construction_license_number_double_digit_info_1st == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_number_double_digit_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_number_double_digit
+        end
+      end
+    end
+
+    # 建設業許可番号(2桁)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_number_double_digit_2nd
+      construction_license_number_double_digit_info_2nd = params.dig(:order, :content, :construction_license_number)&.slice(1)
+      if construction_license_number_double_digit_info_2nd.present?
+        business_industry_double_digit_2nd = BusinessIndustry.find_by(id: construction_license_number_double_digit_info_2nd)
+        if business_industry_double_digit_2nd.nil? && (construction_license_number_double_digit_info_2nd == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_number_double_digit_1st')
+        elsif business_industry_double_digit_2nd.nil? && (construction_license_number_double_digit_info_2nd == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_number_double_digit_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_number_double_digit
+        end
+      end
+    end
+
+    # 建設業許可番号(6桁)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_number_six_digits_1st
+      construction_license_number_six_digits_info_1st = params.dig(:order, :content, :construction_license_number)&.slice(0)
+      if construction_license_number_six_digits_info_1st.present?
+        business_industry_six_digits_1st = BusinessIndustry.find_by(id: construction_license_number_six_digits_info_1st)
+        if business_industry_six_digits_1st.nil? && (construction_license_number_six_digits_info_1st == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_number_six_digits_1st')
+        elsif business_industry_six_digits_1st.nil? && (construction_license_number_six_digits_info_1st == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_number_six_digits_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_number_six_digits
+        end
+      end
+    end
+
+    # 建設業許可番号(6桁)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_number_six_digits_2nd
+      construction_license_number_six_digits_info_2nd = params.dig(:order, :content, :construction_license_number)&.slice(1)
+      if construction_license_number_six_digits_info_2nd.present?
+        business_industry_six_digits_2nd = BusinessIndustry.find_by(id: construction_license_number_six_digits_info_2nd)
+        if business_industry_six_digits_2nd.nil? && (construction_license_number_six_digits_info_2nd == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_number_six_digits_1st')
+        elsif business_industry_six_digits_2nd.nil? && (construction_license_number_six_digits_info_2nd == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_number_six_digits_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_number_six_digits
+        end
+      end
+    end
+
+    # 建設許可証(更新日)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_updated_at_1st
+      construction_license_updated_at_info_1st = params.dig(:order, :content, :construction_license_number)&.slice(0)
+      if construction_license_updated_at_info_1st.present?
+        business_industry_updated_at_1st = BusinessIndustry.find_by(id: construction_license_updated_at_info_1st)
+        if business_industry_updated_at_1st.nil? && (construction_license_updated_at_info_1st == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_updated_at_1st')
+        elsif business_industry_updated_at_1st.nil? && (construction_license_updated_at_info_1st == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_updated_at_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_updated_at
+        end
+      end
+    end
+
+    # 建設許可証(更新日)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_updated_at_2nd
+      construction_license_updated_at_info_2nd = params.dig(:order, :content, :construction_license_number)&.slice(1)
+      if construction_license_updated_at_info_2nd.present?
+        business_industry_updated_at_2nd = BusinessIndustry.find_by(id: construction_license_updated_at_info_2nd)
+        if business_industry_updated_at_2nd.nil? && (construction_license_updated_at_info_2nd == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_updated_at_1st')
+        elsif business_industry_updated_at_2nd.nil? && (construction_license_updated_at_info_2nd == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_updated_at_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_updated_at
+        end
+      end
+    end
+
+    # 建設許可証番号1がbusiness_industryにない時も取得する
+    def construction_license_number_1st
+      construction_license_number_info_1st = params.dig(:order, :content, :construction_license_number)&.slice(0)
+      if construction_license_number_info_1st.present?
+        business_industry_construction_license_1st = BusinessIndustry.find_by(id: construction_license_number_info_1st)
+        if business_industry_construction_license_1st.nil? && (construction_license_number_info_1st == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_number_1st')
+        elsif business_industry_construction_license_1st.nil? && (construction_license_number_info_1st == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_number_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_number
+        end
+      end
+    end
+
+    # 建設許可証番号2がbusiness_industryにない時も取得する
+    def construction_license_number_2nd
+      construction_license_number_info_2nd = params.dig(:order, :content, :construction_license_number)&.slice(1)
+      if construction_license_number_info_2nd.present?
+        business_industry_construction_license_2nd = BusinessIndustry.find_by(id: construction_license_number_info_2nd)
+        if business_industry_construction_license_2nd.nil? && (construction_license_number_info_2nd == @order.content&.[]('genecon_construction_license_id_1st'))
+          @order.content&.[]('genecon_construction_license_number_1st')
+        elsif business_industry_construction_license_2nd.nil? && (construction_license_number_info_2nd == @order.content&.[]('genecon_construction_license_id_2nd'))
+          @order.content&.[]('genecon_construction_license_number_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_number
+        end
+      end
+    end
+
     def order_params
       params.require(:order).permit(
         :site_career_up_id,
@@ -202,28 +414,28 @@ module Users
           genecon_employment_insurance_join_status:                                current_business.business_employment_insurance_join_status,        # 雇用保険加入状況
           genecon_employment_insurance_number:                                     current_business.business_employment_insurance_number, # 雇用保険番号
           # 建設許可証関連
-          genecon_construction_license_id_1st:                                     params.dig(:order, :content, :construction_license_number)&.slice(0),                                                                                                 # 建設許可証番号のid1
-          genecon_occupation_1st:                                                  Industry.find_by(id: BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.industry_id)&.name,                          # 業種1
-          genecon_construction_license_permission_type_minister_governor_1st:      BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_permission_type_minister_governor_i18n,      # 建設業許可種別(大臣,知事)1
-          genecon_construction_license_permission_type_identification_general_1st: BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_permission_type_identification_general_i18n, # 建設業許可種別(特定,一般)1
-          genecon_construction_construction_license_number_double_digit_1st:       BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_number_double_digit,                         # 建設業許可番号(2桁)1
-          genecon_construction_license_number_six_digits_1st:                      BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_number_six_digits,                           # 建設業許可番号(6桁)1
-          genecon_construction_license_updated_at_1st:                             BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_updated_at,                                  # 建設許可証(更新日)1
-          genecon_construction_license_number_1st:                                 BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(0))&.construction_license_number,                                      # 建設許可証番号1
-          genecon_construction_license_id_2nd:                                     params.dig(:order, :content, :construction_license_number)&.slice(1),                                                                                                 # 建設許可証番号のid2
-          genecon_occupation_2nd:                                                  Industry.find_by(id: BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.industry_id)&.name,                          # 業種2
-          genecon_construction_license_permission_type_minister_governor_2nd:      BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_permission_type_minister_governor_i18n,      # 建設業許可種別(大臣,知事)2
-          genecon_construction_license_permission_type_identification_general_2nd: BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_permission_type_identification_general_i18n, # 建設業許可種別(特定,一般)2
-          genecon_construction_construction_license_number_double_digit_2nd:       BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_number_double_digit,                         # 建設業許可番号(2桁)2
-          genecon_construction_license_number_six_digits_2nd:                      BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_number_six_digits,                           # 建設業許可番号(6桁)2
-          genecon_construction_license_updated_at_2nd:                             BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_updated_at,                                  # 建設許可証(更新日)2
-          genecon_construction_license_number_2nd:                                 BusinessIndustry.find_by(id: params.dig(:order, :content, :construction_license_number)&.slice(1))&.construction_license_number,                                      # 建設許可証番号2
-          genecon_specific_skilled_foreigners_exist:                               current_business.specific_skilled_foreigners_exist_i18n,                           # 一号特定技能外国人の従事の状況(有無)
-          genecon_foreign_construction_workers_exist:                              current_business.foreign_construction_workers_exist_i18n,                          # 外国人建設就労者の従事の状況(有無)
-          genecon_foreign_technical_intern_trainees_exist:                         current_business.foreign_technical_intern_trainees_exist_i18n                      # 外国人技能実習生の従事の状況(有無)
+          genecon_construction_license_id_1st:                                     params.dig(:order, :content, :construction_license_number)&.slice(0),    # 建設許可証番号のid1
+          genecon_occupation_1st:                                                  occupation_1st,                                                          # 業種1
+          genecon_construction_license_permission_type_minister_governor_1st:      construction_license_permission_type_minister_governor_1st,              # 建設業許可種別(大臣,知事)1
+          genecon_construction_license_permission_type_identification_general_1st: construction_license_permission_type_identification_general_1st,         # 建設業許可種別(特定,一般)1
+          genecon_construction_license_number_double_digit_1st:                    construction_license_number_double_digit_1st,                            # 建設業許可番号(2桁)1
+          genecon_construction_license_number_six_digits_1st:                      construction_license_number_six_digits_1st,                              # 建設業許可番号(6桁)1
+          genecon_construction_license_updated_at_1st:                             construction_license_updated_at_1st,                                     # 建設許可証(更新日)1
+          genecon_construction_license_number_1st:                                 construction_license_number_1st,                                         # 建設許可証番号1
+          genecon_construction_license_id_2nd:                                     params.dig(:order, :content, :construction_license_number)&.slice(1),    # 建設許可証番号のid2
+          genecon_occupation_2nd:                                                  occupation_2nd,                                                          # 業種2
+          genecon_construction_license_permission_type_minister_governor_2nd:      construction_license_permission_type_minister_governor_2nd,              # 建設業許可種別(大臣,知事)2
+          genecon_construction_license_permission_type_identification_general_2nd: construction_license_permission_type_identification_general_2nd,         # 建設業許可種別(特定,一般)2
+          genecon_construction_license_number_double_digit_2nd:                    construction_license_number_double_digit_2nd,                            # 建設業許可番号(2桁)2
+          genecon_construction_license_number_six_digits_2nd:                      construction_license_number_six_digits_2nd,                              # 建設業許可番号(6桁)2
+          genecon_construction_license_updated_at_2nd:                             construction_license_updated_at_2nd,                                     # 建設許可証(更新日)2
+          genecon_construction_license_number_2nd:                                 construction_license_number_2nd,                                         # 建設許可証番号2
+          genecon_specific_skilled_foreigners_exist:                               current_business.specific_skilled_foreigners_exist_i18n,                 # 一号特定技能外国人の従事の状況(有無)
+          genecon_foreign_construction_workers_exist:                              current_business.foreign_construction_workers_exist_i18n,                # 外国人建設就労者の従事の状況(有無)
+          genecon_foreign_technical_intern_trainees_exist:                         current_business.foreign_technical_intern_trainees_exist_i18n            # 外国人技能実習生の従事の状況(有無)
         }
       )
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
   end
 end
+# rubocop:enable all

--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 module Users
   class RequestOrdersController < Users::Base
     before_action :set_business_workers_name, only: %i[edit update]
@@ -166,7 +167,218 @@ module Users
         Worker.find_by(name: request_order_params[:construction_manager_name])&.job_title
     end
 
-    # rubocop:disable all
+    # 業種1(建設許可証番号)がbusiness_industryにない時も取得する
+    def occupation_1st
+      occupation_info_1st = params.dig(:request_order, :content, :construction_license_number)&.slice(0)
+      if occupation_info_1st.present?
+        business_industry_occupation_1st = BusinessIndustry.find_by(id: occupation_info_1st)
+        industry_id_1st = BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.industry_id
+        if business_industry_occupation_1st.nil? && (occupation_info_1st == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_occupation_1st')
+        elsif business_industry_occupation_1st.nil? && (occupation_info_1st == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_occupation_2nd')
+        else
+          Industry.find_by(id: industry_id_1st)&.name
+        end
+      end
+    end
+
+    # 業種2(建設許可証番号)がbusiness_industryにない時も取得する
+    def occupation_2nd
+      occupation_info_2nd = params.dig(:request_order, :content, :construction_license_number)&.slice(1)
+      if occupation_info_2nd.present?
+        business_industry_occupation_2nd = BusinessIndustry.find_by(id: occupation_info_2nd)
+        industry_id_2nd = BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.industry_id
+        if business_industry_occupation_2nd.nil? && (occupation_info_2nd == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_occupation_1st')
+        elsif business_industry_occupation_2nd.nil? && (occupation_info_2nd == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_occupation_2nd')
+        else
+          Industry.find_by(id: industry_id_2nd)&.name
+        end
+      end
+    end
+
+    # 建設業許可種別(大臣,知事)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_permission_type_minister_governor_1st
+      construction_license_permission_type_minister_governor_info_1st = params.dig(:request_order, :content, :construction_license_number)&.slice(0)
+      if construction_license_permission_type_minister_governor_info_1st.present?
+        business_industry_minister_governor_1st = BusinessIndustry.find_by(id: construction_license_permission_type_minister_governor_info_1st)
+        if business_industry_minister_governor_1st.nil? && (construction_license_permission_type_minister_governor_info_1st == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_permission_type_minister_governor_1st')
+        elsif business_industry_minister_governor_1st.nil? && (construction_license_permission_type_minister_governor_info_1st == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_permission_type_minister_governor_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_permission_type_minister_governor_i18n
+        end
+      end
+    end
+
+    # 建設業許可種別(大臣,知事)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_permission_type_minister_governor_2nd
+      construction_license_permission_type_minister_governor_info_2nd = params.dig(:request_order, :content, :construction_license_number)&.slice(1)
+      if construction_license_permission_type_minister_governor_info_2nd.present?
+        business_industry_minister_governor_2nd = BusinessIndustry.find_by(id: construction_license_permission_type_minister_governor_info_2nd)
+        if business_industry_minister_governor_2nd.nil? && (construction_license_permission_type_minister_governor_info_2nd == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_permission_type_minister_governor_1st')
+        elsif business_industry_minister_governor_2nd.nil? && (construction_license_permission_type_minister_governor_info_2nd == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_permission_type_minister_governor_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_permission_type_minister_governor_i18n
+        end
+      end
+    end
+
+    # 建設業許可種別(特定,一般)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_permission_type_identification_general_1st
+      construction_license_permission_type_identification_general_info_1st = params.dig(:request_order, :content, :construction_license_number)&.slice(0)
+      if construction_license_permission_type_identification_general_info_1st.present?
+        business_industry_identification_general_1st = BusinessIndustry.find_by(id: construction_license_permission_type_identification_general_info_1st)
+        if business_industry_identification_general_1st.nil? && (construction_license_permission_type_identification_general_info_1st == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_permission_type_identification_general_1st')
+        elsif business_industry_identification_general_1st.nil? && (construction_license_permission_type_identification_general_info_1st == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_permission_type_identification_general_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_permission_type_identification_general_i18n
+        end
+      end
+    end
+
+    # 建設業許可種別(特定,一般)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_permission_type_identification_general_2nd
+      construction_license_permission_type_identification_general_info_2nd = params.dig(:request_order, :content, :construction_license_number)&.slice(1)
+      if construction_license_permission_type_identification_general_info_2nd.present?
+        business_industry_identification_general_2nd = BusinessIndustry.find_by(id: construction_license_permission_type_identification_general_info_2nd)
+        if business_industry_identification_general_2nd.nil? && (construction_license_permission_type_identification_general_info_2nd == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_permission_type_identification_general_1st')
+        elsif business_industry_identification_general_2nd.nil? && (construction_license_permission_type_identification_general_info_2nd == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_permission_type_identification_general_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_permission_type_identification_general_i18n
+        end
+      end
+    end
+
+    # 建設業許可番号(2桁)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_number_double_digit_1st
+      construction_license_number_double_digit_info_1st = params.dig(:request_order, :content, :construction_license_number)&.slice(0)
+      if construction_license_number_double_digit_info_1st.present?
+        business_industry_double_digit_1st = BusinessIndustry.find_by(id: construction_license_number_double_digit_info_1st)
+        if business_industry_double_digit_1st.nil? && (construction_license_number_double_digit_info_1st == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_number_double_digit_1st')
+        elsif business_industry_double_digit_1st.nil? && (construction_license_number_double_digit_info_1st == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_number_double_digit_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_number_double_digit
+        end
+      end
+    end
+
+    # 建設業許可番号(2桁)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_number_double_digit_2nd
+      construction_license_number_double_digit_info_2nd = params.dig(:request_order, :content, :construction_license_number)&.slice(1)
+      if construction_license_number_double_digit_info_2nd.present?
+        business_industry_double_digit_2nd = BusinessIndustry.find_by(id: construction_license_number_double_digit_info_2nd)
+        if business_industry_double_digit_2nd.nil? && (construction_license_number_double_digit_info_2nd == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_number_double_digit_1st')
+        elsif business_industry_double_digit_2nd.nil? && (construction_license_number_double_digit_info_2nd == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_number_double_digit_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_number_double_digit
+        end
+      end
+    end
+
+    # 建設業許可番号(6桁)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_number_six_digits_1st
+      construction_license_number_six_digits_info_1st = params.dig(:request_order, :content, :construction_license_number)&.slice(0)
+      if construction_license_number_six_digits_info_1st.present?
+        business_industry_six_digits_1st = BusinessIndustry.find_by(id: construction_license_number_six_digits_info_1st)
+        if business_industry_six_digits_1st.nil? && (construction_license_number_six_digits_info_1st == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_number_six_digits_1st')
+        elsif business_industry_six_digits_1st.nil? && (construction_license_number_six_digits_info_1st == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_number_six_digits_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_number_six_digits
+        end
+      end
+    end
+
+    # 建設業許可番号(6桁)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_number_six_digits_2nd
+      construction_license_number_six_digits_info_2nd = params.dig(:request_order, :content, :construction_license_number)&.slice(1)
+      if construction_license_number_six_digits_info_2nd.present?
+        business_industry_six_digits_2nd = BusinessIndustry.find_by(id: construction_license_number_six_digits_info_2nd)
+        if business_industry_six_digits_2nd.nil? && (construction_license_number_six_digits_info_2nd == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_number_six_digits_1st')
+        elsif business_industry_six_digits_2nd.nil? && (construction_license_number_six_digits_info_2nd == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_number_six_digits_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_number_six_digits
+        end
+      end
+    end
+
+    # 建設許可証(更新日)1(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_updated_at_1st
+      construction_license_updated_at_info_1st = params.dig(:request_order, :content, :construction_license_number)&.slice(0)
+      if construction_license_updated_at_info_1st.present?
+        business_industry_updated_at_1st = BusinessIndustry.find_by(id: construction_license_updated_at_info_1st)
+        if business_industry_updated_at_1st.nil? && (construction_license_updated_at_info_1st == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_updated_at_1st')
+        elsif business_industry_updated_at_1st.nil? && (construction_license_updated_at_info_1st == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_updated_at_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_updated_at
+        end
+      end
+    end
+
+    # 建設許可証(更新日)2(建設許可証番号)がbusiness_industryにない時も取得する
+    def construction_license_updated_at_2nd
+      construction_license_updated_at_info_2nd = params.dig(:request_order, :content, :construction_license_number)&.slice(1)
+      if construction_license_updated_at_info_2nd.present?
+        business_industry_updated_at_2nd = BusinessIndustry.find_by(id: construction_license_updated_at_info_2nd)
+        if business_industry_updated_at_2nd.nil? && (construction_license_updated_at_info_2nd == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_updated_at_1st')
+        elsif business_industry_updated_at_2nd.nil? && (construction_license_updated_at_info_2nd == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_updated_at_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_updated_at
+        end
+      end
+    end
+
+    # 建設許可証番号1がbusiness_industryにない時も取得する
+    def construction_license_number_1st
+      construction_license_number_info_1st = params.dig(:request_order, :content, :construction_license_number)&.slice(0)
+      if construction_license_number_info_1st.present?
+        business_industry_construction_license_1st = BusinessIndustry.find_by(id: construction_license_number_info_1st)
+        if business_industry_construction_license_1st.nil? && (construction_license_number_info_1st == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_number_1st')
+        elsif business_industry_construction_license_1st.nil? && (construction_license_number_info_1st == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_number_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_number
+        end
+      end
+    end
+
+    # 建設許可証番号2がbusiness_industryにない時も取得する
+    def construction_license_number_2nd
+      construction_license_number_info_2nd = params.dig(:request_order, :content, :construction_license_number)&.slice(1)
+      if construction_license_number_info_2nd.present?
+        business_industry_construction_license_2nd = BusinessIndustry.find_by(id: construction_license_number_info_2nd)
+        if business_industry_construction_license_2nd.nil? && (construction_license_number_info_2nd == @request_order.content&.[]('subcon_construction_license_id_1st'))
+          @request_order.content&.[]('subcon_construction_license_number_1st')
+        elsif business_industry_construction_license_2nd.nil? && (construction_license_number_info_2nd == @request_order.content&.[]('subcon_construction_license_id_2nd'))
+          @request_order.content&.[]('subcon_construction_license_number_2nd')
+        else
+          BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_number
+        end
+      end
+    end
+
     def request_order_params
       params.require(:request_order).permit(
         :occupation,
@@ -218,22 +430,22 @@ module Users
           subcon_employment_insurance_join_status:                                current_business.business_employment_insurance_join_status,        # 雇用保険加入状況
           subcon_employment_insurance_number:                                     current_business.business_employment_insurance_number,             # 雇用保険番号
           # 建設許可証関連
-          subcon_construction_license_id_1st:                                     params.dig(:request_order, :content, :construction_license_number)&.slice(0),                                                                                                 # 建設許可証番号のid1
-          subcon_occupation_1st:                                                  Industry.find_by(id: BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.industry_id)&.name,                          # 業種1
-          subcon_construction_license_permission_type_minister_governor_1st:      BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_permission_type_minister_governor_i18n,      # 建設業許可種別(大臣,知事)1
-          subcon_construction_license_permission_type_identification_general_1st: BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_permission_type_identification_general_i18n, # 建設業許可種別(特定,一般)1
-          subcon_construction_construction_license_number_double_digit_1st:       BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_number_double_digit,                         # 建設業許可番号(2桁)1
-          subcon_construction_license_number_six_digits_1st:                      BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_number_six_digits,                           # 建設業許可番号(6桁)1
-          subcon_construction_license_updated_at_1st:                             BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_updated_at,                                  # 建設許可証(更新日)1
-          subcon_construction_license_number_1st:                                 BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(0))&.construction_license_number,                                      # 建設許可証番号1
+          subcon_construction_license_id_1st:                                     params.dig(:request_order, :content, :construction_license_number)&.slice(0), # 建設許可証番号のid1
+          subcon_occupation_1st:                                                  occupation_1st,                                                               # 業種1
+          subcon_construction_license_permission_type_minister_governor_1st:      construction_license_permission_type_minister_governor_1st,                   # 建設業許可種別(大臣,知事)1
+          subcon_construction_license_permission_type_identification_general_1st: construction_license_permission_type_identification_general_1st,              # 建設業許可種別(特定,一般)1
+          subcon_construction_license_number_double_digit_1st:                    construction_license_number_double_digit_1st,                                 # 建設業許可番号(2桁)1
+          subcon_construction_license_number_six_digits_1st:                      construction_license_number_six_digits_1st,                                   # 建設業許可番号(6桁)1
+          subcon_construction_license_updated_at_1st:                             construction_license_updated_at_1st,                                          # 建設許可証(更新日)1
+          subcon_construction_license_number_1st:                                 construction_license_number_1st,                                              # 建設許可証番号1
           subcon_construction_license_id_2nd:                                     params.dig(:request_order, :content, :construction_license_number)&.slice(1), # 建設許可証番号のid2
-          subcon_occupation_2nd:                                                  Industry.find_by(id: BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.industry_id)&.name,                          # 業種2
-          subcon_construction_license_permission_type_minister_governor_2nd:      BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_permission_type_minister_governor_i18n,      # 建設業許可種別(大臣,知事)2
-          subcon_construction_license_permission_type_identification_general_2nd: BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_permission_type_identification_general_i18n, # 建設業許可種別(特定,一般)2
-          subcon_construction_construction_license_number_double_digit_2nd:       BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_number_double_digit,                         # 建設業許可番号(2桁)2
-          subcon_construction_license_number_six_digits_2nd:                      BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_number_six_digits,                           # 建設業許可番号(6桁)2
-          subcon_construction_license_updated_at_2nd:                             BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_updated_at,                                  # 建設許可証(更新日)2
-          subcon_construction_license_number_2nd:                                 BusinessIndustry.find_by(id: params.dig(:request_order, :content, :construction_license_number)&.slice(1))&.construction_license_number,                                      # 建設許可証番号2
+          subcon_occupation_2nd:                                                  occupation_2nd,                                                               # 業種2
+          subcon_construction_license_permission_type_minister_governor_2nd:      construction_license_permission_type_minister_governor_2nd,                   # 建設業許可種別(大臣,知事)2
+          subcon_construction_license_permission_type_identification_general_2nd: construction_license_permission_type_identification_general_2nd,              # 建設業許可種別(特定,一般)2
+          subcon_construction_license_number_double_digit_2nd:                    construction_license_number_double_digit_2nd,                                 # 建設業許可番号(2桁)2
+          subcon_construction_license_number_six_digits_2nd:                      construction_license_number_six_digits_2nd,                                   # 建設業許可番号(6桁)2
+          subcon_construction_license_updated_at_2nd:                             construction_license_updated_at_2nd,                                          # 建設許可証(更新日)2
+          subcon_construction_license_number_2nd:                                 construction_license_number_2nd,                                              # 建設許可証番号2
 
           subcon_retirement_benefit_mutual_aid_status:                            current_business.business_retirement_benefit_mutual_aid_status, # 退職金共済制度(加入状況)
           subcon_employment_manager_name:                                         @business_workers_name_id.find_by(name: current_business.employment_manager_name)&.name, # 雇用管理責任者名
@@ -249,6 +461,6 @@ module Users
         }
       )
     end
-    # rubocop:enable all
   end
 end
+# rubocop:enable all


### PR DESCRIPTION
### 概要
会社情報で建設許可証番号が削除されても、現場情報に登録されている関連データは保持されるように修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
・ orders_controller.rb、request_orders_controller.rbにおいて、business_industryテーブルにレコードがあるかという条件を入れて、なければ元の値を取得するようなメソッドを適用した。

※ なお、内容が重複しているメソッドになったが、まとめたりすると適用されなかったため、不具合解消を優先した。
rubocopにもコントローラーの記述が長すぎるというエラーが発生したため、やむなく「# rubocop:disable all」「# rubocop:enable all」でエラー回避をした。

### 実装画像などあれば添付する
画像は特になし