### PR TITLE
職種情報追加

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1212,6 +1212,11 @@ module DocumentsHelper
     date.blank? ? '年　月　日' : l(date.to_date, format: :ja_kan)
   end
 
+  # 作業員職種情報
+  def worker_occupations(business)
+    business.occupations.pluck(:name).join(', ')
+  end
+
   # (14) 持込機械の機械名情報（持込時の点検表）
   def machine_tag_1st(machine)
     tags = machine&.content&.[]('machine_tags')

--- a/app/javascript/stylesheets/users/doc_24th.scss
+++ b/app/javascript/stylesheets/users/doc_24th.scss
@@ -214,7 +214,7 @@ table.type24 {
 
 .ritz .waffle .doc_24_s29 {
   border-bottom: 1px SOLID #000000;
-  background-color: #ccffcc;
+  background-color: #e9ecef;
   text-align: center;
   font-family: 'docs-Calibri', Arial;
   font-size: 11pt;

--- a/app/views/users/documents/doc_24th/_edit.html.erb
+++ b/app/views/users/documents/doc_24th/_edit.html.erb
@@ -318,7 +318,7 @@
           <td class="doc_24_s27" dir="ltr" colspan="2"><%= employment_contract_no(field_worker) %></td>
           <td class="doc_24_s28" dir="ltr" colspan="3"></td>
           <td class="doc_24_s17" dir="ltr" colspan="2">職 種：</td>
-          <td class="doc_24_s29" dir="ltr" colspan="7"><%= f.text_field name = "occupation_#{j.ordinalize}",value: field_worker.occupation, :placeholder => '例)職種' %></td> <!-- 「職種」24-019 -->
+          <td class="doc_24_s29" dir="ltr" colspan="7"><%= worker_occupations(field_worker.field_workerable.business) %></td> <!-- 「職種」24-019 -->
           <td class="doc_24_s8" dir="ltr">工</td>
           <td class="doc_24_s3"></td>
           <td class="doc_24_s3"></td>

--- a/app/views/users/documents/doc_24th/_show.html.erb
+++ b/app/views/users/documents/doc_24th/_show.html.erb
@@ -309,7 +309,7 @@
           <td class="doc_24_s27" dir="ltr" colspan="2"><%= employment_contract_no(field_worker) %></td>
           <td class="doc_24_s28" dir="ltr" colspan="3"></td>
           <td class="doc_24_s17" dir="ltr" colspan="2">職 種：</td>
-          <td class="doc_24_s29" dir="ltr" colspan="7"><%= field_worker.occupation %> <!-- 「職種」24-019 -->
+          <td class="doc_24_s29" dir="ltr" colspan="7"><%= worker_occupations(field_worker.field_workerable.business) %> <!-- 「職種」24-019 -->
           <td class="doc_24_s8" dir="ltr">工</td>
           <td class="doc_24_s3"></td>
           <td class="doc_24_s3"></td>

--- a/app/views/users/documents/doc_24th/_show.pdf.erb
+++ b/app/views/users/documents/doc_24th/_show.pdf.erb
@@ -248,7 +248,7 @@
         <td class="doc_24_s27" dir="ltr" colspan="2"><%= employment_contract_no(field_worker) %></td>
         <td class="doc_24_s28" dir="ltr" colspan="3"></td>
         <td class="doc_24_s17" dir="ltr" colspan="2">職 種：</td>
-        <td class="doc_24_s29" dir="ltr" colspan="7"><%= field_worker.occupation %></td> <!-- 「職種」24-019 -->
+        <td class="doc_24_s29" dir="ltr" colspan="7"><%= worker_occupations(field_worker.field_workerable.business) %></td> <!-- 「職種」24-019 -->
         <td class="doc_24_s8" dir="ltr">工</td>
         <td class="doc_24_s3"></td>
       </tr>


### PR DESCRIPTION
### 概要
_ドキュメント24に職種情報が表示されるように修正_

### タスク
- [] なし
- [x] あり _(https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit?pli=1#gid=889334529)_

### 実装内容・手法
_職種情報をヘルパーで取得できるように修正しました。_

### 実装画像などあれば添付する
![doc24_occpations](https://github.com/kensuma-1122/kensuma/assets/63386452/6af2f895-fe8c-4c73-bc25-d9a25d22fcbd)

