### PR TITLE
不具合項目247 元請の作業員の電話番号を必須にした。

### DIFF
--- a/app/models/worker.rb
+++ b/app/models/worker.rb
@@ -44,6 +44,7 @@ class Worker < ApplicationRecord
   validates :career_up_id, format: { with: /\A^$|\A\z|\A\d{14}\z/, message: 'は14桁の数字で入力してください' }, allow_nil: true
   validates :name, presence: true
   validates :name_kana, presence: true, format: { with: /\A^$|\A[ァ-ヴ][ァ-ヴー\s]*[ァ-ヴー]\z/, message: 'はカタカナで入力してください' }
+  validates :my_phone_number, presence: true, format: { with: VALID_PHONE_NUMBER_REGEX, message: PHONE_NUMBER_MS }
 
   validates :email, format: { with: VALID_EMAIL_REGEX, message: 'はexample@email.comのような形式で入力してください' }, allow_nil: true
   validates :post_code, format: { with: /\A^$|\A\z|\A\d{7}\z/, message: 'は7桁の数字で入力してください' }, allow_nil: true

--- a/app/models/worker.rb
+++ b/app/models/worker.rb
@@ -51,7 +51,6 @@ class Worker < ApplicationRecord
   with_options unless: -> { business&.user&.is_prime_contractor == true } do
     validates :country, presence: true
     validates :my_address, presence: true
-    validates :my_phone_number, presence: true, format: { with: VALID_PHONE_NUMBER_REGEX, message: PHONE_NUMBER_MS }
     validates :family_address, presence: true
     validates :family_phone_number, presence: true, format: { with: VALID_PHONE_NUMBER_REGEX, message: PHONE_NUMBER_MS }
     validates :birth_day_on, presence: true

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -58,6 +58,7 @@
 
     <%# 電話番号 %>
     <%= f.label :my_phone_number %>
+    <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
     <%= required_label %>
     <%= f.telephone_field :my_phone_number, value: @my_phone_number, class: "form-control", placeholder: annotation_hyphen %><br>
 

--- a/app/views/users/workers/_form.html.erb
+++ b/app/views/users/workers/_form.html.erb
@@ -59,7 +59,6 @@
     <%# 電話番号 %>
     <%= f.label :my_phone_number %>
     <span class="p-1 mb-2 rounded bg-danger text-white">必須</span>
-    <%= required_label %>
     <%= f.telephone_field :my_phone_number, value: @my_phone_number, class: "form-control", placeholder: annotation_hyphen %><br>
 
     <%# 国籍 %>


### PR DESCRIPTION
### 概要
_PR概要を記述する_
不具合項目247 元請の作業員の電話番号を必須にした。
### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=925874582


### 実装内容・手法
_実装内容や、問題の解決手法を記述する_

該当箇所に、必須タグを新設した。
modelにvalidationをつけた。電話番号を入力してください、とエラー文が表示されるようになっている。
Rspecのテストにつき、いろいろ調べたが、現在のテストmodel spec(worker_spec.rbの電話番号の記述、233行目から270行目)でカバーしていると判断。追加はしていないです。

```
describe` '#my_phone_number' do
      context '存在しない場合' do
        before :each do
          subject.my_phone_number = nil
        end

        it 'バリデーションに落ちること' do
          expect(subject).to be_invalid
        end

        it 'バリデーションのエラーが正しいこと' do
          subject.valid?
          expect(subject.errors.full_messages).to include('電話番号を入力してください')
        end
      end

      [
        '123456789',
        '123456789012',
        '123-4567-8901',
        '123/4567/8901'
      ].each do |my_phone_number|
        context '不正なmy_phone_numberの場合' do
          before :each do
            subject.my_phone_number = my_phone_number
          end

          it "バリデーションに落ちること#{my_phone_number}" do
            expect(subject).to be_invalid
          end

          it "バリデーションのエラーが正しいこと#{my_phone_number}" do
            subject.valid?
            expect(subject.errors.full_messages).to include('電話番号は10桁または11桁の数字で入力してください')
          end
        end
      end
    end

```

### 実装画像などあれば添付する
![スクリーンショット 2024-02-25 0 17 58](https://github.com/kensuma-1122/kensuma/assets/107759288/04ad4958-9f89-425b-8ceb-e6a11cdc8d99)
![スクリーンショット 2024-02-25 0 20 02](https://github.com/kensuma-1122/kensuma/assets/107759288/cd86ae2d-e043-4bd1-8d57-83e0b07b6926)
![スクリーンショット 2024-02-25 3 19 17](https://github.com/kensuma-1122/kensuma/assets/107759288/cd6ff324-43f3-4fca-be32-682902f850bd)
<img width="1409" alt="スクリーンショット 2024-02-25 3 35 39" src="https://github.com/kensuma-1122/kensuma/assets/107759288/edb9717a-c714-4572-994e-113a908536cf">


