### PR TITLE
:bug: アップロード機能改修

### DIFF
--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -315,7 +315,7 @@
               <% if @worker.worker_insurance.health_insurance_image.present? && @worker.id.present? %>
                 <% @worker.worker_insurance.health_insurance_image.each_with_index do |image, index| %>
                   <%= image_tag(image.url) %>
-                  <%= link_to "削除", users_worker_update_health_insurance_image_path(@worker.id, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
+                  <%= link_to "削除", users_worker_update_health_insurance_image_path(@worker, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
                 <% end %>
               <% end %>
             </div>


### PR DESCRIPTION
### 概要
_PR概要を記述する_

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
作業員情報マスタデータ入力において、画像を追加保存できるようにした。
また画像の削除をできるように修正した。

### 実装画像などあれば添付する
![image](https://github.com/kensuma-1122/kensuma/assets/80724165/82c2f5a0-34bd-4f19-9ce2-c9783757a202)


