### PR TITLE
外国人就労者情報の修正

### DIFF
--- a/app/controllers/users/request_orders/field_workers_controller.rb
+++ b/app/controllers/users/request_orders/field_workers_controller.rb
@@ -8,6 +8,7 @@ module Users::RequestOrders
     def index
       field_worker_ids = @field_workers.map { |field_worker| field_worker.content['id'] }
       @worker = current_business.workers.where.not(id: field_worker_ids)
+      @foreigners = @field_workers.select { |f| f.content['country'] != "日本" }
     end
 
     def create
@@ -32,7 +33,9 @@ module Users::RequestOrders
       redirect_to users_request_order_field_workers_url
     end
 
-    def edit_workers; end
+    def edit_workers
+      @foreigners = @field_workers.select { |f| f.content['country'] != "日本" }
+    end
 
     def update_workers
       workers_params = params[:request_order][:field_workers]

--- a/app/controllers/users/request_orders/field_workers_controller.rb
+++ b/app/controllers/users/request_orders/field_workers_controller.rb
@@ -8,7 +8,7 @@ module Users::RequestOrders
     def index
       field_worker_ids = @field_workers.map { |field_worker| field_worker.content['id'] }
       @worker = current_business.workers.where.not(id: field_worker_ids)
-      @foreigners = @field_workers.select { |f| f.content['country'] != "日本" }
+      @foreigners = @field_workers.reject { |f| f.content['country'] == '日本' }
     end
 
     def create
@@ -34,7 +34,7 @@ module Users::RequestOrders
     end
 
     def edit_workers
-      @foreigners = @field_workers.select { |f| f.content['country'] != "日本" }
+      @foreigners = @field_workers.reject { |f| f.content['country'] == '日本' }
     end
 
     def update_workers

--- a/app/views/users/request_orders/field_workers/index.html.erb
+++ b/app/views/users/request_orders/field_workers/index.html.erb
@@ -65,31 +65,31 @@
                 <td><%= not_input_display(field_worker.job_description) %></td>
                 <td><%= link_to "削除", users_request_order_field_worker_path(@request_order, field_worker), method: :delete, data: { confirm: "#{field_worker.admission_worker_name}を削除します。本当によろしいですか？" }, class: "btn btn-md btn-danger" %></td>
               </tr>
-              <% if field_worker.content['country'] != "日本" %>
-                <tr align="center">
-                  <th></th>
-                  <th><%= FieldWorker.human_attribute_name(:foreign_work_place) %></th>
-                  <th><%= FieldWorker.human_attribute_name(:foreign_date_start) %></th>
-                  <th><%= FieldWorker.human_attribute_name(:foreign_date_end) %></th>
-                  <th><%= FieldWorker.human_attribute_name(:foreign_job) %></th>
-                  <th><%= FieldWorker.human_attribute_name(:foreign_job_description) %></th>
-                  <th><%= FieldWorker.human_attribute_name(:proper_management_licenses) %></th>
-                </tr>
-                <tr align="center">
-                  <td></td>
-                  <td><%= not_input_display(field_worker.foreign_work_place) %></td>
-                  <td><%= not_input_display(field_worker.foreign_date_start) %></td>
-                  <td><%= not_input_display(field_worker.foreign_date_end) %></td>
-                  <td><%= not_input_display(field_worker.foreign_job) %></td>
-                  <td><%= not_input_display(field_worker.foreign_job_description) %></td>
-                  <% if field_worker.proper_management_licenses.present? %>
-                    <% field_worker.proper_management_licenses.each_with_index do |image, index| %>
-                      <td><%= image_tag(image.url) %></td>
-                    <% end %>
-                  <% end %>
-                </tr>
-              <% end %>
             <% end %>
+            <% if @foreigners.count > 0%>
+              <tr align="center">
+                <th>外国人建設就労者</th>
+                <th><%= FieldWorker.human_attribute_name(:foreign_work_place) %></th>
+                <th><%= FieldWorker.human_attribute_name(:foreign_date_start) %></th>
+                <th><%= FieldWorker.human_attribute_name(:foreign_date_end) %></th>
+                <th><%= FieldWorker.human_attribute_name(:foreign_job) %></th>
+                <th><%= FieldWorker.human_attribute_name(:foreign_job_description) %></th>
+                <th><%= FieldWorker.human_attribute_name(:proper_management_licenses) %></th>
+              </tr>
+              <tr align="center">
+                <td></td>
+                <td><%= not_input_display(@foreigners.first.foreign_work_place) %></td>
+                <td><%= not_input_display(@foreigners.first.foreign_date_start) %></td>
+                <td><%= not_input_display(@foreigners.first.foreign_date_end) %></td>
+                <td><%= not_input_display(@foreigners.first.foreign_job) %></td>
+                <td><%= not_input_display(@foreigners.first.foreign_job_description) %></td>
+                <% if @foreigners.first.proper_management_licenses.present? %>
+                  <% @foreigners.first.proper_management_licenses.each_with_index do |image, index| %>
+                    <td><%= image_tag(image.url) %></td>
+                  <% end %>
+                <% end %>
+              </tr>
+            <%end%>
           </table>
         </div>
       </div>


### PR DESCRIPTION
### 概要
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=397841488
に基づき修正￥

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
一覧に出す外国人情報を外国人の一番初めの人にする

### 実装画像などあれば添付する
編集画面
外人を2人用意
![image](https://github.com/kensuma-1122/kensuma/assets/80724165/5e2d1a73-ca8f-4725-9767-4540d805b157)


一覧画面
外人の１人目である外人1号の情報を表示
![image](https://github.com/kensuma-1122/kensuma/assets/80724165/e68f6589-30b6-431e-985c-0577100dab6c)


