### PR TITLE
不具合76対応：任意保険証の写し画像の表記・削除機能不具合の対応

### DIFF
--- a/app/controllers/users/cars_controller.rb
+++ b/app/controllers/users/cars_controller.rb
@@ -69,7 +69,7 @@ module Users
     end
 
     def update_images
-      car = current_business.cars.find(params[:car_id])
+      car = current_business.cars.find_by(uuid: params[:car_id])
       remain_images = car.images
       deleted_image = remain_images.delete_at(params[:index].to_i)
       deleted_image.try(:remove!)

--- a/app/views/users/cars/_form.html.erb
+++ b/app/views/users/cars/_form.html.erb
@@ -119,16 +119,16 @@
 </div>
 <br>
 <!-- 任意保険ここまで -->
-<% if car.images.present? %>
-  <% car.images.each_with_index do |image, index| %>
+
+<%= f.label :images %>
+<%= f.file_field :images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
+<% if @car.images.present? %>
+  <% @car.images.each_with_index do |image, index| %>
     <%= image_tag(image.url) %>
     <%= link_to "削除", users_car_update_images_path(car, index: index), method: :patch, data: { confirm: "本当に削除してもよろしいですか？" } %>
   <% end %>
   <br>
 <% end %>
-
-<%= f.label :images %>
-<%= f.file_field :images, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
 <br>
 
 <script>


### PR DESCRIPTION
### 概要
_任意保険証の写し画像の表記・削除機能不具合の対応_

### タスク
- [ ] なし
- [x] あり _https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=1619662116_

### 実装内容・手法
_編集画面の任意保険証の写し画像をフォームの下に移動。更新時不具合があったため削除処理を修正。

### 実装画像などあれば添付する
![車両登録_編集画面](https://github.com/kensuma-1122/kensuma/assets/63386452/fd25065f-b770-426a-958b-d6160bce8d36)


