### PR TITLE
不具合項目113,115の修正

### DIFF
--- a/app/views/users/cars/_form.html.erb
+++ b/app/views/users/cars/_form.html.erb
@@ -69,6 +69,7 @@
     <div class="list-group">
       <%= f.label :liability_insurance_period %>
       <div class="list-group-item">
+        <%= f.label :liability_insurance_start_on %>
         <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
         <%= f.date_field :liability_insurance_start_on, class: "form-control" %>
         <br>

--- a/app/views/users/documents/doc_8th/_edit.html.erb
+++ b/app/views/users/documents/doc_8th/_edit.html.erb
@@ -337,7 +337,9 @@
                   <td class="doc_8th_s11"></td>
                   <td class="doc_8th_s11" colspan="3" rowspan="2">事業所の名称</td>
                   <td class="doc_8th_s12" colspan="14" rowspan="2">
-                    <%= document_site_info.site_name %> <!-- 8-001 事業所名(現場名)-->
+                      <%= document_site_info.content&.[]("genecon_name") %> <!-- 8-045 元請会社の「会社名」-->
+									    <span>&nbsp;</span>
+									    <%= document_site_info.site_name %> <!-- 8-001 事業所名(現場名)-->
                   </td>
                   <td class="doc_8th_s2"></td>
                   <td class="doc_8th_s2"></td>

--- a/app/views/users/documents/doc_8th/_show.html.erb
+++ b/app/views/users/documents/doc_8th/_show.html.erb
@@ -326,6 +326,8 @@
 								<td class="doc_8th_s11"></td>
 								<td class="doc_8th_s11" colspan="3" rowspan="2">事業所の名称</td>
 								<td class="doc_8th_s12" colspan="14" rowspan="2">
+									<%= document_site_info.content&.[]("genecon_name") %> <!-- 8-045 元請会社の「会社名」-->
+									<span>&nbsp;</span>
 									<%= document_site_info.site_name %> <!-- 8-001 事業所名(現場名)-->
 								</td>
 								<td class="doc_8th_s2"></td>

--- a/app/views/users/documents/doc_8th/_show.pdf.erb
+++ b/app/views/users/documents/doc_8th/_show.pdf.erb
@@ -326,6 +326,8 @@
 					<td class="s11"></td>
 					<td class="s11" colspan="3" rowspan="2">事業所の名称</td>
 					<td class="s12" colspan="14" rowspan="2">
+						<%= document_site_info.content&.[]("genecon_name") %> <!-- 8-045 元請会社の「会社名」-->
+						<span>&nbsp;</span>
 						<%= document_site_info.site_name %> <!-- 8-001 事業所名(現場名)-->
 					</td>
 					<td class="s2"></td>


### PR DESCRIPTION
### 概要
不具合項目113,115の修正を行いました。
不具合項目スプレッドシート↓
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=0

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
113番の不具合→「始期」のラベルの記述がなかったので記述しました。
115番の不具合→「現場名」の左に「会社名」が表示されるように実装しました。

### 実装画像などあれば添付する
![image](https://github.com/kensuma-1122/kensuma/assets/97861380/ba4d3453-7b0e-487d-985f-5fa0d24b8f31)
<img width="383" alt="会社名も表示するようにしました。タイトルなし" src="https://github.com/kensuma-1122/kensuma/assets/97861380/3e330c81-7e54-47a9-8363-6d87bade0570">

