### PR TITLE
建設許可証番号の誤った記述を修正(伊藤)

### DIFF
--- a/app/views/users/documents/doc_4th/_edit.html.erb
+++ b/app/views/users/documents/doc_4th/_edit.html.erb
@@ -1,7 +1,7 @@
 <!-- (3)全建統一様式(第2号施⼯体制台帳作成建設⼯事の通知) -->
 <%= form_with model: @document, url: users_request_order_document_path, method: :patch, local: true do |f| %>
   <div class="document-outer">
-    <div class="card">  
+    <div class="card">
       <div class="card-body">
         <%= f.submit '登録', class: 'btn btn-block btn-primary' %>
         <%= link_to '詳細画面へ', users_request_order_document_url, class: "btn btn-md btn-block btn-default" %>
@@ -22,7 +22,7 @@
               <td>(全建統一様式第3号)</td>
               <td class="text-right">
                 <%= f.date_field :content, name: "document[content][date_submitted]",
-                                    value: doc_content_date(@document.content&.[]("date_submitted"))                 
+                                    value: doc_content_date(@document.content&.[]("date_submitted"))
                 %> <!-- 3-001 提出日（西暦 -->
               </td>
             </tr>
@@ -85,9 +85,9 @@
                 <td width="6%"><span class="circle">特定</span></td><!-- 「特定or一般」⇩　4-008 -->
               <% else %>
                 <td width="4%">特定</td><!-- 「特定or一般」⇩　4-008 -->
-              <% end %> 
+              <% end %>
               <td rowspan="2">
-                <%= document_site_info.content["genecon_construction_construction_license_number_double_digit_1st"] %> <!-- 4-063元請会社の建設許可番号･前半 -->
+                <%= document_site_info.content["genecon_construction_license_number_double_digit_1st"] %> <!-- 4-063元請会社の建設許可番号･前半 -->
               </td>
               <td rowspan="2" width="3%">第</td>
               <td rowspan="2">
@@ -124,9 +124,9 @@
                 <td width="6%"><span class="circle">特定</span></td><!-- 「特定or一般」⇩　4-013 -->
               <% else %>
                 <td width="4%">特定</td><!-- 「特定or一般」⇩　4-013 -->
-              <% end %> 
+              <% end %>
               <td rowspan="2">
-                <%= document_site_info.content["genecon_construction_construction_license_number_double_digit_2nd"] %> <!-- 4-064 元請会社の建設許可番号･前半 -->
+                <%= document_site_info.content["genecon_construction_license_number_double_digit_2nd"] %> <!-- 4-064 元請会社の建設許可番号･前半 -->
               </td>
               <td rowspan="2">第</td>
               <td rowspan="2">
@@ -565,9 +565,9 @@
                 <td width="6%"><span class="circle">特定</span></td><!-- 「特定or一般」⇩　4-114 -->
               <% else %>
                 <td width="4%">特定</td><!-- 「特定or一般」⇩　4-114 -->
-              <% end %> 
+              <% end %>
               <td rowspan="2">
-                <%= document_subcon_info.content["subcon_construction_construction_license_number_double_digit_1st"] %> <!-- 4-145 下請会社の建設許可番号･前半 -->
+                <%= document_subcon_info.content["subcon_construction_license_number_double_digit_1st"] %> <!-- 4-145 下請会社の建設許可番号･前半 -->
               </td>
               <td rowspan="2" width="3%">第</td>
               <td rowspan="2">
@@ -604,9 +604,9 @@
                 <td width="6%"><span class="circle">特定</span></td><!-- 「特定or一般」⇩　4-119 -->
               <% else %>
                 <td width="4%">特定</td><!-- 「特定or一般」⇩　4-119 -->
-              <% end %> 
+              <% end %>
               <td rowspan="2">
-                <%= document_subcon_info.content["subcon_construction_construction_license_number_double_digit_2nd"] %> <!-- 4-146 下請会社の建設許可番号･前半 -->
+                <%= document_subcon_info.content["subcon_construction_license_number_double_digit_2nd"] %> <!-- 4-146 下請会社の建設許可番号･前半 -->
               </td>
               <td rowspan="2">第</td>
               <td rowspan="2">
@@ -693,7 +693,7 @@
               <td rowspan="2"></td>
               <td>資 格 内 容</td>
               <td>
-                <%= SkillTraining.find(document_subcon_info.professional_engineer_qualification)&.name %> <!-- 4-131 専門技術者の必要資格 --> 
+                <%= SkillTraining.find(document_subcon_info.professional_engineer_qualification)&.name %> <!-- 4-131 専門技術者の必要資格 -->
               </td>
             </tr>
             <tr>

--- a/app/views/users/documents/doc_4th/_form.html.erb
+++ b/app/views/users/documents/doc_4th/_form.html.erb
@@ -73,7 +73,7 @@
                 <td width="4%">特定</td><!-- 「特定or一般」⇩　4-008 -->
               <% end %>
               <td rowspan="2">
-                <%= document_site_info.content["genecon_construction_construction_license_number_double_digit_1st"] %> <!-- 4-063元請会社の建設許可番号･前半 -->
+                <%= document_site_info.content["genecon_construction_license_number_double_digit_1st"] %> <!-- 4-063元請会社の建設許可番号･前半 -->
               </td>
               <td rowspan="2" width="3%">第</td>
               <td rowspan="2">
@@ -112,7 +112,7 @@
                 <td width="4%">特定</td><!-- 「特定or一般」⇩　4-013 -->
               <% end  %>
               <td rowspan="2">
-                <%= document_site_info.content["genecon_construction_construction_license_number_double_digit_2nd"] %> <!-- 4-064 元請会社の建設許可番号･前半 -->
+                <%= document_site_info.content["genecon_construction_license_number_double_digit_2nd"] %> <!-- 4-064 元請会社の建設許可番号･前半 -->
               </td>
               <td rowspan="2">第</td>
               <td rowspan="2">
@@ -553,7 +553,7 @@
                 <td width="4%">特定</td><!-- 「特定or一般」⇩　4-114 -->
               <% end %>
               <td rowspan="2">
-                <%= document_subcon_info.content["subcon_construction_construction_license_number_double_digit_1st"] %> <!-- 4-145 下請会社の建設許可番号･前半 -->
+                <%= document_subcon_info.content["subcon_construction_license_number_double_digit_1st"] %> <!-- 4-145 下請会社の建設許可番号･前半 -->
               </td>
               <td rowspan="2" width="3%">第</td>
               <td rowspan="2">
@@ -592,7 +592,7 @@
                 <td width="4%">特定</td><!-- 「特定or一般」⇩　4-119 -->
               <% end %>
               <td rowspan="2">
-                <%= document_subcon_info.content["subcon_construction_construction_license_number_double_digit_2nd"] %> <!-- 4-146 下請会社の建設許可番号･前半 -->
+                <%= document_subcon_info.content["subcon_construction_license_number_double_digit_2nd"] %> <!-- 4-146 下請会社の建設許可番号･前半 -->
               </td>
               <td rowspan="2">第</td>
               <td rowspan="2">

--- a/app/views/users/documents/doc_4th/_form.pdf.erb
+++ b/app/views/users/documents/doc_4th/_form.pdf.erb
@@ -231,7 +231,7 @@
                   <% end %>
                 </td>
                 <td class="s23" colspan="3" rowspan="4">
-                  <%= document_site_info.content["genecon_construction_construction_license_number_double_digit_1st"] %> <!-- 4-063元請会社の建設許可番号･前半 -->
+                  <%= document_site_info.content["genecon_construction_license_number_double_digit_1st"] %> <!-- 4-063元請会社の建設許可番号･前半 -->
                 </td>
                 <td class="s24" colspan="2" rowspan="4" style="border: 1px solid;">第</td>
                 <td class="s25" colspan="4" rowspan="4">
@@ -299,7 +299,7 @@
                   <% end %>
                 </td>
                 <td class="s23" colspan="3" rowspan="4">
-                  <%= document_site_info.content["genecon_construction_construction_license_number_double_digit_2nd"] %> <!-- 4-064 元請会社の建設許可番号･前半 -->
+                  <%= document_site_info.content["genecon_construction_license_number_double_digit_2nd"] %> <!-- 4-064 元請会社の建設許可番号･前半 -->
                 </td>
                 <td class="s24" colspan="2" rowspan="4" style="border: 1px solid;">第</td>
                 <td class="s25" colspan="4" rowspan="4">
@@ -467,7 +467,7 @@
                   <% end %>
                 </td>
                 <td class="s23" colspan="3" rowspan="4">
-                  <%= document_subcon_info.content["subcon_construction_construction_license_number_double_digit_1st"] %> <!-- 4-145 下請会社の建設許可番号･前半 -->
+                  <%= document_subcon_info.content["subcon_construction_license_number_double_digit_1st"] %> <!-- 4-145 下請会社の建設許可番号･前半 -->
                 </td>
                 <td class="s24" colspan="2" rowspan="4" style="border: 1px solid;">第</td>
                 <td class="s34" colspan="4" rowspan="4">
@@ -529,7 +529,7 @@
                   <% end %>
                 </td>
                 <td class="s23" colspan="3" rowspan="4">
-                  <%= document_subcon_info.content["subcon_construction_construction_license_number_double_digit_2nd"] %> <!-- 4-146　下請会社の建設許可番号･前半 -->
+                  <%= document_subcon_info.content["subcon_construction_license_number_double_digit_2nd"] %> <!-- 4-146　下請会社の建設許可番号･前半 -->
                 </td>
                 <td class="s24" colspan="2" rowspan="4" style="border: 1px solid;">第</td>
                 <td class="s34" colspan="4" rowspan="4">
@@ -1320,9 +1320,9 @@
                 <td class="s42" rowspan="6" style="border: 1px solid;"></td>
                 <td class="s6" colspan="5" rowspan="3">資格内容</td>
                 <td class="s8" colspan="22" rowspan="3">
-                  
+
                     <%= SkillTraining.find(document_site_info.professional_engineer_qualification_1st)&.name %> <!-- 4-042 元請会社の専門技術者の必要資格 -->
-                  
+
                 </td>
                 <td class="s42" rowspan="6"></td>
                 <td class="s6" colspan="5" rowspan="3">資格内容</td>

--- a/app/views/users/documents/doc_5th/_edit.html.erb
+++ b/app/views/users/documents/doc_5th/_edit.html.erb
@@ -1,7 +1,7 @@
 <% document_info.children.each do |child| @child = child %>
   <%= form_with model: @document, url: users_request_order_document_path, method: :patch, local: true do |f| %>
     <div class="document-outer">
-      <div class="card">  
+      <div class="card">
         <div class="card-body">
           <%= f.submit '登録', class: 'btn btn-block btn-primary' %>
           <%= link_to '詳細画面へ', users_request_order_document_url, class: "btn btn-md btn-block btn-default" %>
@@ -921,7 +921,7 @@
                 <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
                 <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= minister(@child&.content&.[]('subcon_construction_license_permission_type_minister_governor_1st')) %></td> <!-- 5-113 大臣(右) -->
                 <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= identification(@child&.content&.[]('subcon_construction_license_permission_type_identification_general_1st')) %></td> <!-- 5-114 特定(右) -->
-                <td class="s_5b_211" dir="ltr" colspan="2" rowspan="4"><%= @child&.content&.[]('subcon_construction_construction_license_number_double_digit_1st') %></td> <!-- 5-145 許可番号 第(右) -->
+                <td class="s_5b_211" dir="ltr" colspan="2" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_double_digit_1st') %></td> <!-- 5-145 許可番号 第(右) -->
                 <td class="s_5b_212" dir="ltr" colspan="2" rowspan="4">第</td>
                 <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_six_digits_1st') %></td> <!-- 5-115 建設許可番号 号(右) -->
                 <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1036,7 +1036,7 @@
                 <td class="s_5a_306" dir="ltr" colspan="4" rowspan="4">工事業</td>
                 <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= minister(document_info.content&.[]('subcon_construction_license_permission_type_minister_governor_1st')) %></td> <!-- 5-020 大臣(左) -->
                 <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= identification(document_info.content&.[]('subcon_construction_license_permission_type_identification_general_1st')) %></td> <!-- 5-021 特定(左) -->
-                <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= document_info.content&.[]('subcon_construction_construction_license_number_double_digit_1st') %></td> <!-- 5-055 許可番号 第(左) -->
+                <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= document_info.content&.[]('subcon_construction_license_number_double_digit_1st') %></td> <!-- 5-055 許可番号 第(左) -->
                 <td class="s_5a_312" dir="ltr" colspan="2" rowspan="4">第</td>
                 <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4"><%= document_info.content&.[]('subcon_construction_license_number_six_digits_1st') %></td> <!-- 5-022 建設許可番号 号(左) -->
                 <td class="s_5a_313" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1057,7 +1057,7 @@
                 <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
                 <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= minister(@child&.content&.[]('subcon_construction_license_permission_type_minister_governor_2nd')) %></td> <!-- 5-118 大臣(右) -->
                 <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= identification(@child&.content&.[]('subcon_construction_license_permission_type_identification_general_2nd')) %></td> <!-- 5-119 特定(右) -->
-                <td class="s_5b_211" dir="ltr" colspan="2" rowspan="4"><%= @child&.content&.[]('subcon_construction_construction_license_number_double_digit_2nd') %></td> <!-- 5-146 許可番号 第(右) -->
+                <td class="s_5b_211" dir="ltr" colspan="2" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_double_digit_2nd') %></td> <!-- 5-146 許可番号 第(右) -->
                 <td class="s_5b_212" dir="ltr" colspan="2" rowspan="4">第</td>
                 <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_six_digits_2nd') %></td> <!-- 5-120 建設許可番号 号(右) -->
                 <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1679,14 +1679,14 @@
                 </td>
                 </td>
                 <td class="s_5a_601" dir="ltr" colspan="8" rowspan="4">外国人建設就<br>労者の従事の<br>状況(有無)</td>
-                
+
                 <td class="s_5a_704" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_construction_workers_exist", @child, "有") %> <!-- 5-136 「各会社の外国人建設就労者の従事の状況(有無)」 -->
                 </td>
                 <td class="s_5a_706" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_construction_workers_exist", @child, "無") %> <!-- 5-136 「各会社の外国人建設就労者の従事の状況(有無)」 -->
                 </td>
                 </td><!-- 30列目 -->
                 <td class="s_5a_601" dir="ltr" colspan="8" rowspan="4">外国人技能実<br>習生の従事の<br>状況(有無)</td>
-                
+
                 <td class="s_5a_704" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_technical_intern_trainees_exist", @child, "有") %> <!-- 5-137 「各会社の外国人技能実習生の従事の状況(有無)」 -->
                 </td>
                 <td class="s_5a_706" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_technical_intern_trainees_exist", @child, "無") %> <!-- 5-137 「各会社の外国人技能実習生の従事の状況(有無)」 -->

--- a/app/views/users/documents/doc_5th/_form.html.erb
+++ b/app/views/users/documents/doc_5th/_form.html.erb
@@ -912,7 +912,7 @@
             <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
             <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= minister(@child&.content&.[]('subcon_construction_license_permission_type_minister_governor_1st')) %></td> <!-- 5-113 大臣(右) -->
             <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= identification(@child&.content&.[]('subcon_construction_license_permission_type_identification_general_1st')) %></td> <!-- 5-114 特定(右) -->
-            <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= @child&.content&.[]('subcon_construction_construction_license_number_double_digit_1st') %></td> <!-- 5-145 許可番号 第(右) -->
+            <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_double_digit_1st') %></td> <!-- 5-145 許可番号 第(右) -->
             <td class="s_5b_216" dir="ltr" colspan="2" rowspan="4">第</td>
             <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_six_digits_1st') %></td> <!-- 5-115 建設許可番号 号(右) -->
             <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1026,7 +1026,7 @@
             <td class="s_5a_306" dir="ltr" colspan="4" rowspan="4">工事業</td>
             <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= minister(document_info.content&.[]('subcon_construction_license_permission_type_minister_governor_1st')) %></td> <!-- 5-020 大臣(左) -->
             <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= identification(document_info.content&.[]('subcon_construction_license_permission_type_identification_general_1st')) %></td> <!-- 5-021 特定(左) -->
-            <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= document_info.content&.[]('subcon_construction_construction_license_number_double_digit_1st') %></td> <!-- 5-055 許可番号 第(左) -->
+            <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= document_info.content&.[]('subcon_construction_license_number_double_digit_1st') %></td> <!-- 5-055 許可番号 第(左) -->
             <td class="s_5a_316" dir="ltr" colspan="2" rowspan="4">第</td>
             <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4"><%= document_info.content&.[]('subcon_construction_license_number_six_digits_1st') %></td> <!-- 5-022 建設許可番号 号(左) -->
             <td class="s_5a_313" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1047,7 +1047,7 @@
             <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
             <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= minister(@child&.content&.[]('subcon_construction_license_permission_type_minister_governor_2nd')) %></td> <!-- 5-118 大臣(右) -->
             <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= identification(@child&.content&.[]('subcon_construction_license_permission_type_identification_general_2nd')) %></td> <!-- 5-119 特定(右) -->
-            <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= @child&.content&.[]('subcon_construction_construction_license_number_double_digit_2nd') %></td> <!-- 5-146 許可番号 第(右) -->
+            <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_double_digit_2nd') %></td> <!-- 5-146 許可番号 第(右) -->
             <td class="s_5b_216" dir="ltr" colspan="2" rowspan="4">第</td>
             <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_six_digits_2nd') %></td> <!-- 5-120 建設許可番号 号(右) -->
             <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1668,14 +1668,14 @@
             </td>
             </td>
             <td class="s_5a_601" dir="ltr" colspan="8" rowspan="4">外国人建設就<br>労者の従事の<br>状況(有無)</td>
-            
+
             <td class="s_5a_704" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_construction_workers_exist", @child, "有") %> <!-- 5-136 「各会社の外国人建設就労者の従事の状況(有無)」 -->
             </td>
             <td class="s_5a_706" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_construction_workers_exist", @child, "無") %> <!-- 5-136 「各会社の外国人建設就労者の従事の状況(有無)」 -->
             </td>
             </td><!-- 30列目 -->
             <td class="s_5a_601" dir="ltr" colspan="8" rowspan="4">外国人技能実<br>習生の従事の<br>状況(有無)</td>
-            
+
             <td class="s_5a_704" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_technical_intern_trainees_exist", @child, "有") %> <!-- 5-137 「各会社の外国人技能実習生の従事の状況(有無)」 -->
             </td>
             <td class="s_5a_706" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_technical_intern_trainees_exist", @child, "無") %> <!-- 5-137 「各会社の外国人技能実習生の従事の状況(有無)」 -->

--- a/app/views/users/documents/doc_5th/_form.pdf.erb
+++ b/app/views/users/documents/doc_5th/_form.pdf.erb
@@ -919,7 +919,7 @@
                 <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
                 <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= minister(@child&.content&.[]('subcon_construction_license_permission_type_minister_governor_1st')) %></td> <!-- 5-113 大臣(右) -->
                 <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= identification(@child&.content&.[]('subcon_construction_license_permission_type_identification_general_1st')) %></td> <!-- 5-114 特定(右) -->
-                <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= @child&.content&.[]('subcon_construction_construction_license_number_double_digit_1st') %></td> <!-- 5-145 許可番号 第(右) -->
+                <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_double_digit_1st') %></td> <!-- 5-145 許可番号 第(右) -->
                 <td class="s_5b_212" dir="ltr" colspan="2" rowspan="4">第</td>
                 <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_six_digits_1st') %></td> <!-- 5-115 建設許可番号 号(右) -->
                 <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1033,7 +1033,7 @@
                 <td class="s_5a_306" dir="ltr" colspan="4" rowspan="4">工事業</td>
                 <td class="s_5a_307" dir="ltr" colspan="4" rowspan="2"><%= minister(document_info.content&.[]('subcon_construction_license_permission_type_minister_governor_1st')) %></td> <!-- 5-020 大臣(左) -->
                 <td class="s_5a_309" dir="ltr" colspan="4" rowspan="2"><%= identification(document_info.content&.[]('subcon_construction_license_permission_type_identification_general_1st')) %></td> <!-- 5-021 特定(左) -->
-                <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= document_info.content&.[]('subcon_construction_construction_license_number_double_digit_1st') %></td> <!-- 5-055 許可番号 第(左) -->
+                <td class="s_5a_311" dir="ltr" colspan="3" rowspan="4"><%= document_info.content&.[]('subcon_construction_license_number_double_digit_1st') %></td> <!-- 5-055 許可番号 第(左) -->
                 <td class="s_5a_312" dir="ltr" colspan="2" rowspan="4">第</td>
                 <td class="s_5a_312" dir="ltr" colspan="4" rowspan="4"><%= document_info.content&.[]('subcon_construction_license_number_six_digits_1st') %></td> <!-- 5-022 建設許可番号 号(左) -->
                 <td class="s_5a_313" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1054,7 +1054,7 @@
                 <td class="s_5b_206" dir="ltr" colspan="4" rowspan="4">工事業</td>
                 <td class="s_5b_207" dir="ltr" colspan="4" rowspan="2"><%= minister(@child&.content&.[]('subcon_construction_license_permission_type_minister_governor_2nd')) %></td> <!-- 5-118 大臣(右) -->
                 <td class="s_5b_209" dir="ltr" colspan="4" rowspan="2"><%= identification(@child&.content&.[]('subcon_construction_license_permission_type_identification_general_2nd')) %></td> <!-- 5-119 特定(右) -->
-                <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= @child&.content&.[]('subcon_construction_construction_license_number_double_digit_2nd') %></td> <!-- 5-146 許可番号 第(右) -->
+                <td class="s_5b_211" dir="ltr" colspan="3" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_double_digit_2nd') %></td> <!-- 5-146 許可番号 第(右) -->
                 <td class="s_5b_212" dir="ltr" colspan="2" rowspan="4">第</td>
                 <td class="s_5b_212" dir="ltr" colspan="4" rowspan="4"><%= @child&.content&.[]('subcon_construction_license_number_six_digits_2nd') %></td> <!-- 5-120 建設許可番号 号(右) -->
                 <td class="s_5b_213" dir="ltr" colspan="2" rowspan="4">号</td>
@@ -1675,14 +1675,14 @@
                 </td>
                 </td>
                 <td class="s_5a_601" dir="ltr" colspan="8" rowspan="4">外国人建設就<br>労者の従事の<br>状況(有無)</td>
-                
+
                 <td class="s_5a_704" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_construction_workers_exist", @child, "有") %> <!-- 5-136 「各会社の外国人建設就労者の従事の状況(有無)」 -->
                 </td>
                 <td class="s_5a_706" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_construction_workers_exist", @child, "無") %> <!-- 5-136 「各会社の外国人建設就労者の従事の状況(有無)」 -->
                 </td>
                 </td><!-- 30列目 -->
                 <td class="s_5a_601" dir="ltr" colspan="8" rowspan="4">外国人技能実<br>習生の従事の<br>状況(有無)</td>
-                
+
                 <td class="s_5a_704" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_technical_intern_trainees_exist", @child, "有") %> <!-- 5-137 「各会社の外国人技能実習生の従事の状況(有無)」 -->
                 </td>
                 <td class="s_5a_706" dir="ltr" colspan="5" rowspan="4"><%= foreign_exist("foreign_technical_intern_trainees_exist", @child, "無") %> <!-- 5-137 「各会社の外国人技能実習生の従事の状況(有無)」 -->


### PR DESCRIPTION
### 概要
④施工体制台帳、⑤再下請負通知書（変更届）に記述してあったconstruction_constructionという記述の修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
④施工体制台帳、⑤再下請負通知書（変更届）のconstruction_constructionをconstructionに修正

### 実装画像などあれば添付する
特になし

