### PR TITLE
不具合修正No.104(平野)

### DIFF
--- a/app/controllers/users/businesses_controller.rb
+++ b/app/controllers/users/businesses_controller.rb
@@ -26,7 +26,7 @@ module Users
           business_welfare_pension_insurance_join_status:              0, # 厚生年金保険(加入状況)
           business_welfare_pension_insurance_office_number:            '01234567890', # 厚生年金保険(事業所整理記号)
           business_employment_insurance_join_status:                   0, # 雇用保険(加入状況)
-          business_employment_insurance_number:                        '01234567890', # 雇用保険(番号)
+          business_employment_insurance_number:                        '0123', # 雇用保険(番号)
           business_retirement_benefit_mutual_aid_status:               0, # 退職金共済制度(加入状況)
           construction_license_status:                                 0 # 建設許可証(取得状況)
           # =============================================

--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -63,7 +63,7 @@ module WorkersHelper
       health_insurance_name:         'サンプル健康保険',
       pension_insurance_type:        :welfare,
       employment_insurance_type:     :insured,
-      employment_insurance_number:   '12345678901',
+      employment_insurance_number:   '1234',
       severance_pay_mutual_aid_type: :kentaikyo,
       severance_pay_mutual_aid_name: 'テスト共済制度',
       has_labor_insurance:           :join

--- a/app/models/worker_insurance.rb
+++ b/app/models/worker_insurance.rb
@@ -37,7 +37,7 @@ class WorkerInsurance < ApplicationRecord
   validates :pension_insurance_type, presence: true
   validates :employment_insurance_type, presence: true, unless: :business_owner_or_master
   validates :employment_insurance_type, absence: true, if: :business_owner_or_master
-  validates :employment_insurance_number, length: { is: 11 }, if: :employment_insurance_number_valid?
+  validates :employment_insurance_number, length: { maximum: 4 }, format: { with: /\A[a-zA-Z0-9｡-ﾟ]+\z/, message: 'は数字と半角カタカナのみ使用できます' }, if: :employment_insurance_number_valid?
   validates :employment_insurance_number, absence: true, unless: :employment_insurance_number_valid?
   validates :has_labor_insurance, presence: true, if: :business_owner_or_master
   validates :has_labor_insurance, absence: true, unless: :business_owner_or_master

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -351,7 +351,8 @@
           <%# 被保険者番号 %>
           <div id="employment_insurance_number" class="mb-3">
             <%= worker_insurance.label :employment_insurance_number %>
-            <%= worker_insurance.text_field :employment_insurance_number, class: "form-control" %>
+            <span class="p-1 mb-2 rounded">※下4桁(1桁～4桁)数字・半角カタカナ使用可能</span>
+            <%= worker_insurance.text_field :employment_insurance_number, maxlength: 4, class: "form-control" %>
           </div>
         </div>
       </div>
@@ -1103,7 +1104,7 @@
           required: "雇用保険のタイプを選択してください。"
         },
         "worker[worker_insurance_attributes][employment_insurance_number]": {
-          required: "被保険者番号は11桁で入力してください。"
+          required: "被保険者番号は4桁以内で入力してください。"
         },
         "worker[worker_insurance_attributes][severance_pay_mutual_aid_type]": {
           required: "建設業退職金共済制度を選択してください。"

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -1104,7 +1104,7 @@
           required: "雇用保険のタイプを選択してください。"
         },
         "worker[worker_insurance_attributes][employment_insurance_number]": {
-          required: "被保険者番号は4桁以内で入力してください。"
+          required: "被保険者番号は数字と半角カタカナの4桁以内で入力してください。"
         },
         "worker[worker_insurance_attributes][severance_pay_mutual_aid_type]": {
           required: "建設業退職金共済制度を選択してください。"

--- a/db/fixtures/development/19_worker_insurance.rb
+++ b/db/fixtures/development/19_worker_insurance.rb
@@ -7,7 +7,7 @@ Worker.all.each do |worker|
         health_insurance_name:         '国民健康保険',
         pension_insurance_type:        rand(0..2),
         employment_insurance_type:     rand(0..2),
-        employment_insurance_number:   "#{sprintf('%04d', rand(9999))}-#{sprintf('%06d', rand(999999))}-#{sprintf('%01d', rand(9))}",
+        employment_insurance_number:   '1Aaｱ',
         severance_pay_mutual_aid_type: rand(0..3),
         severance_pay_mutual_aid_name: 'サンプル共済制度'
       }

--- a/spec/factories/worker_insurances.rb
+++ b/spec/factories/worker_insurances.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     health_insurance_image { [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))] }
     pension_insurance_type { rand(2) }
     employment_insurance_type { :insured }
-    employment_insurance_number { '%.11d' % rand(100000000000) }
+    employment_insurance_number { '1Aaｱ' }
     severance_pay_mutual_aid_type { :other }
     severance_pay_mutual_aid_name { 'テスト' }
   end

--- a/spec/models/worker_insurance_spec.rb
+++ b/spec/models/worker_insurance_spec.rb
@@ -97,48 +97,43 @@ RSpec.describe WorkerInsurance, type: :model do
     end
 
     describe '#employment_insurance_number' do
-      context '被保険者の場合' do
-        %i[
-          12345
-          123あ
-          ア123
-        ].each do |number|
-          before :each do
+      shared_examples '無効な被保険者番号' do |numbers, error_message|
+        numbers.each do |number|
+          before do
             subject.employment_insurance_type = :insured
             subject.employment_insurance_number = number
           end
-
+    
           it 'バリデーションに落ちること' do
             expect(subject).to be_invalid
           end
+    
+          it 'バリデーションのエラーが正しいこと' do
+            subject.valid?
+            expect(subject.errors.full_messages).to include(error_message)
+          end
         end
       end
-
-      # context '被保険者以外の場合' do
-      #   %i[
-      #     1234567890
-      #     123456789012
-      #   ].each do |number|
-      #     before :each do
-      #       subject.employment_insurance_number = number
-      #     end
-
-      #     it 'バリデーションに落ちること(日雇保険)' do
-      #       subject.employment_insurance_type = :day
-      #       expect(subject).to be_invalid
-      #     end
-
-      #     it 'バリデーションのエラーが正しいこと(日雇保険)' do
-      #       subject.valid?
-      #       expect(subject.errors.full_messages).to include('被保険者番号は11文字で入力してください')
-      #     end
-
-      #     it 'バリデーションにとおること(適応除外)' do
-      #       subject.employment_insurance_type = :exemption
-      #       expect(subject).to be_valid
-      #     end
-      #   end
-      # end
+    
+      context '被保険者の場合' do
+        context '無効な形式の場合' do
+          numbers = %i[
+            123あ
+            ア123
+          ]
+          error_message = '被保険者番号は数字と半角カタカナのみ使用できます'
+          include_examples '無効な被保険者番号', numbers, error_message
+        end
+    
+        context '無効な長さの場合' do
+          numbers = %i[
+            12345
+            1234a
+          ]
+          error_message = '被保険者番号は4文字以内で入力してください'
+          include_examples '無効な被保険者番号', numbers, error_message
+        end
+      end
     end
 
     describe '#severance_pay_mutual_aid_type' do

--- a/spec/models/worker_insurance_spec.rb
+++ b/spec/models/worker_insurance_spec.rb
@@ -99,9 +99,9 @@ RSpec.describe WorkerInsurance, type: :model do
     describe '#employment_insurance_number' do
       context '被保険者の場合' do
         %i[
-          1234567890
-          123456789012
-          nil
+          12345
+          123あ
+          ア123
         ].each do |number|
           before :each do
             subject.employment_insurance_type = :insured
@@ -110,11 +110,6 @@ RSpec.describe WorkerInsurance, type: :model do
 
           it 'バリデーションに落ちること' do
             expect(subject).to be_invalid
-          end
-
-          it 'バリデーションのエラーが正しいこと' do
-            subject.valid?
-            expect(subject.errors.full_messages).to include('被保険者番号は11文字で入力してください')
           end
         end
       end

--- a/spec/models/worker_insurance_spec.rb
+++ b/spec/models/worker_insurance_spec.rb
@@ -99,22 +99,22 @@ RSpec.describe WorkerInsurance, type: :model do
     describe '#employment_insurance_number' do
       shared_examples '無効な被保険者番号' do |numbers, error_message|
         numbers.each do |number|
-          before do
+          before(:each) do
             subject.employment_insurance_type = :insured
             subject.employment_insurance_number = number
           end
-    
+
           it 'バリデーションに落ちること' do
             expect(subject).to be_invalid
           end
-    
+
           it 'バリデーションのエラーが正しいこと' do
             subject.valid?
             expect(subject.errors.full_messages).to include(error_message)
           end
         end
       end
-    
+
       context '被保険者の場合' do
         context '無効な形式の場合' do
           numbers = %i[
@@ -124,7 +124,7 @@ RSpec.describe WorkerInsurance, type: :model do
           error_message = '被保険者番号は数字と半角カタカナのみ使用できます'
           include_examples '無効な被保険者番号', numbers, error_message
         end
-    
+
         context '無効な長さの場合' do
           numbers = %i[
             12345


### PR DESCRIPTION
### 概要
- 不具合修正No.171(平野)

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- 不具合修正No.104 作業員情報登録画面の「保険情報」の「雇用保険」の「被保険者番号」を下4桁に変更
数字と半角カタカナのみ入力可能

### 実装画像などあれば添付する
- エラーメッセージ 
![FireShot Capture 078 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/d7375dab-558c-425f-9cf2-005ce1c712fc)
- 4桁まで入力可能
![FireShot Capture 079 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/f0a90778-bf51-4d30-b762-d798996c3d16)
- 詳細画面
![FireShot Capture 080 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/13897f37-99e9-43af-af7e-43395a8142c1)
![FireShot Capture 081 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/7bb95b6d-4a8a-421a-a9d4-445cc6db5a8e)
