### PR TITLE
車両情報一覧にナンバープレート表示

### DIFF
--- a/app/views/users/cars/index.html.erb
+++ b/app/views/users/cars/index.html.erb
@@ -10,6 +10,7 @@
           <tr align="center">
             <th><%= Car.human_attribute_name(:owner_name) %></th>
             <th><%= Car.human_attribute_name(:vehicle_model) %></th>
+            <th><%= Car.human_attribute_name(:vehicle_number) %></th>
             <th></th>
             <th></th>
           </tr>
@@ -19,6 +20,7 @@
           <tr align="center">
             <td><%= link_to car.owner_name, users_car_path(car) %></td>
             <td><%= car.vehicle_model %></td>
+            <td><%= car.vehicle_number %></td>
             <td><%= link_to "編集", edit_users_car_path(car), class: "btn btn-md btn-success" %></td>
             <td><%= link_to "削除", users_car_path(car), method: :delete, data: { confirm: "#{car.vehicle_model}の車両情報を削除します。本当によろしいですか？" }, class: "btn btn-md btn-danger" %></td>
           </tr>


### PR DESCRIPTION
### 概要
_不具合249「車両情報(ナンバープレート)も表示させる」_

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
_車両情報一覧画面（views/users/cars/index.html.erb）にナンバープレートを追加表示させる_

### 実装画像などあれば添付する
![スクリーンショット 2024-02-18 23 39 20](https://github.com/kensuma-1122/kensuma/assets/63439936/d8d1c3d4-f61b-48cf-89ef-0a28336c01df)


