### PR TITLE
Firefoxで会社情報エラーメッセージが二重に出る不具合の対応

### DIFF
--- a/app/controllers/users/businesses_controller.rb
+++ b/app/controllers/users/businesses_controller.rb
@@ -18,7 +18,7 @@ module Users
           address:                                                     'test',
           post_code:                                                   '0123456',
           phone_number:                                                '01234567898',
-          career_up_id:                                                1,
+          career_up_id:                                                '12345678901234',
           business_type:                                               0,
           business_health_insurance_status:                            0, # 健康保険(加入状況)
           business_health_insurance_association:                       'テスト健康保険組合', # 健康保険(組合名)

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -31,6 +31,7 @@ class Business < ApplicationRecord
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :name, presence: true
   validates :name_kana, presence: true, format: { with: /\A[ァ-ヴー・]+\z/u, message: 'はカタカナで入力して下さい。' }
+  validates :career_up_id, length: { maximum: 14, minimum: 14 }
   validates :representative_name, presence: true
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }
   validates :address, presence: true

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -31,7 +31,7 @@ class Business < ApplicationRecord
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :name, presence: true
   validates :name_kana, presence: true, format: { with: /\A[ァ-ヴー・]+\z/u, message: 'はカタカナで入力して下さい。' }
-  validates :career_up_id, length: { maximum: 14, minimum: 14 }
+  validates :career_up_id, length: { maximum: 14, minimum: 14 }, allow_blank: true
   validates :representative_name, presence: true
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }
   validates :address, presence: true

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -36,7 +36,7 @@
     <%= f.text_field :branch_name, class: "form-control" %>
     <br>
     <%= f.label :career_up_id %><!--事業者ID(キャリアアップシステム)-->
-    <%= f.text_field :career_up_id, class: "form-control", minlength: 14, maxlength: 14 %>
+    <%= f.text_field :career_up_id, class: "form-control", maxlength: 14 %>
     <br>
     <%= f.label :career_up_card_copy %><br><!--キャリアアップシステムカードの写し-->
     <% if business.career_up_card_copy.present? %>

--- a/db/fixtures/development/02_business.rb
+++ b/db/fixtures/development/02_business.rb
@@ -10,7 +10,7 @@ User.where(role: 'admin').all.each do |user|
       address:                                          "東京都テスト区1-2-#{user.id}",
       post_code:                                        '0123456',
       phone_number:                                     '01234567898',
-      career_up_id:                                     'abc123',
+      career_up_id:                                     'abc12300000000',
       business_type:                                    0,
       business_health_insurance_status:                 rand(0..2),                  # 健康保険(加入状況)
       business_health_insurance_association:            "テスト#{user.id}健康保険組合", # 健康保険(組合名)

--- a/spec/factories/businesses.rb
+++ b/spec/factories/businesses.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     address { 'TEST' }
     post_code { '0120123' }
     phone_number { '09001230123' }
-    career_up_id { '1' }
+    career_up_id { '12345678901234' }
     business_type { 0 }
     business_health_insurance_status { 0 } # 健康保険(加入状況)
     business_health_insurance_association { 'TEST健康保険組合' } # 健康保険(組合名)


### PR DESCRIPTION
### 概要
_Firefoxで会社情報エラーメッセージが二重に出る不具合に対応しました_

### タスク
- [] なし
- [x] あり _https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=1919440763_

### 実装内容・手法
_inputのminlengthバリデーションを削除_


