### PR TITLE
不具合項目250番修正

### DIFF
--- a/config/locales/model_ja.yml
+++ b/config/locales/model_ja.yml
@@ -255,7 +255,7 @@ ja:
         site_address: 施工場所住所
         # 発注者
         orderer: 発注者
-        order_name: 氏名
+        order_name: 会社名もしくは氏名
         order_post_code: 郵便番号
         hyphen_is_unnecessary: 0123456 -(ハイフン)は不要
         order_address: 住所


### PR DESCRIPTION
### 概要
現場情報画面の発注者の欄の「氏名」を「会社名もしくは氏名」に変更しました。

### タスク
- [x] あり _(タスクのリンクがあれば貼る)_
https://docs.google.com/spreadsheets/d/1fmxdfQU1jv7fySdHrH-SMnkBHVXsPA27QtBzznD9mNM/edit#gid=891313354

### 実装内容・手法

### 実装画像などあれば添付する
before
<img width="452" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/a5548d2d-7cea-4b6e-beca-13a102a36c72">

after
<img width="265" alt="image" src="https://github.com/kensuma-1122/kensuma/assets/97861380/5aa1205e-adf9-48f5-951d-49fa51218bbb">


