### PR TITLE
No.91作業員マスタのモデルspecのコメントアウト解除の実装(奥野)

### DIFF
--- a/spec/factories/worker_insurances.rb
+++ b/spec/factories/worker_insurances.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :worker
     health_insurance_type { :health_insurance_association }
     sequence(:health_insurance_name) { |n| "health_insurance_name#{n}" }
+    health_insurance_image { [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))] }
     pension_insurance_type { rand(2) }
     employment_insurance_type { :insured }
     employment_insurance_number { '%.11d' % rand(100000000000) }

--- a/spec/factories/worker_licenses.rb
+++ b/spec/factories/worker_licenses.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :worker_license do
-    images { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
     association :worker
     association :license
+    images { [Rails::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'), 'image/jpeg')] }
   end
 end

--- a/spec/factories/worker_safety_health_educations.rb
+++ b/spec/factories/worker_safety_health_educations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :worker_safety_health_education do
-    images { '' }
     worker_id { nil }
     safety_health_education_id { nil }
+    images { [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))] }
   end
 end

--- a/spec/factories/worker_skill_trainings.rb
+++ b/spec/factories/worker_skill_trainings.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :worker_skill_training do
-    images { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
+    images { [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))] }
     association :worker
     association :skill_training
   end

--- a/spec/factories/worker_special_educations.rb
+++ b/spec/factories/worker_special_educations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :worker_special_education do
-    images { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
+    images { [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))] }
     association :worker
     association :special_education
   end

--- a/spec/factories/workers.rb
+++ b/spec/factories/workers.rb
@@ -20,8 +20,8 @@ FactoryBot.define do
     experience_term_before_hiring { 1 }
     employment_contract { 1 }
     blank_term { 1 }
-    career_up_id { nil }
-    career_up_images { nil }
+    career_up_id { '12345678901234' }
+    career_up_images { [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))] }
     sex { 0 }
     driver_licences { %w[大型免許 普通免許] }
     driver_licence_number { '123456789012' }
@@ -29,12 +29,13 @@ FactoryBot.define do
     maturity_date { '' }
     confirmed_check { '' }
     confirmed_check_date { '' }
-    # after(:create) do |worker|
-    #   create_list(:worker_license, 1, worker: worker, license: License.create!(name: 'テストライセンス', license_type: 0))
-    #   create_list(:worker_skill_training, 1, worker: worker, skill_training: SkillTraining.create!(name: 'テスト技能講習', short_name: 'テス技'))
-    #   create_list(:worker_special_education, 1, worker: worker, special_education: SpecialEducation.create!(name: 'テスト特別教育'))
-    #   create_list(:worker_insurance, 1, worker: worker)
-    #   create_list(:worker_safety_health_education, 1, worker: worker, safety_health_education: SafetyHealthEducation.create!(name: 'テスト健康診断'))
-    # end
+    after(:create) do |worker|
+      test_image = Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'), 'image/jpeg')
+      create_list(:worker_license, 1, worker: worker, license: License.create!(name: 'テストライセンス', license_type: 0), images: [test_image])
+      create_list(:worker_skill_training, 1, worker: worker, skill_training: SkillTraining.create!(name: 'テスト技能講習', short_name: 'テス技'), images: [test_image])
+      create_list(:worker_special_education, 1, worker: worker, special_education: SpecialEducation.create!(name: 'テスト特別教育'), images: [test_image])
+      create_list(:worker_insurance, 1, worker: worker, health_insurance_image: [test_image])
+      create_list(:worker_safety_health_education, 1, worker: worker, safety_health_education: SafetyHealthEducation.create!(name: 'テスト安全衛生教育'), images: [test_image])
+    end
   end
 end

--- a/spec/models/worker_insurance_spec.rb
+++ b/spec/models/worker_insurance_spec.rb
@@ -1,199 +1,200 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe WorkerInsurance, type: :model do
-#   let(:worker_insurance) { create(:worker_insurance) }
+RSpec.describe WorkerInsurance, type: :model do
+  let(:worker_insurance) { create(:worker_insurance) }
 
-#   describe 'バリデーションについて' do
-#     subject do
-#       worker_insurance
-#     end
+  describe 'バリデーションについて' do
+    subject do
+      worker_insurance
+    end
 
-#     it 'バリデーションが通ること' do
-#       expect(subject).to be_valid
-#     end
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
 
-#     describe '#health_insurance_type' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.health_insurance_type = nil
-#         end
+    describe '#health_insurance_type' do
+      context '存在しない場合' do
+        before :each do
+          subject.health_insurance_type = nil
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('健康保険を入力してください')
-#         end
-#       end
-#     end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('健康保険を入力してください')
+        end
+      end
+    end
 
-#     describe '#health_insurance_name' do
-#       context '健康保険が健康保険組合または、建設国保の場合' do
-#         before :each do
-#           subject.health_insurance_name = nil
-#         end
+    describe '#health_insurance_name' do
+      context '健康保険が健康保険組合または、建設国保の場合' do
+        before :each do
+          subject.health_insurance_name = nil
+        end
 
-#         it 'バリデーションに落ちること(健康保険組合)' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること(健康保険組合)' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと(健康保険組合)' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('保険名を入力してください')
-#         end
+        it 'バリデーションのエラーが正しいこと(健康保険組合)' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('保険名を入力してください')
+        end
 
-#         it 'バリデーションに落ちること(建設国保)' do
-#           subject.health_insurance_type = :construction_national_health_insurance
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること(建設国保)' do
+          subject.health_insurance_type = :construction_national_health_insurance
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと(建設国保)' do
-#           subject.health_insurance_type = :construction_national_health_insurance
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('保険名を入力してください')
-#         end
-#       end
+        it 'バリデーションのエラーが正しいこと(建設国保)' do
+          subject.health_insurance_type = :construction_national_health_insurance
+          subject.valid?
+          expect(subject.errors.full_messages).to include('保険名を入力してください')
+        end
+      end
 
-#       context '健康保険が健康保険組合、建設国保以外の場合' do
-#         before :each do
-#           subject.health_insurance_name = nil
-#         end
+      context '健康保険が健康保険組合、建設国保以外の場合' do
+        before :each do
+          subject.health_insurance_name = nil
+        end
 
-#         it 'バリデーションにとおること(協会けんぽ)' do
-#           subject.health_insurance_type = :japan_health_insurance_association
-#           expect(subject).to be_valid
-#         end
+        it 'バリデーションにとおること(協会けんぽ)' do
+          subject.health_insurance_type = :japan_health_insurance_association
+          expect(subject).to be_valid
+        end
 
-#         it 'バリデーションにとおること(国民健康保険)' do
-#           subject.health_insurance_type = :national_health_insurance
-#           expect(subject).to be_valid
-#         end
+        it 'バリデーションにとおること(国民健康保険)' do
+          subject.health_insurance_type = :national_health_insurance
+          expect(subject).to be_valid
+        end
 
-#         it 'バリデーションにとおること(適応除外)' do
-#           subject.health_insurance_type = :exemption
-#           expect(subject).to be_valid
-#         end
-#       end
-#     end
+        it 'バリデーションにとおること(適応除外)' do
+          subject.health_insurance_type = :exemption
+          subject.health_insurance_image = []
+          expect(subject).to be_valid
+        end
+      end
+    end
 
-#     describe '#pension_insurance_type' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.pension_insurance_type = nil
-#         end
+    describe '#pension_insurance_type' do
+      context '存在しない場合' do
+        before :each do
+          subject.pension_insurance_type = nil
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('年金保険を入力してください')
-#         end
-#       end
-#     end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('年金保険を入力してください')
+        end
+      end
+    end
 
-#     describe '#employment_insurance_number' do
-#       context '被保険者の場合' do
-#         %i[
-#           1234567890
-#           123456789012
-#           nil
-#         ].each do |number|
-#           before :each do
-#             subject.employment_insurance_type = :insured
-#             subject.employment_insurance_number = number
-#           end
+    describe '#employment_insurance_number' do
+      context '被保険者の場合' do
+        %i[
+          1234567890
+          123456789012
+          nil
+        ].each do |number|
+          before :each do
+            subject.employment_insurance_type = :insured
+            subject.employment_insurance_number = number
+          end
 
-#           it 'バリデーションに落ちること' do
-#             expect(subject).to be_invalid
-#           end
+          it 'バリデーションに落ちること' do
+            expect(subject).to be_invalid
+          end
 
-#           it 'バリデーションのエラーが正しいこと' do
-#             subject.valid?
-#             expect(subject.errors.full_messages).to include('被保険者番号は11文字で入力してください')
-#           end
-#         end
-#       end
+          it 'バリデーションのエラーが正しいこと' do
+            subject.valid?
+            expect(subject.errors.full_messages).to include('被保険者番号は11文字で入力してください')
+          end
+        end
+      end
 
-#       # context '被保険者以外の場合' do
-#       #   %i[
-#       #     1234567890
-#       #     123456789012
-#       #   ].each do |number|
-#       #     before :each do
-#       #       subject.employment_insurance_number = number
-#       #     end
+      # context '被保険者以外の場合' do
+      #   %i[
+      #     1234567890
+      #     123456789012
+      #   ].each do |number|
+      #     before :each do
+      #       subject.employment_insurance_number = number
+      #     end
 
-#       #     it 'バリデーションに落ちること(日雇保険)' do
-#       #       subject.employment_insurance_type = :day
-#       #       expect(subject).to be_invalid
-#       #     end
+      #     it 'バリデーションに落ちること(日雇保険)' do
+      #       subject.employment_insurance_type = :day
+      #       expect(subject).to be_invalid
+      #     end
 
-#       #     it 'バリデーションのエラーが正しいこと(日雇保険)' do
-#       #       subject.valid?
-#       #       expect(subject.errors.full_messages).to include('被保険者番号は11文字で入力してください')
-#       #     end
+      #     it 'バリデーションのエラーが正しいこと(日雇保険)' do
+      #       subject.valid?
+      #       expect(subject.errors.full_messages).to include('被保険者番号は11文字で入力してください')
+      #     end
 
-#       #     it 'バリデーションにとおること(適応除外)' do
-#       #       subject.employment_insurance_type = :exemption
-#       #       expect(subject).to be_valid
-#       #     end
-#       #   end
-#       # end
-#     end
+      #     it 'バリデーションにとおること(適応除外)' do
+      #       subject.employment_insurance_type = :exemption
+      #       expect(subject).to be_valid
+      #     end
+      #   end
+      # end
+    end
 
-#     describe '#severance_pay_mutual_aid_type' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.severance_pay_mutual_aid_type = nil
-#         end
+    describe '#severance_pay_mutual_aid_type' do
+      context '存在しない場合' do
+        before :each do
+          subject.severance_pay_mutual_aid_type = nil
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('建設業退職金共済手帳を入力してください')
-#         end
-#       end
-#     end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('建設業退職金共済手帳を入力してください')
+        end
+      end
+    end
 
-#     describe '#severance_pay_mutual_aid_name' do
-#       before :each do
-#         subject.severance_pay_mutual_aid_name = nil
-#       end
+    describe '#severance_pay_mutual_aid_name' do
+      before :each do
+        subject.severance_pay_mutual_aid_name = nil
+      end
 
-#       context '建設業退職金共済手帳がその他の時、存在しない場合' do
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+      context '建設業退職金共済手帳がその他の時、存在しない場合' do
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('その他（建設業退職金共済手帳）を入力してください')
-#         end
-#       end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('その他（建設業退職金共済手帳）を入力してください')
+        end
+      end
 
-#       context '建設業退職金共済手帳がその他以外の場合' do
-#         it 'バリデーションに通ること（建退共手帳）' do
-#           subject.severance_pay_mutual_aid_type = :kentaikyo
-#           expect(subject).to be_valid
-#         end
+      context '建設業退職金共済手帳がその他以外の場合' do
+        it 'バリデーションに通ること（建退共手帳）' do
+          subject.severance_pay_mutual_aid_type = :kentaikyo
+          expect(subject).to be_valid
+        end
 
-#         it 'バリデーションに通ること中退共手帳）' do
-#           subject.severance_pay_mutual_aid_type = :tyutaikyo
-#           expect(subject).to be_valid
-#         end
+        it 'バリデーションに通ること中退共手帳）' do
+          subject.severance_pay_mutual_aid_type = :tyutaikyo
+          expect(subject).to be_valid
+        end
 
-#         it 'バリデーションに通ること（無し）' do
-#           subject.severance_pay_mutual_aid_type = :none
-#           expect(subject).to be_valid
-#         end
-#       end
-#     end
-#   end
-# end
+        it 'バリデーションに通ること（無し）' do
+          subject.severance_pay_mutual_aid_type = :none
+          expect(subject).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/models/worker_license_spec.rb
+++ b/spec/models/worker_license_spec.rb
@@ -1,80 +1,75 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe WorkerLicense, type: :model do
-#   let(:worker) { create(:worker) }
-#   let(:license) { create(:license) }
-#   let :worker_license do
-#     create(:worker_license, worker: worker, license: license)
-#   end
+RSpec.describe WorkerLicense, type: :model do
+  let(:worker) { create(:worker) }
+  let(:license) { create(:license) }
+  let :worker_license do
+    create(:worker_license, worker: worker, license: license, images: [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))])
+  end
 
-#   describe 'バリデーションについて' do
-#     subject do
-#       worker_license
-#     end
+  describe 'バリデーションについて' do
+    subject do
+      worker_license
+    end
 
-#     it 'バリデーションが通ること' do
-#       expect(subject).to be_valid
-#     end
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
 
-#     describe '#worker_id' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.worker_id = ''
-#         end
+    describe '#worker_id' do
+      context '存在しない場合' do
+        before :each do
+          subject.worker_id = ''
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('Workerを入力してください')
-#         end
-#       end
-#     end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('Workerを入力してください')
+        end
+      end
+    end
 
-#     describe '#license_id' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.license_id = ''
-#         end
+    describe '#license_id' do
+      context '存在しない場合' do
+        before :each do
+          subject.license_id = ''
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('Licenseを入力してください')
-#         end
-#       end
-#       # it "重複したemailが存在する場合登録できないこと" do
-#       # user = create(:user) # createメソッドを使用して変数userとデータベースにfactory_botのダミーデータを保存
-#       # another_user = build(:user, email: user.email) # 2人目のanother_userを変数として作成し、buildメソッドを使用して、意図的にemailの内容を重複させる
-#       # another_user.valid? # another_userの「バリデーションにより保存ができない状態であるか」をテスト
-#       # expect(another_user.errors[:email]).to include("はすでに存在します")
-#     end
-#   end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('Licenseを入力してください')
+        end
+      end
+    end
+  end
 
-#   describe 'アソシエーションについて' do
-#     context '紐づく作業員がいる場合' do
-#       subject do
-#         worker_license.worker
-#       end
+  describe 'アソシエーションについて' do
+    context '紐づく作業員がいる場合' do
+      subject do
+        worker_license.worker
+      end
 
-#       it '紐づく作業員を返すこと' do
-#         expect(subject).to eq(worker)
-#       end
-#     end
+      it '紐づく作業員を返すこと' do
+        expect(subject).to eq(worker)
+      end
+    end
 
-#     context '紐づく免許マスタがある場合' do
-#       subject do
-#         worker_license.license
-#       end
+    context '紐づく免許マスタがある場合' do
+      subject do
+        worker_license.license
+      end
 
-#       it '紐づく免許マスタを返すこと' do
-#         expect(subject).to eq(license)
-#       end
-#     end
-#   end
-# end
+      it '紐づく免許マスタを返すこと' do
+        expect(subject).to eq(license)
+      end
+    end
+  end
+end

--- a/spec/models/worker_safety_health_education_spec.rb
+++ b/spec/models/worker_safety_health_education_spec.rb
@@ -1,75 +1,75 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe WorkerSafetyHealthEducation, type: :model do
-#   let(:worker) { create(:worker) }
-#   let(:safety_health_education) { create(:safety_health_education) }
-#   let :worker_safety_health_education do
-#     create(:worker_safety_health_education, worker: worker, safety_health_education: safety_health_education)
-#   end
+RSpec.describe WorkerSafetyHealthEducation, type: :model do
+  let(:worker) { create(:worker) }
+  let(:safety_health_education) { create(:safety_health_education) }
+  let :worker_safety_health_education do
+    create(:worker_safety_health_education, worker: worker, safety_health_education: safety_health_education, images: [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))])
+  end
 
-#   describe 'バリデーションについて' do
-#     subject do
-#       worker_safety_health_education
-#     end
+  describe 'バリデーションについて' do
+    subject do
+      worker_safety_health_education
+    end
 
-#     it 'バリデーションが通ること' do
-#       expect(subject).to be_valid
-#     end
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
 
-#     describe '#worker_id' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.worker_id = ''
-#         end
+    describe '#worker_id' do
+      context '存在しない場合' do
+        before :each do
+          subject.worker_id = ''
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('Workerを入力してください')
-#         end
-#       end
-#     end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('Workerを入力してください')
+        end
+      end
+    end
 
-#     describe '#safety_health_education' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.safety_health_education_id = ''
-#         end
+    describe '#safety_health_education' do
+      context '存在しない場合' do
+        before :each do
+          subject.safety_health_education_id = ''
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('Safety health educationを入力してください')
-#         end
-#       end
-#     end
-#   end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('Safety health educationを入力してください')
+        end
+      end
+    end
+  end
 
-#   describe 'アソシエーションについて' do
-#     context '紐づく作業員がいる場合' do
-#       subject do
-#         worker_safety_health_education.worker
-#       end
+  describe 'アソシエーションについて' do
+    context '紐づく作業員がいる場合' do
+      subject do
+        worker_safety_health_education.worker
+      end
 
-#       it '紐づく作業員を返すこと' do
-#         expect(subject).to eq(worker)
-#       end
-#     end
+      it '紐づく作業員を返すこと' do
+        expect(subject).to eq(worker)
+      end
+    end
 
-#     context '紐づく特別教育マスタがある場合' do
-#       subject do
-#         worker_safety_health_education.safety_health_education
-#       end
+    context '紐づく特別教育マスタがある場合' do
+      subject do
+        worker_safety_health_education.safety_health_education
+      end
 
-#       it '紐づく特別教育マスタを返すこと' do
-#         expect(subject).to eq(safety_health_education)
-#       end
-#     end
-#   end
-# end
+      it '紐づく特別教育マスタを返すこと' do
+        expect(subject).to eq(safety_health_education)
+      end
+    end
+  end
+end

--- a/spec/models/worker_skill_training_spec.rb
+++ b/spec/models/worker_skill_training_spec.rb
@@ -1,75 +1,75 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe WorkerSkillTraining, type: :model do
-#   let(:worker) { create(:worker) }
-#   let(:skill_training) { create(:skill_training) }
-#   let :worker_skill_training do
-#     create(:worker_skill_training, worker: worker, skill_training: skill_training)
-#   end
+RSpec.describe WorkerSkillTraining, type: :model do
+  let(:worker) { create(:worker) }
+  let(:skill_training) { create(:skill_training) }
+  let :worker_skill_training do
+    create(:worker_skill_training, worker: worker, skill_training: skill_training, images: [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))])
+  end
 
-#   describe 'バリデーションについて' do
-#     subject do
-#       worker_skill_training
-#     end
+  describe 'バリデーションについて' do
+    subject do
+      worker_skill_training
+    end
 
-#     it 'バリデーションが通ること' do
-#       expect(subject).to be_valid
-#     end
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
 
-#     describe '#worker_id' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.worker_id = ''
-#         end
+    describe '#worker_id' do
+      context '存在しない場合' do
+        before :each do
+          subject.worker_id = ''
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('Workerを入力してください')
-#         end
-#       end
-#     end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('Workerを入力してください')
+        end
+      end
+    end
 
-#     describe '#skill_training_id' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.skill_training_id = ''
-#         end
+    describe '#skill_training_id' do
+      context '存在しない場合' do
+        before :each do
+          subject.skill_training_id = ''
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('Skill trainingを入力してください')
-#         end
-#       end
-#     end
-#   end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('Skill trainingを入力してください')
+        end
+      end
+    end
+  end
 
-#   describe 'アソシエーションについて' do
-#     context '紐づく作業員がいる場合' do
-#       subject do
-#         worker_skill_training.worker
-#       end
+  describe 'アソシエーションについて' do
+    context '紐づく作業員がいる場合' do
+      subject do
+        worker_skill_training.worker
+      end
 
-#       it '紐づく作業員を返すこと' do
-#         expect(subject).to eq(worker)
-#       end
-#     end
+      it '紐づく作業員を返すこと' do
+        expect(subject).to eq(worker)
+      end
+    end
 
-#     context '紐づく技能講習マスタがある場合' do
-#       subject do
-#         worker_skill_training.skill_training
-#       end
+    context '紐づく技能講習マスタがある場合' do
+      subject do
+        worker_skill_training.skill_training
+      end
 
-#       it '紐づく技能講習マスタを返すこと' do
-#         expect(subject).to eq(skill_training)
-#       end
-#     end
-#   end
-# end
+      it '紐づく技能講習マスタを返すこと' do
+        expect(subject).to eq(skill_training)
+      end
+    end
+  end
+end

--- a/spec/models/worker_spec.rb
+++ b/spec/models/worker_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Worker, type: :model do
         [nil, ''].each do |blank|
           before :each do
             subject.career_up_id = blank
+            subject.career_up_images = []
           end
 
           it "バリデーションに通ること(#{blank})" do
@@ -31,6 +32,7 @@ RSpec.describe Worker, type: :model do
       context '14文字ではない場合' do
         before :each do
           subject.career_up_id = '1234567890123'
+          subject.career_up_images = []
         end
 
         it 'バリデーションに落ちること' do

--- a/spec/models/worker_special_education_spec.rb
+++ b/spec/models/worker_special_education_spec.rb
@@ -1,75 +1,75 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe WorkerSkillTraining, type: :model do
-#   let(:worker) { create(:worker) }
-#   let(:special_education) { create(:special_education) }
-#   let :worker_special_education do
-#     create(:worker_special_education, worker: worker, special_education: special_education)
-#   end
+RSpec.describe WorkerSkillTraining, type: :model do
+  let(:worker) { create(:worker) }
+  let(:special_education) { create(:special_education) }
+  let :worker_special_education do
+    create(:worker_special_education, worker: worker, special_education: special_education, images: [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))])
+  end
 
-#   describe 'バリデーションについて' do
-#     subject do
-#       worker_special_education
-#     end
+  describe 'バリデーションについて' do
+    subject do
+      worker_special_education
+    end
 
-#     it 'バリデーションが通ること' do
-#       expect(subject).to be_valid
-#     end
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
 
-#     describe '#worker_id' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.worker_id = ''
-#         end
+    describe '#worker_id' do
+      context '存在しない場合' do
+        before :each do
+          subject.worker_id = ''
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('Workerを入力してください')
-#         end
-#       end
-#     end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('Workerを入力してください')
+        end
+      end
+    end
 
-#     describe '#skill_training_id' do
-#       context '存在しない場合' do
-#         before :each do
-#           subject.special_education_id = ''
-#         end
+    describe '#skill_training_id' do
+      context '存在しない場合' do
+        before :each do
+          subject.special_education_id = ''
+        end
 
-#         it 'バリデーションに落ちること' do
-#           expect(subject).to be_invalid
-#         end
+        it 'バリデーションに落ちること' do
+          expect(subject).to be_invalid
+        end
 
-#         it 'バリデーションのエラーが正しいこと' do
-#           subject.valid?
-#           expect(subject.errors.full_messages).to include('Special educationを入力してください')
-#         end
-#       end
-#     end
-#   end
+        it 'バリデーションのエラーが正しいこと' do
+          subject.valid?
+          expect(subject.errors.full_messages).to include('Special educationを入力してください')
+        end
+      end
+    end
+  end
 
-#   describe 'アソシエーションについて' do
-#     context '紐づく作業員がいる場合' do
-#       subject do
-#         worker_special_education.worker
-#       end
+  describe 'アソシエーションについて' do
+    context '紐づく作業員がいる場合' do
+      subject do
+        worker_special_education.worker
+      end
 
-#       it '紐づく作業員を返すこと' do
-#         expect(subject).to eq(worker)
-#       end
-#     end
+      it '紐づく作業員を返すこと' do
+        expect(subject).to eq(worker)
+      end
+    end
 
-#     context '紐づく特別教育マスタがある場合' do
-#       subject do
-#         worker_special_education.special_education
-#       end
+    context '紐づく特別教育マスタがある場合' do
+      subject do
+        worker_special_education.special_education
+      end
 
-#       it '紐づく特別教育マスタを返すこと' do
-#         expect(subject).to eq(special_education)
-#       end
-#     end
-#   end
-# end
+      it '紐づく特別教育マスタを返すこと' do
+        expect(subject).to eq(special_education)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要
作業員マスタのモデルspecにおける画像投稿の実装

### タスク
- [ ] なし
- [x] あり https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=0

### 実装内容・手法
・ファクトリーボットにて、画像を入力した状態で、インスタンスを作成させる。
・画像を入力することでテスト落ちする箇所を修正

### 実装画像などあれば添付する


