### PR TITLE
不具合233：建設許可書のネストフォーム登録時エラー対応

### DIFF
--- a/app/controllers/users/businesses_controller.rb
+++ b/app/controllers/users/businesses_controller.rb
@@ -41,6 +41,7 @@ module Users
       @business = Business.new(business_params_with_converted)
       if business_params[:construction_license_status] == "available" && business_params[:business_industries_attributes].blank?
         flash.now[:danger] = '建設許可証が「有」の場合はフォームを入力してください'
+        render :new
       elsif @business.save
         redirect_to users_orders_url
       else

--- a/app/models/business_industry.rb
+++ b/app/models/business_industry.rb
@@ -1,6 +1,6 @@
 class BusinessIndustry < ApplicationRecord
   belongs_to :business
-  belongs_to :industry, optional:true
+  belongs_to :industry, optional: true
   before_save :set_construction_license_number
 
   enum construction_license_permission_type_minister_governor: { minister_permission: 0, governor_permission: 1 }, _prefix: true # 建設許可証(許可種別)
@@ -13,7 +13,7 @@ class BusinessIndustry < ApplicationRecord
   validates :construction_license_number_double_digit, format: { with: /\A\d{1,2}\z/, message: 'は数字2桁以下で入力してください' }, presence: true, if: -> { business.construction_license_status == 'available' }
   validates :construction_license_number_six_digits, format: { with: /\A\d{1,6}\z/, message: 'は数字6桁以下で入力してください' }, presence: true, if: -> { business.construction_license_status == 'available' }
   validates :construction_license_updated_at, presence: true, if: -> { business.construction_license_status == 'available' }
-  validates :industry_id, presence: true, if: -> {business.construction_license_status == 'available'}
+  validates :industry_id, presence: true, if: -> { business.construction_license_status == 'available' }
 
   def set_construction_license_number
     self.construction_license_number = construction_license_number_string

--- a/app/models/business_industry.rb
+++ b/app/models/business_industry.rb
@@ -1,6 +1,6 @@
 class BusinessIndustry < ApplicationRecord
   belongs_to :business
-  belongs_to :industry
+  belongs_to :industry, optional:true
   before_save :set_construction_license_number
 
   enum construction_license_permission_type_minister_governor: { minister_permission: 0, governor_permission: 1 }, _prefix: true # 建設許可証(許可種別)
@@ -13,6 +13,7 @@ class BusinessIndustry < ApplicationRecord
   validates :construction_license_number_double_digit, format: { with: /\A\d{1,2}\z/, message: 'は数字2桁以下で入力してください' }, presence: true, if: -> { business.construction_license_status == 'available' }
   validates :construction_license_number_six_digits, format: { with: /\A\d{1,6}\z/, message: 'は数字6桁以下で入力してください' }, presence: true, if: -> { business.construction_license_status == 'available' }
   validates :construction_license_updated_at, presence: true, if: -> { business.construction_license_status == 'available' }
+  validates :industry_id, presence: true, if: -> {business.construction_license_status == 'available'}
 
   def set_construction_license_number
     self.construction_license_number = construction_license_number_string

--- a/app/views/users/businesses/_form.html.erb
+++ b/app/views/users/businesses/_form.html.erb
@@ -182,7 +182,6 @@
             <%= b.label { b.radio_button + b.text } %>
           </div>
         <% end %>
-        <div id="error" class="text-red">【ご案内】：残っているフォームを全て削除してからチェックを「無」に変更してください。</div>
         <div id="license-insertion-point"></div>
         <!-- BusinessIndustryここから -->
         <div id="hidden-form" class="list-group">
@@ -379,19 +378,10 @@
     console.log(value)
     if(value == undefined){
       list_group.classList.add('hidden');
-      error.classList.add('hidden');
-    }else if (value == 'available'){
+    }else if (value == 'available'){ 
       list_group.classList.remove('hidden');
-      //建設許可証「有」をチェック時は、エラー文を非表示
-      error.classList.add('hidden');
     } else {
       list_group.classList.add('hidden');
-      //建設許可証「無」をチェック、かつフォームが残っている場合は、エラー文を表示し残フォーム削除を促す（nilが送信されると外部キーでエラーが出る為）
-      if ($(".nested-fields").filter(function() {return $(this).css('display') !== 'none'}).length) {
-        error.classList.remove('hidden');
-      } else {
-        error.classList.add('hidden');
-      }
     }
   };
   getRadioConstructionLicense(available_form); //ページの読み込み時に判定

--- a/db/migrate/20231112004308_remove_not_null_constraint_from_industry_id.rb
+++ b/db/migrate/20231112004308_remove_not_null_constraint_from_industry_id.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintFromIndustryId < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :business_industries, :industry_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_09_095340) do
+ActiveRecord::Schema.define(version: 2023_11_12_004308) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "namespace"
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 2023_09_09_095340) do
     t.string "construction_license_number", comment: "建設許可証(建設許可番号)"
     t.date "construction_license_updated_at", comment: "建設許可証(更新日)"
     t.bigint "business_id", null: false
-    t.bigint "industry_id", null: false
+    t.bigint "industry_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["business_id"], name: "index_business_industries_on_business_id"


### PR DESCRIPTION
### 概要
_建設許可書のネストフォーム登録時エラーが起きない修正変更。_

### タスク
- [] なし
- [x] あり _(https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=2118468576)_

### 実装内容・手法
_建設許可書が有の場合のみindustry_id必須となるバリデーションを追加しました。またbusiness_industlysテーブルのnotnull制約を解除しています。_

