### PR TITLE
不具合修正No.104の追加修正(平野)

### DIFF
--- a/app/models/worker_insurance.rb
+++ b/app/models/worker_insurance.rb
@@ -37,7 +37,7 @@ class WorkerInsurance < ApplicationRecord
   validates :pension_insurance_type, presence: true
   validates :employment_insurance_type, presence: true, unless: :business_owner_or_master
   validates :employment_insurance_type, absence: true, if: :business_owner_or_master
-  validates :employment_insurance_number, length: { maximum: 4 }, format: { with: /\A[a-zA-Z0-9｡-ﾟ]+\z/, message: 'は数字と半角カタカナのみ使用できます' }, if: :employment_insurance_number_valid?
+  validates :employment_insurance_number, length: { maximum: 4 }, format: { with: /\A[0-9｡-ﾟ]+\z/, message: 'は数字と半角カタカナのみ使用できます' }, if: :employment_insurance_number_valid?
   validates :employment_insurance_number, absence: true, unless: :employment_insurance_number_valid?
   validates :has_labor_insurance, presence: true, if: :business_owner_or_master
   validates :has_labor_insurance, absence: true, unless: :business_owner_or_master

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -856,6 +856,10 @@
 
 <script>
   $(function(){
+    $.validator.addMethod("alphanumericKatakanaOnly", function(value, element) {
+      return this.optional(element) || /^[0-9｡-ﾟ]+$/.test(value);
+    }, "数字と半角カタカナのみ入力してください。");
+
     $.each(function(key){
       $.validator.addMethod(key, this);
     });
@@ -973,7 +977,8 @@
           required: true
         },
         "worker[worker_insurance_attributes][employment_insurance_number]": {
-          required: true
+          required: true,
+          alphanumericKatakanaOnly: true
         },
         "worker[worker_insurance_attributes][severance_pay_mutual_aid_type]": {
           required: true
@@ -1104,7 +1109,8 @@
           required: "雇用保険のタイプを選択してください。"
         },
         "worker[worker_insurance_attributes][employment_insurance_number]": {
-          required: "被保険者番号は数字と半角カタカナの4桁以内で入力してください。"
+          required: "被保険者番号は数字と半角カタカナの4桁以内で入力してください。",
+          alphanumericKatakanaOnly: "数字と半角カタカナのみ入力してください。"
         },
         "worker[worker_insurance_attributes][severance_pay_mutual_aid_type]": {
           required: "建設業退職金共済制度を選択してください。"

--- a/db/fixtures/development/19_worker_insurance.rb
+++ b/db/fixtures/development/19_worker_insurance.rb
@@ -7,7 +7,7 @@ Worker.all.each do |worker|
         health_insurance_name:         '国民健康保険',
         pension_insurance_type:        rand(0..2),
         employment_insurance_type:     rand(0..2),
-        employment_insurance_number:   '1Aaｱ',
+        employment_insurance_number:   '123ｱ',
         severance_pay_mutual_aid_type: rand(0..3),
         severance_pay_mutual_aid_name: 'サンプル共済制度'
       }

--- a/spec/factories/worker_insurances.rb
+++ b/spec/factories/worker_insurances.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     health_insurance_image { [Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg'))] }
     pension_insurance_type { rand(2) }
     employment_insurance_type { :insured }
-    employment_insurance_number { '1Aaｱ' }
+    employment_insurance_number { '123ｱ' }
     severance_pay_mutual_aid_type { :other }
     severance_pay_mutual_aid_name { 'テスト' }
   end

--- a/spec/models/worker_insurance_spec.rb
+++ b/spec/models/worker_insurance_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe WorkerInsurance, type: :model do
         context '無効な長さの場合' do
           numbers = %i[
             12345
-            1234a
+            1234ｱ
           ]
           error_message = '被保険者番号は4文字以内で入力してください'
           include_examples '無効な被保険者番号', numbers, error_message


### PR DESCRIPTION
### 概要
- 不具合修正No.104の追加修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- 不具合修正No.104 作業員情報登録画面の「保険情報」の「雇用保険」の「被保険者番号」を下4桁に変更の追加修正
入力フォームのバリデーション表示の不具合を修正(全角で入力した場合、フォームバリデーションが効かなかった不具合を修正)


### 実装画像などあれば添付する

![FireShot Capture 086 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/48765a2f-cac5-4bfa-ba57-2e4c1e3c7b4a)

![FireShot Capture 083 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/bf4955e6-198f-4f6f-9fa4-03d806825466)

![FireShot Capture 085 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/fa4ad4c6-3bda-438d-9324-6d299c9d5cee)

![FireShot Capture 084 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/496a69b2-297e-47f6-a733-b6a89e10380f)
