### PR TITLE
不具合修正No.210(平野)

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -8,7 +8,7 @@ module DocumentsHelper
   # document.contentの日付
   def doc_content_date(date)
     if action_name == 'edit'
-      date.nil? ? '' : date.to_date&.strftime('%Y年%-m月%-d日') # nilの場合のstrftime表示エラー回避
+      date.nil? ? '年　月　日' : date.to_date&.strftime('%Y年%-m月%-d日') # nilの場合のstrftime表示エラー回避
     else
       date.nil? ? '年　月　日' : wareki(date.to_date)
     end

--- a/app/views/users/documents/doc_13th/_current_edit.html.erb
+++ b/app/views/users/documents/doc_13th/_current_edit.html.erb
@@ -1732,15 +1732,15 @@
                 <td class="doc_13_s8" colspan="2" rowspan="4">定 期</td>
                 <td class="doc_13_s8" colspan="2" rowspan="2">年次</td>
                 <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_year").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-025 自主検査有効期限・定期・年次 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_year")) %> <!-- 13-025 自主検査有効期限・定期・年次 -->
                 </td>
                 <td class="doc_13_s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
                 <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_machine").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_machine")) %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
                 </td>
                 <td class="doc_13_s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
                 <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_car").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-029 自動車検査証有効期限 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_car")) %> <!-- 13-029 自動車検査証有効期限 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s35"></td>
@@ -1815,7 +1815,7 @@
                 <td class="doc_13_s39"></td>
                 <td class="doc_13_s8" colspan="2" rowspan="2">月次</td>
                 <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_month").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-026 自主検査有効期限・定期・月次 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_month")) %> <!-- 13-026 自主検査有効期限・定期・月次 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s4"></td>
@@ -1894,7 +1894,7 @@
                 <td class="doc_13_s39"></td>
                 <td class="doc_13_s8" colspan="4" rowspan="2">特 定</td>
                 <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_specific").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-027 自主検査有効期限・特定 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_specific")) %> <!-- 13-027 自主検査有効期限・特定 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s4"></td>
@@ -2050,7 +2050,7 @@
                 </td>
                 <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
                 <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="2">
-                  <%= field_special_vehicle.content&.[]("exp_date_insurance").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-034 有効期限 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("exp_date_insurance")) %> <!-- 13-034 有効期限 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s4"></td>

--- a/app/views/users/documents/doc_13th/_current_show.html.erb
+++ b/app/views/users/documents/doc_13th/_current_show.html.erb
@@ -1532,15 +1532,15 @@
               <td class="doc_13_s8" colspan="2" rowspan="4">定 期</td>
               <td class="doc_13_s8" colspan="2" rowspan="2">年次</td>
               <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                <%= field_special_vehicle.content&.[]("check_exp_date_year").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-025 自主検査有効期限・定期・年次 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_year")) %> <!-- 13-025 自主検査有効期限・定期・年次 -->
               </td>
               <td class="doc_13_s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
               <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
-                <%= field_special_vehicle.content&.[]("check_exp_date_machine").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_machine")) %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
               </td>
               <td class="doc_13_s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
               <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
-                <%= field_special_vehicle.content&.[]("check_exp_date_car").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-029 自動車検査証有効期限 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_car")) %> <!-- 13-029 自動車検査証有効期限 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s35"></td>
@@ -1602,7 +1602,7 @@
               <td class="doc_13_s39"></td>
               <td class="doc_13_s8" colspan="2" rowspan="2">月次</td>
               <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                <%= field_special_vehicle.content&.[]("check_exp_date_month").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-026 自主検査有効期限・定期・月次 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_month")) %> <!-- 13-026 自主検査有効期限・定期・月次 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
@@ -1667,7 +1667,7 @@
               <td class="doc_13_s39"></td>
               <td class="doc_13_s8" colspan="4" rowspan="2">特 定</td>
               <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                <%= field_special_vehicle.content&.[]("check_exp_date_specific").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-027 自主検査有効期限・特定 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_specific")) %> <!-- 13-027 自主検査有効期限・特定 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
@@ -1803,7 +1803,7 @@
               </td>
               <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
               <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="2">
-                <%= field_special_vehicle.content&.[]("exp_date_insurance").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-034 有効期限 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("exp_date_insurance")) %> <!-- 13-034 有効期限 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>

--- a/app/views/users/documents/doc_13th/_show.pdf.erb
+++ b/app/views/users/documents/doc_13th/_show.pdf.erb
@@ -1534,15 +1534,15 @@
             <td class="s8" colspan="2" rowspan="4">定 期</td>
             <td class="s8" colspan="2" rowspan="2">年次</td>
             <td class="s24" dir="ltr" colspan="7" rowspan="2">
-              <%= field_special_vehicle.content&.[]("check_exp_date_year").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-025 自主検査有効期限・定期・年次 -->
+              <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_year")) %> <!-- 13-025 自主検査有効期限・定期・年次 -->
             </td>
             <td class="s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
             <td class="s36" dir="ltr" colspan="7" rowspan="6">
-              <%= field_special_vehicle.content&.[]("check_exp_date_machine").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
+              <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_machine")) %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
             </td>
             <td class="s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
             <td class="s36" dir="ltr" colspan="7" rowspan="6">
-              <%= field_special_vehicle.content&.[]("check_exp_date_car").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-029 自動車検査証有効期限 -->
+              <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_car")) %> <!-- 13-029 自動車検査証有効期限 -->
             </td>
             <td class="s4"></td>
             <td class="s35"></td>
@@ -1605,7 +1605,7 @@
             <td class="s39"></td>
             <td class="s8" colspan="2" rowspan="2">月次</td>
             <td class="s24" dir="ltr" colspan="7" rowspan="2">
-              <%= field_special_vehicle.content&.[]("check_exp_date_month").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-026 自主検査有効期限・定期・月次 -->
+              <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_month")) %> <!-- 13-026 自主検査有効期限・定期・月次 -->
             </td>
             <td class="s4"></td>
             <td class="s4"></td>
@@ -1670,7 +1670,7 @@
             <td class="s39"></td>
             <td class="s8" colspan="4" rowspan="2">特 定</td>
             <td class="s24" dir="ltr" colspan="7" rowspan="2">
-              <%= field_special_vehicle.content&.[]("check_exp_date_specific").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-027 自主検査有効期限・特定 -->
+              <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_specific")) %> <!-- 13-027 自主検査有効期限・特定 -->
             </td>
             <td class="s4"></td>
             <td class="s4"></td>
@@ -1806,7 +1806,7 @@
             </td>
             <td class="s8" colspan="2" rowspan="2">千円</td>
             <td class="s36" dir="ltr" colspan="7" rowspan="2">
-              <%= field_special_vehicle.content&.[]("exp_date_insurance").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-034 有効期限 -->
+              <%= doc_content_date(field_special_vehicle.content&.[]("exp_date_insurance")) %> <!-- 13-034 有効期限 -->
             </td>
             <td class="s4"></td>
             <td class="s4"></td>

--- a/app/views/users/documents/doc_13th/_subcon_edit.html.erb
+++ b/app/views/users/documents/doc_13th/_subcon_edit.html.erb
@@ -1726,15 +1726,15 @@
                 <td class="doc_13_s8" colspan="2" rowspan="4">定 期</td>
                 <td class="doc_13_s8" colspan="2" rowspan="2">年次</td>
                 <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_year").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-025 自主検査有効期限・定期・年次 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_year")) %> <!-- 13-025 自主検査有効期限・定期・年次 -->
                 </td>
                 <td class="doc_13_s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
                 <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_machine").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_machine")) %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
                 </td>
                 <td class="doc_13_s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
                 <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_car").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-029 自動車検査証有効期限 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_car")) %> <!-- 13-029 自動車検査証有効期限 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s35"></td>
@@ -1808,7 +1808,7 @@
                 <td class="doc_13_s39"></td>
                 <td class="doc_13_s8" colspan="2" rowspan="2">月次</td>
                 <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_month").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-026 自主検査有効期限・定期・月次 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_month")) %> <!-- 13-026 自主検査有効期限・定期・月次 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s4"></td>
@@ -1885,7 +1885,7 @@
                 <td class="doc_13_s39"></td>
                 <td class="doc_13_s8" colspan="4" rowspan="2">特 定</td>
                 <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                  <%= field_special_vehicle.content&.[]("check_exp_date_specific").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-027 自主検査有効期限・特定 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_specific")) %> <!-- 13-027 自主検査有効期限・特定 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s4"></td>
@@ -2039,7 +2039,7 @@
                 </td>
                 <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
                 <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="2">
-                  <%= field_special_vehicle.content&.[]("exp_date_insurance").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-034 有効期限 -->
+                  <%= doc_content_date(field_special_vehicle.content&.[]("exp_date_insurance")) %> <!-- 13-034 有効期限 -->
                 </td>
                 <td class="doc_13_s4"></td>
                 <td class="doc_13_s4"></td>

--- a/app/views/users/documents/doc_13th/_subcon_show.html.erb
+++ b/app/views/users/documents/doc_13th/_subcon_show.html.erb
@@ -1532,15 +1532,15 @@
               <td class="doc_13_s8" colspan="2" rowspan="4">定 期</td>
               <td class="doc_13_s8" colspan="2" rowspan="2">年次</td>
               <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                <%= field_special_vehicle.content&.[]("check_exp_date_year").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-025 自主検査有効期限・定期・年次 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_year")) %> <!-- 13-025 自主検査有効期限・定期・年次 -->
               </td>
               <td class="doc_13_s34" colspan="5" rowspan="6">移動式<br> クレーン等<br> の性能検査<br> 有効期限</td>
               <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
-                <%= field_special_vehicle.content&.[]("check_exp_date_machine").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_machine")) %> <!-- 13-028 移動式クレーン等の性能検査有効期限 -->
               </td>
               <td class="doc_13_s8" colspan="5" rowspan="6">自 動 車<br> 検 査 証<br> 有効期限</td>
               <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="6">
-                <%= field_special_vehicle.content&.[]("check_exp_date_car").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-029 自動車検査証有効期限 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_car")) %> <!-- 13-029 自動車検査証有効期限 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s35"></td>
@@ -1602,7 +1602,7 @@
               <td class="doc_13_s39"></td>
               <td class="doc_13_s8" colspan="2" rowspan="2">月次</td>
               <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                <%= field_special_vehicle.content&.[]("check_exp_date_month").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-026 自主検査有効期限・定期・月次 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_month")) %> <!-- 13-026 自主検査有効期限・定期・月次 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
@@ -1667,7 +1667,7 @@
               <td class="doc_13_s39"></td>
               <td class="doc_13_s8" colspan="4" rowspan="2">特 定</td>
               <td class="doc_13_s24" dir="ltr" colspan="7" rowspan="2">
-                <%= field_special_vehicle.content&.[]("check_exp_date_specific").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-027 自主検査有効期限・特定 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("check_exp_date_specific")) %> <!-- 13-027 自主検査有効期限・特定 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>
@@ -1803,7 +1803,7 @@
               </td>
               <td class="doc_13_s8" colspan="2" rowspan="2">千円</td>
               <td class="doc_13_s36" dir="ltr" colspan="7" rowspan="2">
-                <%= field_special_vehicle.content&.[]("exp_date_insurance").to_date.strftime('%Y年%-m月%-d日') %> <!-- 13-034 有効期限 -->
+                <%= doc_content_date(field_special_vehicle.content&.[]("exp_date_insurance")) %> <!-- 13-034 有効期限 -->
               </td>
               <td class="doc_13_s4"></td>
               <td class="doc_13_s4"></td>


### PR DESCRIPTION
### 概要
- 不具合修正No.210

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- 不具合修正No.210 ⑬移動式クレーン／車両系建設機械等使用届の、詳細・編集・PDF画面500エラー
原因：「undefined method `to_date' for nil:NilClass」とのエラー表示があり、View側の日付にnilがある場合エラーになっていた。
解決法：既存の、nil回避用の日付ヘルパーメソッドを使用し対応。


### 実装画像などあれば添付する


