### PR TITLE
③施⼯体制台帳作成建設⼯事の通知背景色修正

### DIFF
--- a/app/javascript/stylesheets/users/doc_3rd.scss
+++ b/app/javascript/stylesheets/users/doc_3rd.scss
@@ -286,6 +286,8 @@
   left: 700px;
   bottom: 1165px;
   letter-spacing: -0.37px;
+  height: 80px;
+  background-color:#ccffcc;
 }
 
 #sd_t1a_1 {
@@ -348,6 +350,11 @@
 
 .sd_s6 {
   font-size: 17px;
+  color: #000;
+}
+
+.sd_s7 {
+  font-size: 14px;
   color: #000;
 }
 

--- a/app/views/users/documents/doc_3rd/_show.html.erb
+++ b/app/views/users/documents/doc_3rd/_show.html.erb
@@ -23,7 +23,7 @@
       <span id="sd_t16_1" class="sd_t sd_s2">当工事は、建設業法（昭和24年法律第100号）第24条の7に基づく施工体制台帳の作成を要する建設工事 </span>
       <span id="sd_t17_1" class="sd_t sd_s2">です。 </span>
       <span id="sd_t18_1" class="sd_t sd_s1">(全建統一様式第２号) </span>
-      <span id="sd_t19_1" class="sd_t sd_s2">
+      <span id="sd_t19_1" class="sd_t sd_s7">
         <%= doc_content_date(@document.content&.[]("date_submitted")) %> <!-- 3-001 提出日（西暦 -->
       </span>
       <span id="sd_t1a_1" class="sd_t sd_s6">下請負業者の皆さんへ </span>


### PR DESCRIPTION
### 概要
施⼯体制台帳作成建設⼯事の通知背景色修正
### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
_実装内容や、問題の解決手法を記述する_

### 実装画像などあれば添付する
詳細画面
<img width="624" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/80724165/b1558c2f-6134-4ad3-bb27-ef7b6b361fb0">

編集画面
<img width="727" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/80724165/91b7a697-3122-4c6d-910b-7c98b2ab48db">

###PDFは最初から背景色白
<img width="829" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/80724165/a25206f4-0bc6-45a4-87ee-030fbc6f752c">


