### PR TITLE
不具合再修正No.216(平野)

### DIFF
--- a/app/models/worker_insurance.rb
+++ b/app/models/worker_insurance.rb
@@ -30,7 +30,7 @@ class WorkerInsurance < ApplicationRecord
   }, _prefix: true
 
   enum has_labor_insurance: { join: 0, not_join: 1 }, _prefix: true       # 労働保険特別加入の有無
-  
+
   with_options unless: -> { worker.business&.user&.is_prime_contractor == true } do
     validates :health_insurance_type, presence: true
     validates :pension_insurance_type, presence: true

--- a/app/models/worker_insurance.rb
+++ b/app/models/worker_insurance.rb
@@ -30,18 +30,21 @@ class WorkerInsurance < ApplicationRecord
   }, _prefix: true
 
   enum has_labor_insurance: { join: 0, not_join: 1 }, _prefix: true       # 労働保険特別加入の有無
-
-  validates :health_insurance_type, presence: true
+  
+  with_options unless: -> { worker.business&.user&.is_prime_contractor == true } do
+    validates :health_insurance_type, presence: true
+    validates :pension_insurance_type, presence: true
+    validates :employment_insurance_type, presence: true
+    validates :employment_insurance_type, absence: true, if: :business_owner_or_master
+    validates :severance_pay_mutual_aid_type, presence: true
+  end
   validates :health_insurance_name, presence: true, if: :insurance_name_valid?
   validates :health_insurance_name, absence: true, unless: :insurance_name_valid?
-  validates :pension_insurance_type, presence: true
-  validates :employment_insurance_type, presence: true, unless: :business_owner_or_master
-  validates :employment_insurance_type, absence: true, if: :business_owner_or_master
   validates :employment_insurance_number, length: { maximum: 4 }, format: { with: /\A[0-9｡-ﾟ]+\z/, message: 'は数字と半角カタカナのみ使用できます' }, if: :employment_insurance_number_valid?
   validates :employment_insurance_number, absence: true, unless: :employment_insurance_number_valid?
   validates :has_labor_insurance, presence: true, if: :business_owner_or_master
   validates :has_labor_insurance, absence: true, unless: :business_owner_or_master
-  validates :severance_pay_mutual_aid_type, presence: true
+  
   validates :severance_pay_mutual_aid_name, presence: true, if: :severance_pay_mutual_aid_name_valid?
   validate :valid_health_insurance_image
 

--- a/app/models/worker_insurance.rb
+++ b/app/models/worker_insurance.rb
@@ -44,7 +44,6 @@ class WorkerInsurance < ApplicationRecord
   validates :employment_insurance_number, absence: true, unless: :employment_insurance_number_valid?
   validates :has_labor_insurance, presence: true, if: :business_owner_or_master
   validates :has_labor_insurance, absence: true, unless: :business_owner_or_master
-  
   validates :severance_pay_mutual_aid_name, presence: true, if: :severance_pay_mutual_aid_name_valid?
   validate :valid_health_insurance_image
 

--- a/app/models/worker_medical.rb
+++ b/app/models/worker_medical.rb
@@ -11,12 +11,14 @@ class WorkerMedical < ApplicationRecord
   enum is_med_exam: { y: 0, n: 1 }, _prefix: true         # 健康診断受診の有無
   enum is_special_med_exam: { y: 0, n: 1 }, _prefix: true # 特別健康診断受診の有無
 
-  validates :med_exam_on, presence: true, if: :med_exam_y?
-  validates :med_exam_on, absence: true, unless: :med_exam_y?
-  validates :max_blood_pressure, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 999 }, if: :med_exam_y?
-  validates :max_blood_pressure, absence: true, unless: :med_exam_y?
-  validates :min_blood_pressure, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 999 }, if: :med_exam_y?
-  validates :min_blood_pressure, absence: true, unless: :med_exam_y?
+  with_options unless: -> { worker.business&.user&.is_prime_contractor == true } do
+    validates :med_exam_on, presence: true, if: :med_exam_y?
+    validates :med_exam_on, absence: true, unless: :med_exam_y?
+    validates :max_blood_pressure, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 999 }, if: :med_exam_y?
+    validates :max_blood_pressure, absence: true, unless: :med_exam_y?
+    validates :min_blood_pressure, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 999 }, if: :med_exam_y?
+    validates :min_blood_pressure, absence: true, unless: :med_exam_y?
+  end
   validates :is_special_med_exam, presence: true
   validates :special_med_exam_on, presence: true, if: :special_med_exam_y?
   validates :special_med_exam_on, absence: true, unless: :special_med_exam_y?

--- a/db/migrate/20231021134834_change_column_to_null.rb
+++ b/db/migrate/20231021134834_change_column_to_null.rb
@@ -1,0 +1,13 @@
+class ChangeColumnToNull < ActiveRecord::Migration[6.1]
+  def up
+    change_column_null :worker_insurances, :health_insurance_type, true
+    change_column_null :worker_insurances, :pension_insurance_type, true
+    change_column_null :worker_insurances, :severance_pay_mutual_aid_type, true
+  end
+
+  def down
+    change_column_null :worker_insurances, :health_insurance_type, false
+    change_column_null :worker_insurances, :pension_insurance_type, false
+    change_column_null :worker_insurances, :severance_pay_mutual_aid_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_09_095340) do
+ActiveRecord::Schema.define(version: 2023_10_21_134834) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "namespace"
@@ -697,14 +697,14 @@ ActiveRecord::Schema.define(version: 2023_09_09_095340) do
   end
 
   create_table "worker_insurances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.integer "health_insurance_type", null: false
+    t.integer "health_insurance_type"
     t.string "health_insurance_name"
     t.json "health_insurance_image"
-    t.integer "pension_insurance_type", null: false
+    t.integer "pension_insurance_type"
     t.integer "employment_insurance_type"
     t.integer "has_labor_insurance"
     t.string "employment_insurance_number"
-    t.integer "severance_pay_mutual_aid_type", null: false
+    t.integer "severance_pay_mutual_aid_type"
     t.string "severance_pay_mutual_aid_name"
     t.bigint "worker_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
### 概要
 - 不具合修正No.216 元請会社の作業員情報の「氏名・フリガナ・資格情報の資格名」以外の必須を外す
 - 元請会社の資格情報、血液型のバリデーション解除が反映されない不具合の修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- カラムのnull: false修正
- modelのバリデーション 修正

### 実装画像などあれば添付する


