### PR TITLE
不具合98番の修正

### DIFF
--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -38,15 +38,6 @@
     <%= f.label :career_up_id %><!--事業者ID(キャリアアップシステム)-->
     <%= f.text_field :career_up_id, class: "form-control", maxlength: 14 %>
     <br>
-    <%= f.label :career_up_card_copy %><br><!--キャリアアップシステムカードの写し-->
-    <% if business.career_up_card_copy.present? %>
-      <% business.career_up_card_copy.each_with_index do |image, index| %>
-        <%= image_tag(image.url) %>
-        <%= link_to "削除", delete_career_up_card_copy_users_business_path(index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
-      <% end %>
-      <br>
-    <% end %>
-    <%= f.file_field :career_up_card_copy, multiple: true %>
     <br><br>
     <%= f.label :representative_name %><!-- 代表者名 -->
     <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>

--- a/app/views/users/businesses/show.html.erb
+++ b/app/views/users/businesses/show.html.erb
@@ -35,15 +35,6 @@
           <td></td>
         </tr>
         <tr>
-          <th>&emsp;&emsp;<%= Business.human_attribute_name(:career_up_card_copy) %></th>
-          <td class="career-up-card-copy-input">
-            <% @business.career_up_card_copy.each do |image| %>
-              <%= image_tag(image.url) %>
-            <% end %>
-          </td>
-          <td></td>
-        </tr>
-        <tr>
           <th>&emsp;&emsp;<%= Business.human_attribute_name(:representative_name) %></th>
           <td><%= @business.representative_name %></td>
           <td></td>


### PR DESCRIPTION
### 概要
不具合98番の修正を行いました。会社情報の「建設キャリアアップシステムカードの写し」が不要とのことなのでフォームを消しました。

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法


### 実装画像などあれば添付する
<img width="193" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/fa8183d8-53a3-439f-8dd3-624291484293">
<img width="385" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/3aa7409f-9705-4cfc-bf9b-1c3acf10a106">

