### PR TITLE
不具合修正No189,No190(平野)

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -13,7 +13,7 @@ class Document < ApplicationRecord
   # 自身の書類一覧取得(自身が元請の場合、一次の場合、二次の場合、三次以降の場合)
   scope :system_chart_documents_type, -> { where(document_type: [18, 22]) }
   scope :genecon_documents_type, -> { where(document_type: [1, 2, 3, 4]) }
-  scope :first_subcon_documents_type, -> { where(document_type: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 23]) }
+  scope :first_subcon_documents_type, -> { where(document_type: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 23, 24]) }
   scope :second_subcon_documents_type, -> { where(document_type: [3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 21, 24]) }
   scope :third_or_later_subcon_documents_type, -> { where(document_type: [3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 21, 24]) }
   # 元請け配下の一次下請け書類一覧取得

--- a/app/views/users/request_orders/show.html.erb
+++ b/app/views/users/request_orders/show.html.erb
@@ -51,17 +51,22 @@
 <% unless @request_order.parent_id.nil? %>
   <section class="content">
     <div class="col-md-12">
-      <div class="card card-outline card-primary">
+      <div class="card card-outline card-primary collapsed-card">
         <div class="card-header">
-          <h3 class="card-title">現場情報(<%= sc_hierarchy(@request_order) %>)</h3>
+          <h3 class="card-title">
+            現場情報(<%= sc_hierarchy(@request_order) %>)
+            <% if @request_order.parent_id.nil? || @request_order.construction_name.nil? %>
+              <%= link_to "現場情報登録", edit_users_request_order_path, class: "btn btn-sm btn-success" %>
+            <% end %>
+          </h3>
           <div class="card-tools">
             <button type="button" class="btn btn-tool" data-card-widget="collapse">
-            <i class="fas fa-minus"></i>
+            <i class="fas fa-plus"></i>
             </button>
           </div>
         </div>
 
-        <div class="card-body table-responsive p-0">
+        <div class="card-body table-responsive p-0" style="display: none;">
           <% unless @request_order.parent_id.nil? || @request_order.construction_name.nil? %>
             <table class="table table-hover text-nowrap">
               <tbody>
@@ -222,7 +227,6 @@
               <tr>
                 <td>
                   現場情報を登録してください。
-                  <%= link_to "現場情報登録", edit_users_request_order_path, class: "btn btn-sm btn-success" %>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
### 概要
不具合修正 No.189, No.190

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- No.189 一次下請の書類一覧 ㉔新規入場者調査票がない
一次下請けの書類一覧に、新規入場者調査票を表示

- No.190 下請の現場情報のデフォルトを閉じた状態にする
デフォルトで閉じた状態にする

### 実装画像などあれば添付する

![FireShot Capture 067 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/754b0e11-0284-405f-8afb-8341e5849271)

