### PR TITLE
doc13の受付確認者フォーム修正

### DIFF
--- a/app/controllers/users/sub_request_orders/documents_controller.rb
+++ b/app/controllers/users/sub_request_orders/documents_controller.rb
@@ -80,6 +80,8 @@ module Users::SubRequestOrders
             date_submitted:                field_special_vehicle_keys, # 13-001 提出日(西暦)
             prime_contractor_confirmation: field_special_vehicle_keys, # 13-037 元請確認欄･担当者
             receipt_number:                field_special_vehicle_keys, # 13-038 受付番号
+            reception_confirmation_date:   field_special_vehicle_keys, # 13-039 受付確認年月日
+            person_confirming_receipt:     field_special_vehicle_keys, # 13-040 受付確認者
             a_over_winding_prevention:     field_special_vehicle_keys, # 13-111 (a)Aクレーン部 安全装置         巻過防止装置
             a_overload_protector:          field_special_vehicle_keys, # 13-112 (a)Aクレーン部 安全装置         過負荷防止装置
             a_anti_slip_hook:              field_special_vehicle_keys, # 13-113 (a)Aクレーン部 安全装置         フックのはずれ

--- a/app/views/users/documents/doc_13th/_current_edit.html.erb
+++ b/app/views/users/documents/doc_13th/_current_edit.html.erb
@@ -2355,19 +2355,11 @@
                 <td class="doc_13_s23" dir="ltr" colspan="12" rowspan="3" style="background-color: #e9ecef;">
                   <%= @document.approval_content&.[]('receipt_number')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-038 受付番号 -->
                 </td>
-                <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3" style="background-color: ##e9ecef;">
-                  <br>
-                  <%= f.date_field name = "content[reception_confirmation_date][field_special_vehicle_#{field_special_vehicle.id}]",
-                                      value: doc_content_date(@document.content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")),
-                                      class: 'form-control'
-                  %>　<!-- 13-039 受付確認年月日 -->
+                <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3" style="background-color: #e9ecef;">
+                  <%= wareki(@document.approval_content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")) %> <!-- 13-039 受付確認年月日 -->
                 </td>
-                <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3" style="background-color: ##e9ecef;">
-                  <%= f.select name = "content[person_confirming_receipt][field_special_vehicle_#{field_special_vehicle.id}]",
-                                @current_business.workers.map {|worker|worker.name},
-                                { selected: @document.content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}"), include_blank: "選択して下さい" },
-                                class: 'form-control'
-                  %> <!-- 13-040 受付確認者 -->
+                <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3" style="background-color: #e9ecef;">
+                  <%= @document.approval_content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-040 受付確認者 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s4"></td>

--- a/app/views/users/documents/doc_13th/_current_show.html.erb
+++ b/app/views/users/documents/doc_13th/_current_show.html.erb
@@ -2109,10 +2109,10 @@
                 <%= @document.approval_content&.[]('receipt_number')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-038 受付番号 -->
               </td>
               <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3" style="background-color: #e9ecef;">
-                <%= wareki(@document.content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")) %> <!-- 13-039 受付確認年月日 -->
+                <%= wareki(@document.approval_content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")) %> <!-- 13-039 受付確認年月日 -->
               </td>
               <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3" style="background-color: #e9ecef;">
-                <%= @document.content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-040 受付確認者 -->
+                <%= @document.approval_content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-040 受付確認者 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>

--- a/app/views/users/documents/doc_13th/_show.pdf.erb
+++ b/app/views/users/documents/doc_13th/_show.pdf.erb
@@ -2112,10 +2112,10 @@
               <%= @document.approval_content&.[]('receipt_number')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-038 受付番号 -->
             </td>
             <td class="s36" dir="ltr" colspan="7" rowspan="3" >
-              <%= wareki(@document.content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")) %> <!-- 13-039 受付確認年月日 -->
+              <%= wareki(@document.approval_content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")) %> <!-- 13-039 受付確認年月日 -->
             </td>
             <td class="s36" dir="ltr" colspan="5" rowspan="3" >
-              <%= @document.content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-040 受付確認者 -->
+              <%= @document.approval_content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-040 受付確認者 -->
             </td>
             <td class="s4"></td>
             <td class="s4"></td>

--- a/app/views/users/documents/doc_13th/_subcon_edit.html.erb
+++ b/app/views/users/documents/doc_13th/_subcon_edit.html.erb
@@ -2351,10 +2351,18 @@
                   %> <!-- 13-038 受付番号 -->
                 </td>
                 <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3" style="background-color: #ccffcc;">
-                  <%= wareki(@document.content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")) %> <!-- 13-039 受付確認年月日 -->
+                  <br>
+                  <%= f.date_field name = "approval_content[reception_confirmation_date][field_special_vehicle_#{field_special_vehicle.id}]",
+                                      value: @document.approval_content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}"),
+                                      class: 'form-control'
+                  %>　<!-- 13-039 受付確認年月日 -->
                 </td>
                 <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3" style="background-color: #ccffcc;">
-                  <%= @document.content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-040 受付確認者 -->
+                  <%= f.select name = "approval_content[person_confirming_receipt][field_special_vehicle_#{field_special_vehicle.id}]",
+                                @current_business.workers.map {|worker|worker.name},
+                                { selected: @document.approval_content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}"), include_blank: "選択して下さい" },
+                                class: 'form-control'
+                  %> <!-- 13-040 受付確認者 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s4"></td>

--- a/app/views/users/documents/doc_13th/_subcon_show.html.erb
+++ b/app/views/users/documents/doc_13th/_subcon_show.html.erb
@@ -2109,10 +2109,10 @@
                 <%= @document.approval_content&.[]('receipt_number')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-038 受付番号 -->
               </td>
               <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="3" style="background-color: #ccffcc;">
-                <%= wareki(@document.content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")) %> <!-- 13-039 受付確認年月日 -->
+                <%= wareki(@document.approval_content&.[]('reception_confirmation_date')&.[]("field_special_vehicle_#{field_special_vehicle.id}")) %> <!-- 13-039 受付確認年月日 -->
               </td>
               <td class="doc_13_s36" dir="ltr" colspan="5" rowspan="3" style="background-color: #ccffcc;">
-                <%= @document.content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-040 受付確認者 -->
+                <%= @document.approval_content&.[]('person_confirming_receipt')&.[]("field_special_vehicle_#{field_special_vehicle.id}") %> <!-- 13-040 受付確認者 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>


### PR DESCRIPTION
### 概要
_doc13の受付確認者フォーム修正_

### タスク
- なし
- [x] あり _(https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit?pli=1#gid=1429390186)_

### 実装内容・手法
元請けアカウントで受付確認者フォームが編集できるように修正しました。

### 実装画像などあれば添付する

![fix201](https://github.com/kensuma-1122/kensuma/assets/63386452/036f6471-32fd-4f3d-baeb-e91c64c9ed60)

