### PR TITLE
不具合項目112番修正

### DIFF
--- a/app/views/users/cars/_form.html.erb
+++ b/app/views/users/cars/_form.html.erb
@@ -94,7 +94,7 @@
       <%= voluntary.collection_select :company_voluntary_id, CarInsuranceCompany.all, :id, :name, { prompt: true }, { class: "form-select" } %>
       <br>
       <%= voluntary.label :voluntary_securities_number %>
-      <%= voluntary.text_field :voluntary_securities_number, class: "form-control", placeholder: Car.human_attribute_name(:voluntary_securities_number) %>
+      <%= voluntary.text_field :voluntary_securities_number, class: "form-control", placeholder: CarVoluntaryInsurance.human_attribute_name(:voluntary_securities_number) %>
       <br>
       <%= voluntary.label :personal_insurance %>
       <%= voluntary.select :personal_insurance, CarVoluntaryInsurance.personal_insurances.keys.to_a, { prompt: true }, { class: "form-select" } %>


### PR DESCRIPTION
### 概要
任意保険の証券番号のプレースホルダーが英語表記だったものを「証券番号」に修正しました。

### タスク
- [ ] なし
- [x] あり
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=57085877

### 実装内容・手法
「voluntary_securities_number」カラムがあるのは「car_voluntary_insurances」テーブルなので、モデル名を「Car」から「CarVoluntaryInsurance」に変更しました。

### 実装画像などあれば添付する
変更前↓
![image](https://github.com/kensuma-1122/kensuma/assets/97861380/9e7efedd-be61-4452-b599-ada044dfc038)
変更後↓
![image](https://github.com/kensuma-1122/kensuma/assets/97861380/a2e46384-82bf-4d66-8fd2-fdf12f00a518)
