### PR TITLE
不具合修正No.212(平野)

### DIFF
--- a/db/migrate/20221220055915_add_column2_machine.rb
+++ b/db/migrate/20221220055915_add_column2_machine.rb
@@ -1,6 +1,5 @@
 class AddColumn2Machine < ActiveRecord::Migration[6.1]
   def change
     add_column :machines, :extra_inspection_item6, :string
-    add_column :machines, :insulation_resistance_measurement, :integer
   end
 end

--- a/db/migrate/20230729011024_add_insulation_resistance_measurement_machine.rb
+++ b/db/migrate/20230729011024_add_insulation_resistance_measurement_machine.rb
@@ -1,0 +1,5 @@
+class AddInsulationResistanceMeasurementMachine < ActiveRecord::Migration[6.1]
+  def change
+    add_column :machines, :insulation_resistance_measurement, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_25_100210) do
+ActiveRecord::Schema.define(version: 2023_07_29_011024) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "namespace"


### PR DESCRIPTION
### 概要
- 不具合修正No.212(平野)

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- 不具合修正No.212 「持込機械情報」の「編集画面」で更新ボタンを押すと500エラーになる
#### 原因
- 本番環境に、insulation_resistance_measurement(絶縁抵抗測定値)のカラムが存在しないためエラーになっている。

#### 症状
- マイグレーションファイルの「extra_inspection_item6」は反映されているが、「insulation_resistance_measurement」は反映されていない。
- 念のため、ローカル環境でdb:migrateをおこなった所、「insulation_resistance_measurement」カラムがschemaから消えた。
```
class AddColumn2Machine < ActiveRecord::Migration[6.1]
  def change
    add_column :machines, :extra_inspection_item6, :string
    add_column :machines, :insulation_resistance_measurement, :integer ←これが反映されない
  end
end
```
#### 対応・結果
- 既存のマイグレーションファイルから下記のコードを削除し、新たにカラム追加のマイグレーションファイルを作成し、db:migrateをおこなった所、schemaに反映された。
```
add_column :machines, :insulation_resistance_measurement, :integer 
```
### 実装画像などあれば添付する


