### PR TITLE
高齢・年少就労者の職種・作業内容表示修正

### DIFF
--- a/app/views/users/documents/doc_10th/_show.html.erb
+++ b/app/views/users/documents/doc_10th/_show.html.erb
@@ -48,8 +48,8 @@
             <td class="gray"><%= worker_str(field_worker, "name") %></td><!-- 65歳以上の「入場する作業員」10-008 -->
             <td class="gray"><%= worker_str(field_worker, "birth_day_on") %></td><!--「生年月日」10-009 -->
             <td class="gray"><%= age_for_admission_date_start(field_worker) %></td><!--「年齢」10-010 -->
-            <td class="green"><%= field_worker.content&.[]("occupation") %></td><!--「職種」10-011 -->
-            <td class="green"><%= field_worker.content&.[]("work_notice") %></td><!--「高年齢就労者・作業内容」10-012 -->
+            <td class="green"><%= worker_occupation(field_worker) %></td><!--「職種」10-011 -->
+            <td class="green"><%= field_worker&.job_description %></td><!--「高年齢就労者・作業内容」10-012 -->
           </tr>
         <% j += 1 %>
         <% end %>

--- a/app/views/users/documents/doc_11th/_show.html.erb
+++ b/app/views/users/documents/doc_11th/_show.html.erb
@@ -45,11 +45,11 @@
         <% j = 1 %>
         <% document_info.field_workers.where(id: age_border(18)).each do |field_worker| %>
           <tr>
-            <td class="gray"><%= worker_str(field_worker, "name") %></td><!-- 65歳以上の「入場する作業員」10-008 -->
+            <td class="gray"><%= worker_str(field_worker, "name") %></td><!-- 18歳以下の「入場する作業員」10-008 -->
             <td class="gray"><%= worker_str(field_worker, "birth_day_on") %></td><!--「生年月日」10-009 -->
             <td class="gray"><%= age_for_admission_date_start(field_worker) %></td><!--「年齢」10-010 -->
-            <td class="green"><%= field_worker.content&.[]("occupation") %></td><!--「職種」10-011 -->
-            <td class="green"><%= field_worker.content&.[]("work_notice") %></td><!--「高年齢就労者・作業内容」10-012 -->
+            <td class="green"><%= worker_occupation(field_worker) %></td><!--「職種」10-011 -->
+            <td class="green"><%= field_worker&.job_description %></td><!--「年少就労者・作業内容」10-012 -->
           </tr>
         <% j += 1 %>
         <% end %>


### PR DESCRIPTION
### 概要
_ドキュメント10，11の高齢・年少就労者の職種・作業内容が表示されない不具合を修正しました_

### タスク
- [] なし
- [x] あり _(https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=212668610)_

### 実装内容・手法
_viewの値表示箇所を修正_