### PR TITLE
不具合項目「27.選択した技能講習を削除できない」修正

### DIFF
--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -40,15 +40,19 @@ module Users
           supervisor_apply:                    %w[基本契約約款の通り 契約書に準拠する 口頭及び文書による].sample,
           site_agent_name:                     'テスト作業員1',
           site_agent_apply:                    %w[基本契約約款の通り 契約書に準拠する 口頭及び文書による].sample,
-          supervising_engineer_name:           'テスト作業員1',
+          #supervising_engineer_name:           'テスト作業員1',
           supervising_engineer_check:          0,
-          supervising_engineer_assistant_name: 'テスト作業員1'
+          #supervising_engineer_assistant_name: 'テスト作業員1'
           # =============================================
         )
       else
         @order = current_business.orders.new
       end
-    end
+        @professional_engineer_qualification_1st = SkillTraining.all.order(:id)
+        @professional_engineer_qualification_2nd = SkillTraining.all.order(:id)
+        @supervising_engineer_qualification = SkillTraining.all.order(:id)
+        @supervising_engineer_assistant_qualification = SkillTraining.all.order(:id)
+      end
 
     def create
       @order = current_business.orders.build(order_params_with_converted)
@@ -70,7 +74,63 @@ module Users
       end
     end
 
-    def edit; end
+    def edit
+      # orderの技術者名1から作業員テーブルのレコードを特定する
+      worker = Worker.find_by(name: @order.professional_engineer_name_1st, business_id: current_business.id)
+      # 作業員のidで作業員と技能講習マスターの中間テーブルを特定する
+      worker_skill_training = WorkerSkillTraining.where(worker_id: worker&.id)
+      array = []
+      worker_skill_training.each do |record|
+        array << record.skill_training_id
+      end
+      if worker.nil?
+        @professional_engineer_qualification_1st = SkillTraining.all.order(:id)
+      else
+        @professional_engineer_qualification_1st = SkillTraining.where("id IN (?)", array)
+      end
+
+      # orderの技術者名2から作業員テーブルのレコードを特定する
+      worker = Worker.find_by(name: @order.professional_engineer_name_2nd, business_id: current_business.id)
+      # 作業員のidで作業員と技能講習マスターの中間テーブルを特定する
+      worker_skill_training = WorkerSkillTraining.where(worker_id: worker&.id)
+      array = []
+      worker_skill_training.each do |record|
+        array << record.skill_training_id
+      end
+      if worker.nil?
+        @professional_engineer_qualification_2nd = SkillTraining.all.order(:id)
+      else
+        @professional_engineer_qualification_2nd = SkillTraining.where("id IN (?)", array)
+      end
+      
+      # orderの監督技術者･主任技術者から作業員テーブルのレコードを特定する
+      worker = Worker.find_by(name: @order.supervising_engineer_name, business_id: current_business.id)
+      # 作業員のidで作業員と技能講習マスターの中間テーブルを特定する
+      worker_skill_training = WorkerSkillTraining.where(worker_id: worker&.id)
+      array = []
+      worker_skill_training.each do |record|
+        array << record.skill_training_id
+      end
+      if worker.nil?
+        @supervising_engineer_qualification = SkillTraining.all.order(:id)
+      else
+        @supervising_engineer_qualification = SkillTraining.where("id IN (?)", array)
+      end
+      
+      # orderの監督技術者補佐から作業員テーブルのレコードを特定する
+      worker = Worker.find_by(name: @order.supervising_engineer_assistant_name, business_id: current_business.id)
+      # 作業員のidで作業員と技能講習マスターの中間テーブルを特定する
+      worker_skill_training = WorkerSkillTraining.where(worker_id: worker&.id)
+      array = []
+      worker_skill_training.each do |record|
+        array << record.skill_training_id
+      end
+      if worker.nil?
+        @supervising_engineer_assistant_qualification = SkillTraining.all.order(:id)
+      else
+        @supervising_engineer_assistant_qualification = SkillTraining.where("id IN (?)", array)
+      end
+    end
 
     def update
       if @order.update(order_params_with_converted)
@@ -93,7 +153,7 @@ module Users
     def professional_engineer_1st_skill_training_options
       professional_engineer_name_1st = params[:professional_engineer_name_1st]
       worker = Worker.find_by(name: professional_engineer_name_1st)
-      options = worker.skill_trainings
+      options = worker&.skill_trainings
       render json: options
     end
 
@@ -101,7 +161,7 @@ module Users
     def professional_engineer_2nd_skill_training_options
       professional_engineer_name_2nd = params[:professional_engineer_name_2nd]
       worker = Worker.find_by(name: professional_engineer_name_2nd)
-      options = worker.skill_trainings
+      options = worker&.skill_trainings
       render json: options
     end
 
@@ -109,7 +169,7 @@ module Users
     def supervising_engineer_skill_training_options
       supervising_engineer_name = params[:supervising_engineer_name]
       worker = Worker.find_by(name: supervising_engineer_name)
-      options = worker.skill_trainings
+      options = worker&.skill_trainings
       render json: options
     end
 
@@ -117,7 +177,7 @@ module Users
     def supervising_engineer_assistant_skill_training_options
       supervising_engineer_assistant_name = params[:supervising_engineer_assistant_name]
       worker = Worker.find_by(name: supervising_engineer_assistant_name)
-      options = worker.skill_trainings
+      options = worker&.skill_trainings
       render json: options
     end
 

--- a/app/controllers/users/request_orders_controller.rb
+++ b/app/controllers/users/request_orders_controller.rb
@@ -19,6 +19,12 @@ module Users
       @third_or_later_subcon_documents = RequestOrder.find_by(uuid: @request_order.uuid).documents.third_or_later_subcon_documents_type
     end
 
+    def new
+      @professional_engineer_qualification = SkillTraining.all.order(:id)
+      @lead_engineer_qualification = SkillTraining.all.order(:id)
+      @registered_core_engineer_qualification = SkillTraining.all.order(:id)
+    end
+
     def edit
       # テスト用デフォルト値 ==========================
       if Rails.env.development? && @request_order.construction_name.nil?
@@ -49,6 +55,49 @@ module Users
         end
       end
       # =============================================
+    
+      # request_orderの技術者名から作業員テーブルのレコードを特定する
+      worker = Worker.find_by(name: @request_order.professional_engineer_name, business_id: current_business.id)
+      # 作業員のidで作業員と技能講習マスターの中間テーブルを特定する
+      worker_skill_training = WorkerSkillTraining.where(worker_id: worker&.id)
+      array = []
+      worker_skill_training.each do |record|
+        array << record.skill_training_id
+      end
+      if worker.nil?
+        @professional_engineer_qualification = SkillTraining.all.order(:id)
+      else
+        @professional_engineer_qualification = SkillTraining.where("id IN (?)", array)
+      end
+    
+      # request_orderの主任技術者名から作業員テーブルのレコードを特定する
+      worker = Worker.find_by(name: @request_order.lead_engineer_name, business_id: current_business.id)
+      # 作業員のidで作業員と技能講習マスターの中間テーブルを特定する
+      worker_skill_training = WorkerSkillTraining.where(worker_id: worker&.id)
+      array = []
+      worker_skill_training.each do |record|
+        array << record.skill_training_id
+      end
+      if worker.nil?
+        @lead_engineer_qualification = SkillTraining.all.order(:id)
+      else
+        @lead_engineer_qualification = SkillTraining.where("id IN (?)", array)
+      end
+    
+      # requestorderの登録基幹技能者名から作業員テーブルのレコードを特定する
+      worker = Worker.find_by(name: @request_order.registered_core_engineer_name, business_id: current_business.id)
+      # 作業員のidで作業員と技能講習マスターの中間テーブルを特定する
+      worker_skill_training = WorkerSkillTraining.where(worker_id: worker&.id)
+      array = []
+      worker_skill_training.each do |record|
+        array << record.skill_training_id
+      end
+      if worker.nil?
+        @registered_core_engineer_qualification = SkillTraining.all.order(:id)
+      else
+        @registered_core_engineer_qualification = SkillTraining.where("id IN (?)", array)
+      end
+    
     end
 
     def update
@@ -114,7 +163,7 @@ module Users
     def professional_engineer_skill_training_options
       professional_engineer_name = params[:professional_engineer_name]
       worker = Worker.find_by(name: professional_engineer_name)
-      options = worker.skill_trainings
+      options = worker&.skill_trainings
       render json: options
     end
 
@@ -130,7 +179,7 @@ module Users
     def lead_engineer_skill_training_options
       lead_engineer_name = params[:lead_engineer_name]
       worker = Worker.find_by(name: lead_engineer_name)
-      options = worker.skill_trainings
+      options = worker&.skill_trainings
       render json: options
     end
 
@@ -138,7 +187,7 @@ module Users
     def registered_core_engineer_license_options
       registered_core_engineer_name = params[:registered_core_engineer_name]
       worker = Worker.find_by(name: registered_core_engineer_name)
-      options = worker.licenses
+      options = worker&.licenses
       render json: options
     end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -49,21 +49,21 @@ class Order < ApplicationRecord
 
   private
 
-    def name_is_required_professional_engineer_name_1st
-      if professional_engineer_name_1st.blank? && (professional_engineer_details_1st.present? || professional_engineer_qualification_1st.present?)
-        errors.add(:professional_engineer_name_1st, '専門技術者の氏名を入力してください')
-      end
+  def name_is_required_professional_engineer_name_1st
+    if professional_engineer_name_1st.blank? && (professional_engineer_details_1st.present? || professional_engineer_qualification_1st.present?)
+      errors.add(:professional_engineer_name_1st, '専門技術者の氏名を入力してください')
     end
-
-    def name_is_required_professional_engineer_name_2nd
-      if professional_engineer_name_2nd.blank? && (professional_engineer_details_2nd.present? || professional_engineer_qualification_2nd.present?)
-        errors.add(:professional_engineer_name_2nd, '専門技術者2の氏名を入力してください')
-      end
-    end  
-
-    def name_is_required_supervising_engineer_assistant_qualification
-      if supervising_engineer_assistant_name.blank? && supervising_engineer_assistant_qualification.present?
-        errors.add(:supervising_engineer_assistant_name, '監督技術者補佐の氏名を入力してください')
-      end
-    end    
   end
+
+  def name_is_required_professional_engineer_name_2nd
+    if professional_engineer_name_2nd.blank? && (professional_engineer_details_2nd.present? || professional_engineer_qualification_2nd.present?)
+      errors.add(:professional_engineer_name_2nd, '専門技術者2の氏名を入力してください')
+    end
+  end
+
+  def name_is_required_supervising_engineer_assistant_qualification
+    if supervising_engineer_assistant_name.blank? && supervising_engineer_assistant_qualification.present?
+      errors.add(:supervising_engineer_assistant_name, '監督技術者補佐の氏名を入力してください')
+    end
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -36,9 +36,34 @@ class Order < ApplicationRecord
   validates :health_and_safety_manager_name,             presence: true                          # 元方安全衛生管理者(氏名)
   validates :submission_destination,                     presence: true                          # 提出先及び担当者(部署･氏名)
 
+  # 氏名無しで更新させない
+  validate :name_is_required_professional_engineer_name_1st
+  validate :name_is_required_professional_engineer_name_2nd
+  validate :name_is_required_supervising_engineer_assistant_qualification
+
   before_create -> { self.site_uu_id = SecureRandom.uuid }
 
   def to_param
     site_uu_id
   end
-end
+
+  private
+
+    def name_is_required_professional_engineer_name_1st
+      if professional_engineer_name_1st.blank? && (professional_engineer_details_1st.present? || professional_engineer_qualification_1st.present?)
+        errors.add(:professional_engineer_name_1st, '専門技術者の氏名を入力してください')
+      end
+    end
+
+    def name_is_required_professional_engineer_name_2nd
+      if professional_engineer_name_2nd.blank? && (professional_engineer_details_2nd.present? || professional_engineer_qualification_2nd.present?)
+        errors.add(:professional_engineer_name_2nd, '専門技術者2の氏名を入力してください')
+      end
+    end  
+
+    def name_is_required_supervising_engineer_assistant_qualification
+      if supervising_engineer_assistant_name.blank? && supervising_engineer_assistant_qualification.present?
+        errors.add(:supervising_engineer_assistant_name, '監督技術者補佐の氏名を入力してください')
+      end
+    end    
+  end

--- a/app/models/request_order.rb
+++ b/app/models/request_order.rb
@@ -36,10 +36,10 @@ class RequestOrder < ApplicationRecord
   validates :safety_promoter_name,               presence: true, on: :update                            # 安全推進者(氏名)
   validates :foreman_name,                       presence: true, on: :update                            # 職長(氏名)
 
-  #　氏名無しで更新させない
+  # 　氏名無しで更新させない
   validate :name_is_required_professional_engineer
   validate :name_is_required_registered_core_engineer
-  
+
   has_closure_tree
 
   before_create -> { self.uuid = SecureRandom.uuid }
@@ -60,5 +60,5 @@ class RequestOrder < ApplicationRecord
     if registered_core_engineer_name.blank? && registered_core_engineer_qualification.present?
       errors.add(:registered_core_engineer_name, '登録基幹技能者の氏名を入力してください')
     end
-  end  
+  end
 end

--- a/app/models/request_order.rb
+++ b/app/models/request_order.rb
@@ -36,6 +36,10 @@ class RequestOrder < ApplicationRecord
   validates :safety_promoter_name,               presence: true, on: :update                            # 安全推進者(氏名)
   validates :foreman_name,                       presence: true, on: :update                            # 職長(氏名)
 
+  #　氏名無しで更新させない
+  validate :name_is_required_professional_engineer
+  validate :name_is_required_registered_core_engineer
+  
   has_closure_tree
 
   before_create -> { self.uuid = SecureRandom.uuid }
@@ -43,4 +47,18 @@ class RequestOrder < ApplicationRecord
   def to_param
     uuid
   end
+
+  private
+
+  def name_is_required_professional_engineer
+    if professional_engineer_name.blank? && (professional_engineer_details.present? || professional_engineer_qualification.present?)
+      errors.add(:professional_engineer_name, '専門技術者の氏名を入力してください')
+    end
+  end
+
+  def name_is_required_registered_core_engineer
+    if registered_core_engineer_name.blank? && registered_core_engineer_qualification.present?
+      errors.add(:registered_core_engineer_name, '登録基幹技能者の氏名を入力してください')
+    end
+  end  
 end

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -231,7 +231,8 @@
         <%= f.collection_radio_buttons(:foreign_work_status_exist, Business.foreign_work_status_exists_i18n, :first, :last, { checked: @business&.foreign_work_status_exist? ? @business&.foreign_work_status_exist : false }) do |b| %>
           <div>
             <%= b.label { b.radio_button + b.text } %>
-          </div>        <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
     <br>

--- a/app/views/users/orders/_form.html.erb
+++ b/app/views/users/orders/_form.html.erb
@@ -123,9 +123,11 @@
       %>
       <br>
       <%= f.label :professional_engineer_qualification_1st %> <!-- 専門技術者1(資格内容) -->
-      <%= f.select :professional_engineer_qualification_1st, options_for_select(@order.professional_engineer_qualification_1st.to_s.split(',')&.map{ |id| [SkillTraining.find(id).name, id] } || [], selected: @order.professional_engineer_qualification_1st, include_blank: true), {},
-                    { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id_1st' }
-      %>
+      <% if @professional_engineer_qualification_1st.blank? %>
+        <%= f.select :professional_engineer_qualification_1st, options_for_select(SkillTraining.all.order(:id).map{ |skill| [skill.name, skill.id] }, selected: @order.professional_engineer_qualification_1st), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id_1st' } %>
+      <% else %>
+        <%= f.select :professional_engineer_qualification_1st, options_for_select(@professional_engineer_qualification_1st.map{ |skill| [skill.name, skill.id] }, selected: @order.professional_engineer_qualification_1st), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id_1st' } %>
+      <% end %>
       <br><br>
       <%= f.label :professional_engineer_details_1st %> <!-- 専門技術者1(担当工事内容) -->
       <%= f.text_field :professional_engineer_details_1st, class: "form-control" %>
@@ -142,9 +144,11 @@
       %>
       <br>
       <%= f.label :professional_engineer_qualification_2nd %> <!-- 専門技術者2(資格内容) -->
-      <%= f.select :professional_engineer_qualification_2nd, options_for_select(@order.professional_engineer_qualification_2nd.to_s.split(',')&.map{ |id| [SkillTraining.find(id).name, id] } || [], selected: @order.professional_engineer_qualification_2nd, include_blank: true), {},
-                    { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id_2nd' }
-                   %>
+      <% if @professional_engineer_qualification_2nd.blank? %>
+        <%= f.select :professional_engineer_qualification_2nd, options_for_select(SkillTraining.all.order(:id).map{ |skill| [skill.name, skill.id] }, selected: @order.professional_engineer_qualification_2nd), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id_2nd' } %>
+      <% else %>
+        <%= f.select :professional_engineer_qualification_2nd, options_for_select(@professional_engineer_qualification_2nd.map{ |skill| [skill.name, skill.id] }, selected: @order.professional_engineer_qualification_2nd), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id_2nd' } %>
+      <% end %>
       <br><br>
       <%= f.label :professional_engineer_details_2nd %> <!-- 専門技術者2(担当工事内容) -->
       <%= f.text_field :professional_engineer_details_2nd, class: "form-control" %>
@@ -171,9 +175,11 @@
       </div>
       <br>
       <%= f.label :supervising_engineer_qualification %> <!-- 監督技術者･主任技術者(資格内容) -->
-      <%= f.select :supervising_engineer_qualification, options_for_select(@order.supervising_engineer_qualification.to_s.split(',')&.map{ |id| [SkillTraining.find(id).name, id] } || [], selected: @order.supervising_engineer_qualification, include_blank: true), {},
-                    { class: "form-select form-select-sm", style: "width: 100%", id: 'supervising_engineer_qualification_id' }
-                   %>
+      <% if @supervising_engineer_qualification.blank? %>
+        <%= f.select :supervising_engineer_qualification, options_for_select(SkillTraining.all.order(:id).map{ |skill| [skill.name, skill.id] }, selected: @order.supervising_engineer_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'supervising_engineer_qualification_id' } %>
+      <% else %>
+        <%= f.select :supervising_engineer_qualification, options_for_select(@supervising_engineer_qualification.map{ |skill| [skill.name, skill.id] }, selected: @order.supervising_engineer_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'supervising_engineer_qualification_id' } %>
+      <% end %>
       <br>
     </div>
   </div>
@@ -186,9 +192,11 @@
                     { id: "supervising_engineer_assistant_name", class: "form-select form-select-sm", style: "width: 100%" }
       %><br>
       <%= f.label :supervising_engineer_assistant_qualification %><br> <!-- 監督技術者補佐(資格内容) -->
-      <%= f.select :supervising_engineer_assistant_qualification, options_for_select(@order.supervising_engineer_assistant_qualification.to_s.split(',')&.map{ |id| [SkillTraining.find(id).name, id] } || [], selected: @order.supervising_engineer_assistant_qualification, include_blank: true), {},
-                    { class: "form-select form-select-sm", style: "width: 100%", id: 'supervising_engineer_assistant_qualification_id' }
-                   %>
+      <% if @supervising_engineer_assistant_qualification.blank? %>
+        <%= f.select :supervising_engineer_assistant_qualification, options_for_select(SkillTraining.all.order(:id).map{ |skill| [skill.name, skill.id] }, selected: @order.supervising_engineer_assistant_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'supervising_engineer_assistant_qualification_id' } %>
+      <% else %>
+        <%= f.select :supervising_engineer_assistant_qualification, options_for_select(@supervising_engineer_assistant_qualification.map{ |skill| [skill.name, skill.id] }, selected: @order.supervising_engineer_assistant_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'supervising_engineer_assistant_qualification_id' } %>
+      <% end %>
     </div>
   </div>
   <div class="list-group-item">

--- a/app/views/users/request_orders/_form.html.erb
+++ b/app/views/users/request_orders/_form.html.erb
@@ -75,8 +75,11 @@
         <%= f.text_field :professional_engineer_details, class: "form-control" %>
         <br>
         <%= f.label :professional_engineer_qualification %> <!-- 資格内容(専門技術者) -->
-        <%= f.select :professional_engineer_qualification, options_for_select(@request_order.professional_engineer_qualification.to_s.split(',')&.map{ |id| [SkillTraining.find(id).name, id] } || [], include_blank: true), {},
-                    { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id' } %>
+        <% if @professional_engineer_qualification.blank? %>
+        <%= f.select :professional_engineer_qualification, options_for_select(SkillTraining.all.order(:id).map{ |skill| [skill.name, skill.id] }, selected: @request_order.professional_engineer_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id' } %>
+        <% else %>
+        <%= f.select :professional_engineer_qualification, options_for_select(@professional_engineer_qualification.map{ |skill| [skill.name, skill.id] }, selected: @request_order.professional_engineer_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'professional_engineer_qualification_id' } %>
+        <% end %>
       </div><br>
     </div>
     <div class="list-group-item">
@@ -121,9 +124,11 @@
         </div><br>
         <%= f.label :lead_engineer_qualification %> <!-- 資格内容(主任技術者)) -->
         <span class="p-1 mb-2 rounded bg-danger text-white">必須</span><br>
-        <%= f.select :lead_engineer_qualification, options_for_select(@request_order.lead_engineer_qualification.to_s.split(',')&.map{ |id| [SkillTraining.find(id).name, id] } || [], selected: @request_order.lead_engineer_qualification, include_blank: true), {},
-            { class: "form-select form-select-sm", style: "width: 100%", id: 'lead_engineer_qualification_id' }
-        %><br>
+        <% if @lead_engineer_qualification.blank? %>
+        <%= f.select :lead_engineer_qualification, options_for_select(SkillTraining.all.order(:id).map{ |skill| [skill.name, skill.id] }, selected: @request_order.lead_engineer_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'lead_engineer_qualification_id' } %>
+        <% else %>
+        <%= f.select :lead_engineer_qualification, options_for_select(@lead_engineer_qualification.map{ |skill| [skill.name, skill.id] }, selected: @request_order.lead_engineer_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'lead_engineer_qualification_id' } %>
+        <% end %><br>
       </div>
     </div>
     <div class="list-group-item">
@@ -183,9 +188,11 @@
                           { id: "registered_core_engineer_name", class: "form-select form-select-sm", style: "width: 100%" }
         %><br>
         <%= f.label :registered_core_engineer_qualification %> <!-- 資格内容(登録基幹技能者) -->
-        <%= f.select :registered_core_engineer_qualification, options_for_select(@request_order.registered_core_engineer_qualification.to_s.split(',')&.map{ |id| [License.find(id).name, id] }, include_blank: true), {},
-                      { class: "form-select form-select-sm", style: "width: 100%", id: 'registered_core_engineer_qualification_id' }
-        %><br>
+        <% if @registered_core_engineer_qualification.blank? %>
+        <%= f.select :registered_core_engineer_qualification, options_for_select(SkillTraining.all.order(:id).map{ |skill| [skill.name, skill.id] }, selected: @request_order.registered_core_engineer_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'registered_core_engineer_qualification_id' } %>
+        <% else %>
+        <%= f.select :registered_core_engineer_qualification, options_for_select(@registered_core_engineer_qualification.map{ |skill| [skill.name, skill.id] }, selected: @request_order.registered_core_engineer_qualification), { include_blank: true }, { class: "form-select form-select-sm", style: "width: 100%", id: 'registered_core_engineer_qualification_id' } %>
+        <% end %><br>
       </div>
     </div>
     <div class="list-group-item">


### PR DESCRIPTION
### 概要
不具合であった「技能講習を一度選択して保存後に、再度編集画面を開いて、選択した技能講習を空白にしたり、削除することができない」の修正。(元請け、下請けの現場情報編集ページの資格内容)

### タスク
- [ ] なし
- [x] あり 
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=924457760

### 実装内容・手法
元請け[専門技術者1、専門技術者2、監督技術者補佐]
下請け[専門技術者、登録基幹技能者]
を氏名無しで登録できないようにするためバリデーションを掛けました。

### 実装画像などあれば添付する
<img width="773" alt="スクリーンショット 2023-05-20 025006" src="https://github.com/kensuma-1122/kensuma/assets/97861380/d67cd823-1e16-4285-81be-370220199287">
<img width="201" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/8a45b497-ced8-4f92-bb52-fd699fd57107">
<img width="786" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/5a8b4cd2-2479-49eb-a56d-dfeac479a489">
