### PR TITLE
#265 現場情報を折りたたんでも「現場情報修正」等が見えるようにする

### DIFF
--- a/app/views/users/documents/shares/_show_request_order_link.html.erb
+++ b/app/views/users/documents/shares/_show_request_order_link.html.erb
@@ -1,6 +1,6 @@
-<%= link_to "入場作業員", users_request_order_field_workers_path(request_order), class: "btn btn-sm btn-success" %>
-<%= link_to "車両", users_request_order_field_cars_path(request_order), class: "btn btn-sm btn-success" %>
-<%= link_to "特殊車両", users_request_order_field_special_vehicles_path(request_order), class: "btn btn-sm btn-success" %>
-<%= link_to "機械", users_request_order_field_machines_path(request_order), class: "btn btn-sm btn-success" %>
-<%= link_to "溶剤", new_users_request_order_field_solvent_path(request_order), class: "btn btn-sm btn-success" %>
-<%= link_to "火気", new_users_request_order_field_fire_path(request_order), class: "btn btn-sm btn-success" %>
+<%= link_to "入場作業員", users_request_order_field_workers_path(request_order), class: "btn btn-sm btn-success", style: "position: relative; top: 10px;" %>
+<%= link_to "車両", users_request_order_field_cars_path(request_order), class: "btn btn-sm btn-success", style: "position: relative; top: 10px;" %>
+<%= link_to "特殊車両", users_request_order_field_special_vehicles_path(request_order), class: "btn btn-sm btn-success", style: "position: relative; top: 10px;" %>
+<%= link_to "機械", users_request_order_field_machines_path(request_order), class: "btn btn-sm btn-success", style: "position: relative; top: 10px;" %>
+<%= link_to "溶剤", new_users_request_order_field_solvent_path(request_order), class: "btn btn-sm btn-success", style: "position: relative; top: 10px;" %>
+<%= link_to "火気", new_users_request_order_field_fire_path(request_order), class: "btn btn-sm btn-success", style: "position: relative; top: 10px;" %>

--- a/app/views/users/request_orders/show.html.erb
+++ b/app/views/users/request_orders/show.html.erb
@@ -131,18 +131,25 @@
           </div>
         </div>
 
+        <% unless @request_order.parent_id.nil? || @request_order.construction_name.nil? %>
+          <table class="table table-borderless">
+            <tbody>
+              <tr>
+                <td>
+                  <%= link_to "現場情報修正", edit_users_request_order_path, class: "btn btn-sm btn-success", style: "position: relative; top: 10px;" %>
+                </td>
+                <td>
+                  <%= render '/users/documents/shares/show_request_order_link', request_order: @request_order %>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        <% end %>
+
         <div class="card-body table-responsive p-0" style="display: none;">
           <% unless @request_order.parent_id.nil? || @request_order.construction_name.nil? %>
             <table class="table table-hover text-nowrap">
               <tbody>
-                <tr>
-                  <td>
-                    <%= link_to "現場情報修正", edit_users_request_order_path, class: "btn btn-sm btn-success" %>
-                  </td>
-                  <td>
-                    <%= render '/users/documents/shares/show_request_order_link', request_order: @request_order %>
-                  </td>
-                </tr>
                 <tr>
                   <th><%= RequestOrder.human_attribute_name(:request_order_infomation) %></th> <!--現場情報-->
                   <td></td>


### PR DESCRIPTION
refs: #492 
### 概要

- 現場情報を折りたたんでも「現場情報修正」等が見えるようにする

![5cbd24b4208026c0a6bc526d4e668291](https://github.com/kensuma-1122/kensuma/assets/146853039/d75d370b-18d1-4da3-ae60-e2f91b34ea5a)

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
_実装内容や、問題の解決手法を記述する_

### 実装画像などあれば添付する


