### PR TITLE
不具合222番修正

### DIFF
--- a/app/views/users/documents/doc_14th/_current_edit.html.erb
+++ b/app/views/users/documents/doc_14th/_current_edit.html.erb
@@ -1027,34 +1027,34 @@
                 <td class="doc_14_s16"></td>
                 <td class="doc_14_s22" colspan="8" rowspan="3">絶縁抵抗測定値</td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-038未実装※' %> <!-- 14-038 「絶縁抵抗測定値/1」 -->
+                  <%= machine_str(m1, "insulation_resistance_measurement") %> <!-- 14-038 「絶縁抵抗測定値/1」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-062未実装※' %> <!-- 14-062 「絶縁抵抗測定値/2」 -->
+                  <%= machine_str(m2, "insulation_resistance_measurement") %> <!-- 14-062 「絶縁抵抗測定値/2」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-086未実装※' %> <!-- 14-086 「絶縁抵抗測定値/3」 -->
+                  <%= machine_str(m3, "insulation_resistance_measurement") %> <!-- 14-086 「絶縁抵抗測定値/3」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-110未実装※' %> <!-- 14-110 「絶縁抵抗測定値/4」 -->
+                  <%= machine_str(m4, "insulation_resistance_measurement") %> <!-- 14-110 「絶縁抵抗測定値/4」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-134未実装※' %> <!-- 14-134 「絶縁抵抗測定値/5」 -->
+                  <%= machine_str(m5, "insulation_resistance_measurement") %> <!-- 14-134 「絶縁抵抗測定値/5」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-158未実装※' %> <!-- 14-158 「絶縁抵抗測定値/6」 -->
+                  <%= machine_str(m6, "insulation_resistance_measurement") %> <!-- 14-158 「絶縁抵抗測定値/6」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-182未実装※' %> <!-- 14-182 「絶縁抵抗測定値/7」 -->
+                  <%= machine_str(m7, "insulation_resistance_measurement") %> <!-- 14-182 「絶縁抵抗測定値/7」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-206未実装※' %> <!-- 14-206 「絶縁抵抗測定値/8」 -->
+                  <%= machine_str(m8, "insulation_resistance_measurement") %> <!-- 14-206 「絶縁抵抗測定値/8」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-230未実装※' %> <!-- 14-230 「絶縁抵抗測定値/9」 -->
+                  <%= machine_str(m9, "insulation_resistance_measurement") %> <!-- 14-230 「絶縁抵抗測定値/9」 -->
                 </td>
                 <td class="doc_14_s30" colspan="2" rowspan="3">
-                  <%= '※14-254未実装※' %> <!-- 14-254 「絶縁抵抗測定値/10」 -->
+                  <%= machine_str(m10, "insulation_resistance_measurement") %> <!-- 14-254 「絶縁抵抗測定値/10」 -->
                 </td>
                 <td class="doc_14_s18" dir="ltr" colspan="8" rowspan="2"> 20）その他</td>
               </tr>

--- a/app/views/users/documents/doc_14th/_show.html.erb
+++ b/app/views/users/documents/doc_14th/_show.html.erb
@@ -1010,34 +1010,34 @@
               <td class="doc_14_s16"></td>
               <td class="doc_14_s22" colspan="8" rowspan="3">絶縁抵抗測定値</td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-038未実装※' %> <!-- 14-038 「絶縁抵抗測定値/1」 -->
+                <%= machine_str(m1, "insulation_resistance_measurement") %> <!-- 14-062 「絶縁抵抗測定値/1」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-062未実装※' %> <!-- 14-062 「絶縁抵抗測定値/2」 -->
+                <%= machine_str(m2, "insulation_resistance_measurement") %> <!-- 14-062 「絶縁抵抗測定値/2」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-086未実装※' %> <!-- 14-086 「絶縁抵抗測定値/3」 -->
+                <%= machine_str(m3, "insulation_resistance_measurement") %> <!-- 14-086 「絶縁抵抗測定値/3」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-110未実装※' %> <!-- 14-110 「絶縁抵抗測定値/4」 -->
+                <%= machine_str(m4, "insulation_resistance_measurement") %> <!-- 14-110 「絶縁抵抗測定値/4」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-134未実装※' %> <!-- 14-134 「絶縁抵抗測定値/5」 -->
+                <%= machine_str(m5, "insulation_resistance_measurement") %> <!-- 14-134 「絶縁抵抗測定値/5」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-158未実装※' %> <!-- 14-158 「絶縁抵抗測定値/6」 -->
+                <%= machine_str(m6, "insulation_resistance_measurement") %> <!-- 14-158 「絶縁抵抗測定値/6」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-182未実装※' %> <!-- 14-182 「絶縁抵抗測定値/7」 -->
+                <%= machine_str(m7, "insulation_resistance_measurement") %> <!-- 14-182 「絶縁抵抗測定値/7」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-206未実装※' %> <!-- 14-206 「絶縁抵抗測定値/8」 -->
+                <%= machine_str(m8, "insulation_resistance_measurement") %> <!-- 14-206 「絶縁抵抗測定値/8」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-230未実装※' %> <!-- 14-230 「絶縁抵抗測定値/9」 -->
+                <%= machine_str(m9, "insulation_resistance_measurement") %> <!-- 14-230 「絶縁抵抗測定値/9」 -->
               </td>
               <td class="doc_14_s30" colspan="2" rowspan="3">
-                <%= '※14-254未実装※' %> <!-- 14-254 「絶縁抵抗測定値/10」 -->
+                <%= machine_str(m10, "insulation_resistance_measurement") %> <!-- 14-254 「絶縁抵抗測定値/10」 -->
               </td>
               <td class="doc_14_s18" dir="ltr" colspan="8" rowspan="2"> 20）その他</td>
             </tr>

--- a/app/views/users/documents/doc_14th/_show.pdf.erb
+++ b/app/views/users/documents/doc_14th/_show.pdf.erb
@@ -1018,34 +1018,34 @@
             <td class="doc_14_s16"></td>
             <td class="doc_14_s22" colspan="8" rowspan="3">絶縁抵抗測定値</td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-038 「絶縁抵抗測定値/1」 -->
+              <%= machine_str(m1, "insulation_resistance_measurement") %> <!-- 14-038 「絶縁抵抗測定値/1」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-062 「絶縁抵抗測定値/2」 -->
+              <%= machine_str(m2, "insulation_resistance_measurement") %> <!-- 14-062 「絶縁抵抗測定値/2」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-086 「絶縁抵抗測定値/3」 -->
+              <%= machine_str(m3, "insulation_resistance_measurement") %> <!-- 14-086 「絶縁抵抗測定値/3」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-110 「絶縁抵抗測定値/4」 -->
+              <%= machine_str(m4, "insulation_resistance_measurement") %> <!-- 14-110 「絶縁抵抗測定値/4」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-134 「絶縁抵抗測定値/5」 -->
+              <%= machine_str(m5, "insulation_resistance_measurement") %> <!-- 14-134 「絶縁抵抗測定値/5」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-158 「絶縁抵抗測定値/6」 -->
+              <%= machine_str(m6, "insulation_resistance_measurement") %> <!-- 14-158 「絶縁抵抗測定値/6」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-182 「絶縁抵抗測定値/7」 -->
+              <%= machine_str(m7, "insulation_resistance_measurement") %> <!-- 14-182 「絶縁抵抗測定値/7」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-206 「絶縁抵抗測定値/8」 -->
+              <%= machine_str(m8, "insulation_resistance_measurement") %> <!-- 14-206 「絶縁抵抗測定値/8」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-230 「絶縁抵抗測定値/9」 -->
+              <%= machine_str(m9, "insulation_resistance_measurement") %> <!-- 14-230 「絶縁抵抗測定値/9」 -->
             </td>
             <td class="doc_14_s30_1" colspan="2" rowspan="3">
-              ※14-038<br>未実装※ <!-- 14-254 「絶縁抵抗測定値/10」 -->
+              <%= machine_str(m10, "insulation_resistance_measurement") %> <!-- 14-254 「絶縁抵抗測定値/10」 -->
             </td>
             <td class="doc_14_s18" dir="ltr" colspan="8" rowspan="2"> 20）その他</td>
           </tr>

--- a/app/views/users/machines/_form.html.erb
+++ b/app/views/users/machines/_form.html.erb
@@ -35,7 +35,7 @@
   </div>
 </div><br>
 
-<%= f.label :insulation_resistance_measurement %>【Ω】
+<%= f.label :insulation_resistance_measurement %>【MΩ】
 <%= f.text_field :insulation_resistance_measurement, class: "form-control", placeholder: Machine.human_attribute_name(:insulation_resistance_measurement) %><br>
 
 <div class="list-group">

--- a/app/views/users/machines/show.html.erb
+++ b/app/views/users/machines/show.html.erb
@@ -35,7 +35,7 @@
         </tr>
         <tr>
           <th><%= Machine.human_attribute_name(:insulation_resistance_measurement) %></th>
-          <td><%= @machine.insulation_resistance_measurement %>Ω</td>
+          <td><%= @machine.insulation_resistance_measurement %>MΩ</td>
         </tr>
         <tr>
           <th><%= Machine.human_attribute_name(:extra_inspection) %></th>


### PR DESCRIPTION
### 概要
・⑭持込機械等電動工具・電気溶接機等使用届の「絶縁抵抗測定値」の箇所が未実装でしたので実装しました。
・持込機械情報登録画面では【Ω】ですが、持込機械等(電動工具電気溶接機等)使用届【参考様式第６号】では【MΩ】と単位の違いがありましたので【MΩ】に合わせました。
### タスク
- [ ] なし
- [x] あり
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=2097726487

### 実装内容・手法


### 実装画像などあれば添付する
<img width="545" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/e50b4c79-0016-43de-b19a-a4cc6e907579">
<img width="489" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/6faff068-cc84-47a6-934e-b5fe241d6388">
<img width="272" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/d146ab31-ed25-4238-bafd-28fea28502e1">

