### PR TITLE
不具合項目118番修正

### DIFF
--- a/app/views/users/machines/show.html.erb
+++ b/app/views/users/machines/show.html.erb
@@ -55,5 +55,6 @@
     <%= link_to "編集", edit_users_machine_path(@machine), class: "btn btn-success btn-md btn-block" %>
     <%= link_to "削除", users_machine_path(@machine), method: :delete,
                               data: { confirm: "#{@machine.name}の持込機械情報を削除します。本当によろしいですか？" }, class: "btn btn-danger btn-md btn-block" %>
+    <%= link_to "一覧画面へ", users_machines_path, class: "btn btn-default btn-md btn-block" %>
   </div>
 </div>


### PR DESCRIPTION
### 概要
持込機械情報一覧の詳細画面に「一覧画面へ」を追加しました。

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=849579890

### 実装画像などあれば添付する
↓修正前
<img width="537" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/8c8550ef-44bd-4bb0-8d2e-3cc8598cb66d">

↓修正後
<img width="843" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/d3ac70e0-50e7-45aa-8fb9-338dd88f48d5">

↓一覧画面へ遷移後
<img width="847" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/6acc03d1-9218-46de-aeb2-8416e197197e">

