### PR TITLE
不具合項目203番の修正

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1605,8 +1605,15 @@ module DocumentsHelper
   #doc_9
   # 自身の一つ上階層の会社情報&現場情報取得
   def get_myself_and_myparent_site
-    request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
-    @parent_request_orber = RequestOrder.find(request_order.parent_id)
+    request_order_uuid = params[:request_order_uuid]
+    return if request_order_uuid.nil?
+  
+    request_order = RequestOrder.find_by(uuid: request_order_uuid)
+    return if request_order.nil?
+  
+    @parent_request_orber = RequestOrder.find_by(id: request_order.parent_id)
+    return if @parent_request_orber.nil?
+  
     @parent_business = @parent_request_orber.business
   end
   # rubocop:enable all

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1605,10 +1605,15 @@ module DocumentsHelper
   #doc_9
   # 自身の一つ上階層の会社情報&現場情報取得
   def get_myself_and_myparent_site
-    if @parent_request_order&.parent?
-      @parent_request_order = RequestOrder.find_by(id: @parent_request_order.parent_id)
+    request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
+    if request_order&.prime_contractor?
+      @parent_request_order = nil
+      @parent_business = nil
+    else
+      @parent_request_order = RequestOrder.find(request_order.parent_id)
       @parent_business = @parent_request_order.business
     end
   end
+  
   # rubocop:enable all
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1605,16 +1605,10 @@ module DocumentsHelper
   #doc_9
   # 自身の一つ上階層の会社情報&現場情報取得
   def get_myself_and_myparent_site
-    request_order_uuid = params[:request_order_uuid]
-    return if request_order_uuid.nil?
-  
-    request_order = RequestOrder.find_by(uuid: request_order_uuid)
-    return if request_order.nil?
-  
-    @parent_request_orber = RequestOrder.find_by(id: request_order.parent_id)
-    return if @parent_request_orber.nil?
-  
-    @parent_business = @parent_request_orber.business
+    if @parent_request_order&.parent?
+      @parent_request_order = RequestOrder.find_by(id: @parent_request_order.parent_id)
+      @parent_business = @parent_request_order.business
+    end
   end
   # rubocop:enable all
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1606,11 +1606,11 @@ module DocumentsHelper
   # 自身の一つ上階層の会社情報&現場情報取得
   def get_myself_and_myparent_site
     request_order = RequestOrder.find_by(uuid: params[:request_order_uuid])
-    if request_order&.prime_contractor?
+    if request_order.prime_contractor?
       @parent_request_order = nil
       @parent_business = nil
     else
-      @parent_request_order = RequestOrder.find(request_order.parent_id)
+      @parent_request_order = request_order.parent
       @parent_business = @parent_request_order.business
     end
   end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1614,6 +1614,5 @@ module DocumentsHelper
       @parent_business = @parent_request_order.business
     end
   end
-  
   # rubocop:enable all
 end

--- a/app/models/request_order.rb
+++ b/app/models/request_order.rb
@@ -48,6 +48,10 @@ class RequestOrder < ApplicationRecord
     uuid
   end
 
+  def parent?
+    parent_id.nil?
+  end
+
   private
 
   def name_is_required_professional_engineer

--- a/app/models/request_order.rb
+++ b/app/models/request_order.rb
@@ -48,7 +48,7 @@ class RequestOrder < ApplicationRecord
     uuid
   end
 
-  def parent?
+  def prime_contractor?
     parent_id.nil?
   end
 

--- a/app/views/users/documents/doc_9th/_edit.html.erb
+++ b/app/views/users/documents/doc_9th/_edit.html.erb
@@ -18,7 +18,7 @@
     <% get_myself_and_myparent_site %>
     <% number_of_pages = 1%>
     <% total_number_of_pages = foreign_field_workers.each_slice(3).size%>
-    <% parent_subcon_info = sc_hierarchy(@parent_request_orber)[0..2] %>
+    <% parent_subcon_info = sc_hierarchy(@parent_request_order)[0..2] %>
     <% foreign_field_workers.each_slice(3).each_with_index do |(w1, w2, w3), i| %>
       <div id="ninth-document" class="document-inner">
         <div class="ninth-text-container">

--- a/app/views/users/documents/doc_9th/_edit.html.erb
+++ b/app/views/users/documents/doc_9th/_edit.html.erb
@@ -680,7 +680,7 @@
                     <%= worker_str(w1, "job_title") %> <!-- 9-024 責任者・役職 -->
                   <td class="doc_9_s5" dir="ltr" colspan="2">氏名</td>
                   <td class="doc_9_s32" dir="ltr" colspan="6">
-                    <%= document_subcon_info.content["foreigners_employment_manager"] %> <!-- 9-025 責任者・氏名 -->
+                    <%= document_subcon_info&.content&.[]("foreigners_employment_manager") %> <!-- 9-025 責任者・氏名 -->
                   <td class="doc_9_s5" dir="ltr" colspan="2">連絡先</td>
                   <td class="doc_9_s43" dir="ltr" colspan="7">
                     <%= phone_number_add_hyphen(worker_str(w1, "my_phone_number")) if w1.present? %> <!-- 9-026 責任者・連絡先(TEL) -->

--- a/app/views/users/documents/doc_9th/_show.html.erb
+++ b/app/views/users/documents/doc_9th/_show.html.erb
@@ -666,7 +666,7 @@
                   <%= worker_str(w1, "job_title") if w1.present? %> <!-- 9-024 責任者・役職 -->
                 <td class="doc_9_s5" dir="ltr" colspan="2">氏名</td>
                 <td class="doc_9_s32" dir="ltr" colspan="6">
-                  <%= document_subcon_info.content["foreigners_employment_manager"] %> <!-- 9-025 責任者・氏名 -->
+                  <%= document_subcon_info&.content&.[]("foreigners_employment_manager") %> <!-- 9-025 責任者・氏名 -->
                 <td class="doc_9_s5" dir="ltr" colspan="2">連絡先</td>
                 <td class="doc_9_s43" dir="ltr" colspan="7">
                   <%= phone_number_add_hyphen(worker_str(w1, "my_phone_number")) if w1.present? %> <!-- 9-026 責任者・連絡先(TEL) -->

--- a/app/views/users/documents/doc_9th/_show.html.erb
+++ b/app/views/users/documents/doc_9th/_show.html.erb
@@ -4,7 +4,7 @@
                                                         .where.not("JSON_CONTAINS(content, ?, '$.status_of_residence')", "\"permanent_resident\"")
                                                         .where.not("JSON_CONTAINS(content, ?, '$.status_of_residence')", "\"skill_practice\"")%>
   <% get_myself_and_myparent_site %>
-  <% parent_subcon_info = sc_hierarchy(@parent_request_orber)[0..2] %>
+  <% parent_subcon_info = sc_hierarchy(@parent_request_order)[0..2] %>
   <% number_of_pages = 1 %>
   <% total_number_of_pages = foreign_field_workers.each_slice(3).size %>
   <% foreign_field_workers.each_slice(3).each_with_index do |(w1, w2, w3), i| %>

--- a/app/views/users/documents/doc_9th/_show.pdf.erb
+++ b/app/views/users/documents/doc_9th/_show.pdf.erb
@@ -663,7 +663,7 @@
                   <%= worker_str(w1, "job_title") %> <!-- 9-024 責任者・役職 -->
                 <td class="doc_9_s5" dir="ltr" colspan="2">氏名</td>
                 <td class="doc_9_s32" dir="ltr" colspan="6">
-                  <%= document_subcon_info.content["foreigners_employment_manager"] %> <!-- 9-025 責任者・氏名 -->
+                  <%= document_subcon_info&.content&.[]("foreigners_employment_manager") %> <!-- 9-025 責任者・氏名 -->
                 <td class="doc_9_s5" dir="ltr" colspan="2">連絡先</td>
                 <td class="doc_9_s43" dir="ltr" colspan="7">
                   <%= phone_number_add_hyphen(worker_str(w1, "my_phone_number")) if w1.present? %> <!-- 9-026 責任者・連絡先(TEL) -->
@@ -707,7 +707,7 @@
       </div>
     </div>
   </body>
-<% end%>
+<% end %>
 
 
 <style>

--- a/app/views/users/documents/doc_9th/_show.pdf.erb
+++ b/app/views/users/documents/doc_9th/_show.pdf.erb
@@ -6,7 +6,7 @@
                                                         .where.not("JSON_CONTAINS(content, ?, '$.status_of_residence')", "\"permanent_resident\"")
                                                         .where.not("JSON_CONTAINS(content, ?, '$.status_of_residence')", "\"skill_practice\"")%>
 <% get_myself_and_myparent_site %>
-<% parent_subcon_info = sc_hierarchy(@parent_request_orber)[0..2] %>
+<% parent_subcon_info = sc_hierarchy(@parent_request_order)[0..2] %>
 <% number_of_pages = 1%>
 <% total_number_of_pages = foreign_field_workers.each_slice(3).size%>
 <% foreign_field_workers.each_slice(3).each_with_index do |(w1, w2, w3), i| %>


### PR DESCRIPTION
### 概要
下請けが作業員情報(外国人の入場作業員)を登録していない状態で、元請けが下請けの「➈外国人建設就労者建設現場入場届出書」のPDFページを見に行くとエラーになるbugを修正致しました。
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=0

※あと実装中に、「9-025 責任者・氏名」がnilだとエラーになるのを見つけたので修正しました。

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
params[:request_order_uuid]がnilだった場合エラーになるコードでしたのでrequest_order_uuidがnilであれば、処理を終了してメソッドから抜けるような処理にしました。

### 実装画像などあれば添付する
元請けが現場情報を作成 → 「下請けへ書類作成依頼」→ 「➈外国人建設就労者建設現場入場届出書」のPDFページを見に行く→ エラー発生
<img width="643" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/caee609f-cfa1-4e68-b133-1fa39717eedb">
だったのを、
<img width="942" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/5ff6ec43-0846-480c-8ee2-a9041f93cfb5">
になるようにしました。
