### PR TITLE
不具合修正No.211(平野)

### DIFF
--- a/app/views/users/request_orders/show.html.erb
+++ b/app/views/users/request_orders/show.html.erb
@@ -48,6 +48,71 @@
   </div>
 </section>
 
+<!-- 工事作業所災害防止協議会兼施工体系図,作業間連絡調整書 -->
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card <%= @request_order.order.system_chart_status ? 'card-primary' : 'card-danger' %> card-outline">
+          <div class="card-body">
+            <div class="row">
+              <div class="card-body table-responsive p-0">
+                <table class="table table-sm text-nowrap">
+                  <thead>
+                    <tr>
+                      <th>労務安全書類一覧</th>
+                      <th></th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% if @request_order.parent_id.nil? %>
+                      <tr>
+                        <th>
+                          <% if @request_order.order.system_chart_status %>
+                            <span class="text-primary"><i class="fas fa-check-circle"></i> 現在公開中です</span>
+                          <% else %>
+                            <span class="text-danger"><i class="fas fa-times-circle"></i> 現在非公開です</span>
+                          <% end %>
+                          <%= link_to_if(@request_order.order.system_chart_status, '　→ 非公開にする'.html_safe, system_chart_status_users_order_path(@request_order.order), method: :patch,
+                                                                                    data: { confirm: "工事作業所災害防止協議会兼施工体系図と作業間連絡調整書を非公開にします。よろしいですか？" }, class: "text-danger no-underline") do %>
+                            <%= link_to '　→ 公開する', system_chart_status_users_order_path(@request_order.order), method: :patch,
+                                                      data: { confirm: "工事作業所災害防止協議会兼施工体系図と作業間連絡調整書を下請けに公開にします。よろしいですか？" }, class: "text-primary no-underline" %>
+                          <% end %>
+                        </th>
+                        <td></td>
+                        <td></td>
+                      </tr>
+                    <% end %>
+
+                    <% @system_chart_documents.each do |current_user_document| %>
+                      <tr>
+                        <td>
+                          <%= current_user_document.document_type_i18n %>
+                        </td>
+                        <td class="text-right">
+                          <% if @request_order.order.system_chart_status || @request_order.parent_id.nil? %>
+                              <%= link_to '詳細', users_request_order_document_path(@request_order.uuid, current_user_document.uuid) %>
+                            <% else %>
+                              <span class="text-danger">元請にて作成中</span> 
+                            <% end %>
+                        </td>
+                        <td class="text-right">
+                          <%= link_to 'PDF', users_request_order_document_path(@request_order.uuid, current_user_document.uuid, format: :pdf), target: :_blank, rel: "noopener noreferrer" if @request_order.order.system_chart_status? || @request_order.parent_id.nil? %>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<section>
+
 <% unless @request_order.parent_id.nil? %>
   <section class="content">
     <div class="col-md-12">
@@ -236,71 +301,6 @@
       </div>
   </section>
 <% end %>
-
-<!-- 工事作業所災害防止協議会兼施工体系図,作業間連絡調整書 -->
-<section class="content">
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-md-12">
-        <div class="card <%= @request_order.order.system_chart_status ? 'card-primary' : 'card-danger' %> card-outline">
-          <div class="card-body">
-            <div class="row">
-              <div class="card-body table-responsive p-0">
-                <table class="table table-sm text-nowrap">
-                  <thead>
-                    <tr>
-                      <th>労務安全書類一覧</th>
-                      <th></th>
-                      <th></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <% if @request_order.parent_id.nil? %>
-                      <tr>
-                        <th>
-                          <% if @request_order.order.system_chart_status %>
-                            <span class="text-primary"><i class="fas fa-check-circle"></i> 現在公開中です</span>
-                          <% else %>
-                            <span class="text-danger"><i class="fas fa-times-circle"></i> 現在非公開です</span>
-                          <% end %>
-                          <%= link_to_if(@request_order.order.system_chart_status, '　→ 非公開にする'.html_safe, system_chart_status_users_order_path(@request_order.order), method: :patch,
-                                                                                    data: { confirm: "工事作業所災害防止協議会兼施工体系図と作業間連絡調整書を非公開にします。よろしいですか？" }, class: "text-danger no-underline") do %>
-                            <%= link_to '　→ 公開する', system_chart_status_users_order_path(@request_order.order), method: :patch,
-                                                      data: { confirm: "工事作業所災害防止協議会兼施工体系図と作業間連絡調整書を下請けに公開にします。よろしいですか？" }, class: "text-primary no-underline" %>
-                          <% end %>
-                        </th>
-                        <td></td>
-                        <td></td>
-                      </tr>
-                    <% end %>
-
-                    <% @system_chart_documents.each do |current_user_document| %>
-                      <tr>
-                        <td>
-                          <%= current_user_document.document_type_i18n %>
-                        </td>
-                        <td class="text-right">
-                          <% if @request_order.order.system_chart_status || @request_order.parent_id.nil? %>
-                              <%= link_to '詳細', users_request_order_document_path(@request_order.uuid, current_user_document.uuid) %>
-                            <% else %>
-                              <span class="text-danger">元請にて作成中</span> 
-                            <% end %>
-                        </td>
-                        <td class="text-right">
-                          <%= link_to 'PDF', users_request_order_document_path(@request_order.uuid, current_user_document.uuid, format: :pdf), target: :_blank, rel: "noopener noreferrer" if @request_order.order.system_chart_status? || @request_order.parent_id.nil? %>
-                        </td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-<section>
 
 <!-- 元請（自身の情報） -->
 <section class="content">


### PR DESCRIPTION
### 概要
- 不具合修正No.211

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- 不具合修正No.211 「労務安全書類一覧」を自社の現場情報の上に移動
労務安全書類一覧の表示位置の並び替えのみ

### 実装画像などあれば添付する

![FireShot Capture 093 - 建スマ - localhost](https://github.com/kensuma-1122/kensuma/assets/52871417/159e47aa-2ecb-4772-96bb-a138de21e4ac)

