### PR TITLE
不具合244・245・246「年月日入力フォームの幅調整」

### DIFF
--- a/app/views/users/cars/_form.html.erb
+++ b/app/views/users/cars/_form.html.erb
@@ -44,11 +44,11 @@
   <div class="list-group-item">
     <%= f.label :vehicle_inspection_start_on %>
     <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-    <%= f.date_field :vehicle_inspection_start_on, class: "form-control" %>
+    <%= f.date_field :vehicle_inspection_start_on, style: "width: 25%;", class: "form-control" %>
     <br>
     <%= f.label :vehicle_inspection_end_on %>
     <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-    <%= f.date_field :vehicle_inspection_end_on, class: "form-control" %>
+    <%= f.date_field :vehicle_inspection_end_on, style: "width: 25%;", class: "form-control" %>
     <br>
   </div>
 </div>
@@ -71,11 +71,11 @@
       <div class="list-group-item">
         <%= f.label :liability_insurance_start_on %>
         <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-        <%= f.date_field :liability_insurance_start_on, class: "form-control" %>
+        <%= f.date_field :liability_insurance_start_on, style: "width: 25%;", class: "form-control" %>
         <br>
         <%= f.label :liability_insurance_end_on %>
         <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-        <%= f.date_field :liability_insurance_end_on, class: "form-control" %>
+        <%= f.date_field :liability_insurance_end_on, style: "width: 25%;", class: "form-control" %>
         <br>
       </div>
       <br>
@@ -106,10 +106,10 @@
         <%= voluntary.label :voluntary_insurance_period %>
         <div class="list-group-item">
         <%= voluntary.label :voluntary_insurance_start_on %>
-        <%= voluntary.date_field :voluntary_insurance_start_on, class: "form-control" %>
+        <%= voluntary.date_field :voluntary_insurance_start_on, style: "width: 25%;", class: "form-control" %>
         <br>
         <%= voluntary.label :voluntary_insurance_end_on %>
-        <%= voluntary.date_field :voluntary_insurance_end_on, class: "form-control" %>
+        <%= voluntary.date_field :voluntary_insurance_end_on, style: "width: 25%;", class: "form-control" %>
         <br>
         </div>
         <br>

--- a/app/views/users/orders/_form.html.erb
+++ b/app/views/users/orders/_form.html.erb
@@ -71,15 +71,15 @@
       <br>
       <%= f.label :start_date %> <!-- 工期(自) -->
       <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-      <%= f.date_field :start_date, class: "form-control" %>
+      <%= f.date_field :start_date, style: "width: 25%;", class: "form-control" %>
       <br>
       <%= f.label :end_date %> <!-- 工期(至) -->
       <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-      <%= f.date_field :end_date, class: "form-control" %>
+      <%= f.date_field :end_date, style: "width: 25%;", class: "form-control" %>
       <br>
       <%= f.label :contract_date %> <!-- 契約日 -->
       <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-      <%= f.date_field :contract_date, class: "form-control" %>
+      <%= f.date_field :contract_date, style: "width: 25%;", class: "form-control" %>
       <br>
     </div>
   </div>

--- a/app/views/users/special_vehicles/_form.html.erb
+++ b/app/views/users/special_vehicles/_form.html.erb
@@ -28,7 +28,7 @@
 <br>
 <%= f.label :year_manufactured %> <!-- 製造年 -->
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-<%= f.date_field :year_manufactured, class: "form-control", placeholder: SpecialVehicle.human_attribute_name(:year_manufactured) %>
+<%= f.date_field :year_manufactured, style: "width: 25%;", class: "form-control", placeholder: SpecialVehicle.human_attribute_name(:year_manufactured) %>
 <br>
 <%= f.label :control_number %> <!-- 管理番号(整理番号) -->
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
@@ -36,22 +36,22 @@
 <br>
 <%= f.label :check_exp_date_year %> <!-- 年次 -->
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-<%= f.date_field :check_exp_date_year, class: "form-control" %>
+<%= f.date_field :check_exp_date_year, style: "width: 25%;", class: "form-control" %>
 <br>
 <%= f.label :check_exp_date_month %> <!-- 月次 -->
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-<%= f.date_field :check_exp_date_month, class: "form-control" %>
+<%= f.date_field :check_exp_date_month, style: "width: 25%;", class: "form-control" %>
 <br>
 <%= f.label :check_exp_date_specific %> <!-- 特定 -->
-<%= f.date_field :check_exp_date_specific, class: "form-control" %>
+<%= f.date_field :check_exp_date_specific, style: "width: 25%;", class: "form-control" %>
 <br>
 <%= f.label :check_exp_date_machine %> <!-- 移動式クレーン等の性能検査有効期限 -->
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-<%= f.date_field :check_exp_date_machine, class: "form-control" %>
+<%= f.date_field :check_exp_date_machine, style: "width: 25%;", class: "form-control" %>
 <br>
 <%= f.label :check_exp_date_car %> <!-- 自動車検査証有効期限 -->
 <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-<%= f.date_field :check_exp_date_car, class: "form-control" %>
+<%= f.date_field :check_exp_date_car, style: "width: 25%;", class: "form-control" %>
 <br>
 <%= f.label :in_house_inspections %> <!-- 自社の点検表の写し -->
 <%= f.file_field :in_house_inspections, accept: 'image/jpg, image/jpeg, image/png', multiple: true, class: "form-control" %>
@@ -144,7 +144,7 @@
 <br>
 
 <%= f.label :exp_date_insurance %> <!-- 有効期限 -->
-<%= f.date_field :exp_date_insurance, class: "form-control" %>
+<%= f.date_field :exp_date_insurance, style: "width: 25%;", class: "form-control" %>
 
 <script>
   $(function(){


### PR DESCRIPTION
### 概要
_各登録画面の年月日入力フォームの幅調整_

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
_車両情報登録画面・特殊車両登録画面・現場情報登録画面のdate_fieldの幅を短くした_

### 実装画像などあれば添付する
車両情報登録画面
<img width="1649" alt="スクリーンショット 2024-02-19 22 10 11" src="https://github.com/kensuma-1122/kensuma/assets/63439936/542fee30-fd09-4433-8050-25ab7a2c1e77">

特殊車両登録画面
<img width="1653" alt="スクリーンショット 2024-02-19 22 09 51" src="https://github.com/kensuma-1122/kensuma/assets/63439936/4787a6ed-7e71-4ce2-809e-933035f4f5da">

現場情報
<img width="1650" alt="スクリーンショット 2024-02-19 22 12 31" src="https://github.com/kensuma-1122/kensuma/assets/63439936/52e1c9fb-67b7-4a70-8036-9df430dc8fc0">
登録画面



