### PR TITLE
不具合再修正No.216_3(平野)

### DIFF
--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -73,7 +73,7 @@ module WorkersHelper
       health_insurance_type:         :not_health_insurance,
       pension_insurance_type:        :welfare,
       employment_insurance_type:     :exemption,
-      severance_pay_mutual_aid_type: :none,
+      severance_pay_mutual_aid_type: :none
       # has_labor_insurance:           :not_join
       # ============================================
     )
@@ -106,7 +106,7 @@ module WorkersHelper
       health_insurance_type:         :not_health_insurance,
       pension_insurance_type:        :welfare,
       employment_insurance_type:     :exemption,
-      severance_pay_mutual_aid_type: :none,
+      severance_pay_mutual_aid_type: :none
       # has_labor_insurance:           :not_join
       # ============================================
     )

--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -70,14 +70,11 @@ module WorkersHelper
     )
     @worker.build_worker_insurance(
       # テスト用デフォルト値 ==========================
-      health_insurance_type:         :health_insurance_association,
-      health_insurance_name:         'サンプル健康保険',
+      health_insurance_type:         :not_health_insurance,
       pension_insurance_type:        :welfare,
-      employment_insurance_type:     :insured,
-      employment_insurance_number:   '1234',
-      severance_pay_mutual_aid_type: :kentaikyo,
-      severance_pay_mutual_aid_name: 'テスト共済制度',
-      has_labor_insurance:           :join
+      employment_insurance_type:     :exemption,
+      severance_pay_mutual_aid_type: :none,
+      # has_labor_insurance:           :not_join
       # ============================================
     )
   end
@@ -98,19 +95,19 @@ module WorkersHelper
     @worker.worker_special_educations.build
     @worker.build_worker_medical(
       # 本番環境用デフォルト値 ==========================
-      is_med_exam:         :y,
-      is_special_med_exam: :y,
+      is_med_exam:         :n,
+      is_special_med_exam: :n,
       health_condition:    :good
       # ============================================
     )
     @worker.worker_safety_health_educations.build
     @worker.build_worker_insurance(
       # 本番環境用デフォルト値 ==========================
-      health_insurance_type:         :health_insurance_association,
+      health_insurance_type:         :not_health_insurance,
       pension_insurance_type:        :welfare,
-      employment_insurance_type:     :insured,
-      severance_pay_mutual_aid_type: :kentaikyo,
-      has_labor_insurance:           :join
+      employment_insurance_type:     :exemption,
+      severance_pay_mutual_aid_type: :none,
+      # has_labor_insurance:           :not_join
       # ============================================
     )
   end


### PR DESCRIPTION
### 概要
- 元請の作業員情報登録時のバリデーション解除の再修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
- 元請の作業員情報のバリデーション解除の修正。
- 本番環境用の入力フォームのデフォルト値がバリデーションに引っかかるため、デフォルト値を修正。

### 実装画像などあれば添付する


